### PR TITLE
Adds in jar task

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
@@ -72,3 +72,18 @@ tasks.jacocoTestReport {
 
     dependsOn(tasks.test) // tests are required to run before generating the report
 }
+
+// NOTE: This is temporary change to allow us to build uber jars that can be used to integrate
+// upstream. Ultimately more thinking around packaging and distribution will be required. 
+tasks.register<Jar>("uberJar") {
+    archiveClassifier = "uber"
+
+    from(sourceSets.main.get().output)
+
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    dependsOn(configurations.runtimeClasspath)
+    from({
+        configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) }
+    })
+}


### PR DESCRIPTION
*Issue #, if available:*

Adds in jar task that can be used to build per project uber jars to allow easy integration into projects like S3A. 

See https://github.com/amazon-contributing/private-hadoop-staging/pull/8/files for how these jars can then be used. 

NOTE: This is a temporary change to allow for easy and quick integration. Ultimately more thinking is required here.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
