### PR TITLE
Update instructions on how to run micro-benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The project is configured to be built via Gradle (Gradle 8.7). It also targets J
 * To apply formatting: `./gradlew spotlessApply`
 * To list all tasks: `./gradlew tasks`
 * To publish JARs to Maven local: `./gradlew publishToMavenLocal`
+* To build JMH benchmarks JAR: `./gradlew jmhJar`
 
 # Microbenchmarks
 
@@ -30,14 +31,19 @@ prefix in your bucket for all micro-benchmark related stuff). Now, to generate s
 
 ## Running the Benchmarks
 
-Just run `./gradlew jmh --rerun`. (The reason for re-run is a Gradle-quirk. You may want to re-run benchmarks even when
+There are two ways:
+1. Just run `./gradlew jmh --rerun`. (The reason for re-run is a Gradle-quirk. You may want to re-run benchmarks even when
 you did not actually change the source of your project: `--rerun` turns off the Gradle optimisation that falls through
 build steps when nothing changed.)
+2. Run `java -jar input-stream/build/libs/input-stream-jmh.jar` (but don't forget to build the JMH JAR first; this you
+can do with the `jmhJar` command listed above). This pattern is more useful when you want to add 
+advanced configurations. For example, you could run `java -jar input-stream/build/libs/input-stream-jmh.jar -e SeekingReadBenchmarks`
+to not run the benchmarks that seek.
 
 ## Developing integrations
 
 When you are building this library into connectors, your IDE will need to be aware of the JARs (common, object-client,
-input-stream). Consuming these via Maven/Gradle is natural and you can use `./gradlew publishToMavenLocal` to have the
+input-stream). Consuming these via Maven/Gradle is natural, and you can use `./gradlew publishToMavenLocal` to have the
 built JARs installed to your Maven local repository (this is `~/.m2` most of the time).
 
 

--- a/input-stream/src/jmh/java/com/amazon/connector/s3/benchmark/SeekingReadBenchmarks.java
+++ b/input-stream/src/jmh/java/com/amazon/connector/s3/benchmark/SeekingReadBenchmarks.java
@@ -33,8 +33,8 @@ import software.amazon.awssdk.utils.IoUtils;
  */
 @Fork(1)
 @State(Scope.Benchmark)
-@Warmup(iterations = 3)
-@Measurement(iterations = 15)
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
 @BenchmarkMode(Mode.SingleShotTime)
 public class SeekingReadBenchmarks {
 

--- a/input-stream/src/jmh/java/com/amazon/connector/s3/benchmark/SequentialReadBenchmark.java
+++ b/input-stream/src/jmh/java/com/amazon/connector/s3/benchmark/SequentialReadBenchmark.java
@@ -30,8 +30,8 @@ import software.amazon.awssdk.utils.IoUtils;
  */
 @Fork(1)
 @State(Scope.Benchmark)
-@Warmup(iterations = 3)
-@Measurement(iterations = 15)
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
 @BenchmarkMode(Mode.SingleShotTime)
 public class SequentialReadBenchmark {
 


### PR DESCRIPTION
While investigating an issue I had to run micro-benchmarks and wanted to run a subset only. Added the command for this.

The microbenchmarks also ran very long with the default number of repetitions (15) so lowered this (to 3). This should give us a better development experience when we implement the sequential prefetcher.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
