### PR TITLE
Extend GitHub workflow to upload JARs for S3FileIO

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -10,7 +10,9 @@ env:
   S3_BUCKET : ${{ vars.S3_BUCKET }}
   STATE_MACHINE_ARN : ${{ secrets.STATE_MACHINE_ARN }}
   ROLE_TO_ASSUME: ${{ secrets.ASSUME_ROLE_ARN }}
-  STATE_MACHINE_INPUT: ${{ vars.STEP_FUNCTION_INPUT }}
+  STATE_MACHINE_INPUT_S3A: ${{ vars.STATE_MACHINE_INPUT_S3A }}
+  STATE_MACHINE_INPUT_S3FILEIO: ${{ vars.STATE_MACHINE_INPUT_S3FILEIO }}
+
 # Permission can be added at job level or workflow level    
 permissions:
       id-token: write   # This is required for requesting the JWT
@@ -60,5 +62,7 @@ jobs:
         run: aws s3 cp common/build/libs/object-client.jar s3://${{ env.S3_BUCKET }}/s3fileio/object-client.jar
 
       - name: Trigger S3A Benchmarks
-        run:  aws stepfunctions start-execution --state-machine-arn ${{ env.STATE_MACHINE_ARN }} --input ${{ env.STATE_MACHINE_INPUT }}
+        run:  aws stepfunctions start-execution --state-machine-arn ${{ env.STATE_MACHINE_ARN }} --input ${{ env.STATE_MACHINE_INPUT_S3A }}
 
+      - name: Trigger S3FileIO Benchmarks
+        run:  aws stepfunctions start-execution --state-machine-arn ${{ env.STATE_MACHINE_ARN }} --input ${{ env.STATE_MACHINE_INPUT_S3FILEIO }}


### PR DESCRIPTION
This change adds the instructions to copy generated S3FileIO JARs to their respective S3 locations where benchmarking can pick it up from.

The S3FileIO does not currently rely on using Uber JARs should we first need to do `./gradlew build` to generate the thin JARs. This also gives us some additional safety as the uberJar task does not run tests by default.

The "common" JAR was also missing so added commands to upload this to S3 too.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
