### PR TITLE
Add extra logs and throw Exception when seeing wrong range.

### DIFF
--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/blockmanager/BlockManagerTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/blockmanager/BlockManagerTest.java
@@ -99,6 +99,11 @@ public class BlockManagerTest {
             CompletableFuture.completedFuture(
                 ObjectContent.builder().stream(new ByteArrayInputStream(content)).build()));
 
+    when(objectClient.headObject(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                ObjectMetadata.builder().contentLength(contentLength).build()));
+
     ObjectStatus objectStatus = mock(ObjectStatus.class);
     when(objectStatus.getS3URI()).thenReturn(URI);
 


### PR DESCRIPTION
Simplify for now logic responsible for building range for prefetching. Previous logic was relying on finding two cached blocks, one that contains start range and second that contains end range. However, due to concurrent access to the cache, the blocks for the requested range can be evicted or added while checking for the start and end blocks. These mutations in cache, while we are building range for prefetching is leading to construction of incorrect range. When the incorrect range was passed down to S3CrtAsyncClient, it caused crushes (should be fixed soon by https://github.com/awslabs/aws-c-s3/pull/440). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
