### PR TITLE
Github action to build and upload s3 seekable stream jars to s3 bucket 

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -4,8 +4,6 @@ name: Build and upload s3 seekable stream jars to s3a treatment bucket
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 env:
   AWS_REGION :  ${{ vars.AWS_REGION }} #Change to reflect your Region


### PR DESCRIPTION
This change adds a github workflow / action to build and upload s3 seekable stream jars to a bucket which is used by the benchmarking. The authentication is via Github OIDC provider. IAM role has been created which provides sts:AssumeRoleWithWebIdentity to the s3-connector-framework repository. 
