### PR TITLE
Simplify local development of integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The project is configured to be built via Gradle (Gradle 8.7). It also targets J
 * To skip reference tests: `./gradlew build -x referenceTest`
 * To apply formatting: `./gradlew spotlessApply`
 * To list all tasks: `./gradlew tasks`
+* To publish JARs to Maven local: `./gradlew publishToMavenLocal`
 
 # Microbenchmarks
 
@@ -32,6 +33,12 @@ prefix in your bucket for all micro-benchmark related stuff). Now, to generate s
 Just run `./gradlew jmh --rerun`. (The reason for re-run is a Gradle-quirk. You may want to re-run benchmarks even when
 you did not actually change the source of your project: `--rerun` turns off the Gradle optimisation that falls through
 build steps when nothing changed.)
+
+## Developing integrations
+
+When you are building this library into connectors, your IDE will need to be aware of the JARs (common, object-client,
+input-stream). Consuming these via Maven/Gradle is natural and you can use `./gradlew publishToMavenLocal` to have the
+built JARs installed to your Maven local repository (this is `~/.m2` most of the time).
 
 
 ## Security

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -23,6 +23,8 @@ tasks.withType<JavaCompile>().configureEach {
 publishing {
     publications {
         create<MavenPublication>("common") {
+            // TODO: update this when we figure out versioning
+            //  ticket: https://app.asana.com/0/1206885953994785/1207481230403504/f
             version = "1.0.0"
 
             from(components["java"])

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -100,6 +100,8 @@ jmh {
 publishing {
     publications {
         create<MavenPublication>("inputStream") {
+            // TODO: update this when we figure out versioning
+            //  ticket: https://app.asana.com/0/1206885953994785/1207481230403504/f
             version = "1.0.0"
 
             from(components["java"])

--- a/object-client/build.gradle.kts
+++ b/object-client/build.gradle.kts
@@ -27,6 +27,8 @@ tasks.test {
 publishing {
     publications {
         create<MavenPublication>("objectClient") {
+            // TODO: update this when we figure out versioning
+            //  ticket: https://app.asana.com/0/1206885953994785/1207481230403504/f
             version = "1.0.0"
 
             from(components["java"])


### PR DESCRIPTION
While re-thinking the dependency model in the S3FileIO--SeekableStream integrations we idenfitifed the need to be able to easily consume new LOCAL SeekableStream changes.

That is, when I introduce a change in SeekableStream, I should be able to easily consume this when also working on S3FileIO changes and changes should propagate seemlessly to "another IDE window".

This can be done easily via Maven local repositories and a gradle plugin.

See https://github.com/amazon-contributing/private-iceberg-staging/pull/20 for how this looks like from another Gradle setup.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
