### PR TITLE
Add code coverage verification to builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,22 +48,3 @@ jobs:
     #
     # - name: Build with Gradle 8.5
     #   run: gradle build
-
-  dependency-submission:
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 8
-      uses: actions/setup-java@v4
-      with:
-        java-version: '8'
-        distribution: 'temurin'
-
-    # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
-    # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
-    - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -4,8 +4,29 @@
 
 plugins {
     id("buildlogic.java-library-conventions")
+    id("jacoco")
 }
 
 dependencies {
     api(project(":object-client"))
 }
+
+tasks.test {
+    // Report is generated and verification is run after tests
+    finalizedBy(tasks.jacocoTestReport, tasks.jacocoTestCoverageVerification)
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.95".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test) // tests are required to run before generating the report
+}
+


### PR DESCRIPTION
This commit adds the Jacoco plugin and configures it to enforce a 95% code coverage. Reports are also always generated with builds.


> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
