### PR TITLE
Adds in prefetch details to referrer header.

### DIFF
--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/blockmanager/MultiObjectsBlockManager.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/blockmanager/MultiObjectsBlockManager.java
@@ -8,6 +8,7 @@ import com.amazon.connector.s3.object.ObjectMetadata;
 import com.amazon.connector.s3.request.GetRequest;
 import com.amazon.connector.s3.request.HeadRequest;
 import com.amazon.connector.s3.request.Range;
+import com.amazon.connector.s3.request.Referrer;
 import com.amazon.connector.s3.util.S3URI;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -314,12 +315,15 @@ public class MultiObjectsBlockManager implements AutoCloseable {
         contentLength(s3URI),
         s3URI.getKey());
 
+    Range range = new Range(OptionalLong.of(start), OptionalLong.of(end));
+
     CompletableFuture<ObjectContent> objectContent =
         this.objectClient.getObject(
             GetRequest.builder()
                 .bucket(s3URI.getBucket())
                 .key(s3URI.getKey())
-                .range(new Range(OptionalLong.of(start), OptionalLong.of(end)))
+                .range(range)
+                .referrer(new Referrer(range.toString(), isPrefetch).toString())
                 .build());
 
     IOBlock ioBlock = new IOBlock(start, end, objectContent);

--- a/object-client/src/main/java/com/amazon/connector/s3/S3SdkObjectClient.java
+++ b/object-client/src/main/java/com/amazon/connector/s3/S3SdkObjectClient.java
@@ -91,11 +91,10 @@ public class S3SdkObjectClient implements ObjectClient, AutoCloseable {
     if (Objects.nonNull(getRequest.getRange())) {
       String range = getRequest.getRange().toString();
       builder.range(range);
-      // Temporarily adding range of data requested as a Referrer header to allow for easy analysis
-      // of access logs. This is similar to what the Auditing feature in S3A does.
+
       builder.overrideConfiguration(
           AwsRequestOverrideConfiguration.builder()
-              .putHeader("Referer", range)
+              .putHeader("Referer", getRequest.getReferrer())
               .putHeader(HEADER_USER_AGENT, this.userAgent.getUserAgent())
               .build());
     }

--- a/object-client/src/main/java/com/amazon/connector/s3/request/GetRequest.java
+++ b/object-client/src/main/java/com/amazon/connector/s3/request/GetRequest.java
@@ -14,4 +14,5 @@ public class GetRequest {
   @NonNull String bucket;
   @NonNull String key;
   Range range;
+  String referrer;
 }

--- a/object-client/src/main/java/com/amazon/connector/s3/request/Referrer.java
+++ b/object-client/src/main/java/com/amazon/connector/s3/request/Referrer.java
@@ -1,0 +1,28 @@
+package com.amazon.connector.s3.request;
+
+import lombok.Getter;
+
+/** Represents the referrer header to be passed in when making a request. */
+public class Referrer {
+  @Getter private final String range;
+  @Getter private final boolean isPrefetch;
+
+  /**
+   * Construct a referrer object.
+   *
+   * @param range range of data requested
+   * @param isPrefetch is the request on the prefetch path?
+   */
+  public Referrer(String range, boolean isPrefetch) {
+    this.range = range;
+    this.isPrefetch = isPrefetch;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder referrer = new StringBuilder();
+    referrer.append(range);
+    referrer.append(",isPrefetch=").append(isPrefetch);
+    return referrer.toString();
+  }
+}

--- a/object-client/src/test/java/com/amazon/connector/s3/request/ReferrerTest.java
+++ b/object-client/src/test/java/com/amazon/connector/s3/request/ReferrerTest.java
@@ -1,0 +1,21 @@
+package com.amazon.connector.s3.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class ReferrerTest {
+
+  @Test
+  void testConstructor() {
+    Referrer referrer = new Referrer(null, false);
+    assertNotNull(referrer);
+  }
+
+  @Test
+  void testReferrerToString() {
+    Referrer referrer = new Referrer("bytes=11083511-19472118", true);
+    assertEquals(referrer.toString(), "bytes=11083511-19472118,isPrefetch=true");
+  }
+}


### PR DESCRIPTION

*Description of changes:*

Allows for more details to be added into the referrer header. This lets us explain what is going on easily by looking at the referrer header in access logs. 

For example, if a query shows a lot of speedup, we can calculate what % of requests were prefetched by doing `Select * from logs where referrer contains prefetch=true`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
