### PR TITLE
Fixes off by one error.

### DIFF
--- a/input-stream/src/main/java/com/amazon/connector/s3/blockmanager/BlockManager.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/blockmanager/BlockManager.java
@@ -159,9 +159,9 @@ public class BlockManager implements AutoCloseable {
     long end;
 
     if (size > READAHEAD_LENGTH) {
-      end = Math.min(start + size, getLastObjectByte());
+      end = Math.min(start + size - 1, getLastObjectByte());
     } else {
-      end = Math.min(start + READAHEAD_LENGTH, getLastObjectByte());
+      end = Math.min(start + READAHEAD_LENGTH - 1, getLastObjectByte());
     }
 
     return createBlock(start, end);


### PR DESCRIPTION
I was off by one previously, leading to extra GET requests in the access logs. This fixes this, and range of GETs in access logs now exactly match S3A requested ranges in random mode, which is what we wanted for the base implementation. 

Benchmarked with this change, and we're still 3-4% slower though! 

