### PR TITLE
Optimize block reading

### DIFF
--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/blockmanager/MultiObjectsBlockManager.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/blockmanager/MultiObjectsBlockManager.java
@@ -224,12 +224,21 @@ public class MultiObjectsBlockManager implements AutoCloseable {
       }
 
       IOBlock ioBlock = getBlockForPosition(nextReadPos, numBytesRemaining, s3URI);
-      long blockOffset = nextReadPos - ioBlock.getStart();
-      if (ioBlock.size() - blockOffset < numBytesRemaining) {
-        long nextStartPos = nextReadPos + ioBlock.size() - blockOffset;
-        if (nextStartPos <= getLastObjectByte(s3URI))
-          getBlockForPosition(
-              nextStartPos, numBytesRemaining - ioBlock.size() + blockOffset, s3URI);
+      // Calculate the absolute start position within the current block and the number of bytes
+      // remaining in it
+      long absolutStartPositionInsideBlock = nextReadPos - ioBlock.getStart();
+      long bytesRemainingInBlock = ioBlock.size() - absolutStartPositionInsideBlock;
+      // Check if the current block has enough bytes to satisfy the remaining read
+      if (bytesRemainingInBlock < numBytesRemaining) {
+        // Calculate the relative start position for the next block
+        long relativeStartPositionForNextBlock = nextReadPos + bytesRemainingInBlock;
+        if (relativeStartPositionForNextBlock <= getLastObjectByte(s3URI)) {
+          // Calculate the number of bytes to read for the next block
+          long bytesToReadAfterCurrentBlock = numBytesRemaining - bytesRemainingInBlock;
+          // Prefetch async block if it doesn't exist
+          prefechBlockForPositionIfNotExists(
+              relativeStartPositionForNextBlock, bytesToReadAfterCurrentBlock, s3URI);
+        }
       }
       int numBytesToRead = ioBlock.read(buffer, nextReadOffset, numBytesRemaining, nextReadPos);
       nextReadOffset += numBytesToRead;
@@ -266,6 +275,14 @@ public class MultiObjectsBlockManager implements AutoCloseable {
     }
 
     return lookup.get();
+  }
+
+  private void prefechBlockForPositionIfNotExists(long pos, long len, S3URI s3URI)
+      throws IOException {
+    Optional<IOBlock> lookup = lookupBlockForPosition(pos, s3URI);
+    if (!lookup.isPresent()) {
+      createPrefetchBlockAtWithSize(pos, len, s3URI);
+    }
   }
 
   private IOBlock getBlockForPosition(long pos, S3URI s3URI) throws IOException {
@@ -309,6 +326,19 @@ public class MultiObjectsBlockManager implements AutoCloseable {
     }
 
     return createBlock(start, end, s3URI, false);
+  }
+
+  private CompletableFuture<IOBlock> createPrefetchBlockAtWithSize(
+      long start, long size, S3URI s3URI) throws IOException {
+    long end;
+
+    if (size > configuration.getReadAheadBytes()) {
+      end = Math.min(start + size - 1, getLastObjectByte(s3URI));
+    } else {
+      end = Math.min(start + configuration.getReadAheadBytes() - 1, getLastObjectByte(s3URI));
+    }
+
+    return createPrefetchBlock(start, end, s3URI);
   }
 
   private IOBlock createBlock(long start, long end, S3URI s3URI, boolean isPrefetch)

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/blockmanager/MultiObjectsBlockManagerTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/blockmanager/MultiObjectsBlockManagerTest.java
@@ -1,6 +1,7 @@
 package com.amazon.connector.s3.io.physical.blockmanager;
 
 import static com.amazon.connector.s3.util.Constants.ONE_MB;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -21,8 +22,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -129,6 +132,81 @@ public class MultiObjectsBlockManagerTest {
   }
 
   @Test
+  void testAbsenceOfDuplicateReading() throws IOException {
+    StringBuilder sb = new StringBuilder(8 * ONE_MB);
+    sb.append(StringUtils.repeat("0", 8 * ONE_MB));
+    FakeObjectClient objectClient = new FakeObjectClient(sb.toString());
+    MultiObjectsBlockManager multiObjectsBlockManager =
+        new MultiObjectsBlockManager(objectClient, BlockManagerConfiguration.DEFAULT);
+    S3URI s3URI = S3URI.of("test", "test");
+
+    byte[] buffer = new byte[ONE_MB];
+    multiObjectsBlockManager.read(buffer, 0, 1, 0, s3URI);
+    multiObjectsBlockManager.read(buffer, 0, 1, 10, s3URI);
+    // with first read we should read up to READ_AHEAD bytes with one get request
+
+    multiObjectsBlockManager.read(
+        buffer, 0, (int) BlockManagerConfiguration.DEFAULT_READ_AHEAD_BYTES, 100, s3URI);
+    // this read should initiate second get request outside the first one
+    assertEquals(2, objectClient.getGetRequestCount().get());
+
+    assertEquals(2, objectClient.getRequestedRanges().size());
+    // ensure that Get ranges is not overlapping
+    assertEquals(0, objectClient.getRequestedRanges().getFirst().getStart().orElse(-1));
+    assertEquals(
+        BlockManagerConfiguration.DEFAULT_READ_AHEAD_BYTES - 1,
+        objectClient.getRequestedRanges().getFirst().getEnd().orElse(-1));
+    assertEquals(
+        BlockManagerConfiguration.DEFAULT_READ_AHEAD_BYTES,
+        objectClient.getRequestedRanges().getLast().getStart().orElse(-1));
+    assertEquals(
+        BlockManagerConfiguration.DEFAULT_READ_AHEAD_BYTES * 2 - 1,
+        objectClient.getRequestedRanges().getLast().getEnd().orElse(-1));
+
+    multiObjectsBlockManager.read(
+        buffer, 0, (int) BlockManagerConfiguration.DEFAULT_READ_AHEAD_BYTES, 1000, s3URI);
+    // previous two GET request should be enough for providing data for this read request
+    assertEquals(2, objectClient.getGetRequestCount().get());
+
+    multiObjectsBlockManager.read(
+        buffer, 0, (int) BlockManagerConfiguration.DEFAULT_READ_AHEAD_BYTES * 3, 1000, s3URI);
+    // with this read we should use two cached Get request and create new Get request bugger than
+    // READ_AHEAD
+    assertEquals(3, objectClient.getGetRequestCount().get());
+    assertEquals(
+        BlockManagerConfiguration.DEFAULT_READ_AHEAD_BYTES * 2,
+        objectClient.getRequestedRanges().getLast().getStart().orElse(-1));
+    assertEquals(
+        BlockManagerConfiguration.DEFAULT_READ_AHEAD_BYTES * 3 + 999,
+        objectClient.getRequestedRanges().getLast().getEnd().orElse(-1));
+  }
+
+  @Test
+  void testTailRead() throws IOException {
+    StringBuilder sb = new StringBuilder(4 * ONE_MB);
+    final int HALF_MB = ONE_MB / 2;
+    sb.append(StringUtils.repeat("0", 3 * ONE_MB + HALF_MB));
+    sb.append(StringUtils.repeat("1", HALF_MB));
+    FakeObjectClient objectClient = new FakeObjectClient(sb.toString());
+    MultiObjectsBlockManager multiObjectsBlockManager =
+        new MultiObjectsBlockManager(objectClient, BlockManagerConfiguration.DEFAULT);
+    S3URI s3URI = S3URI.of("test", "test");
+
+    byte[] buffer = new byte[HALF_MB];
+    byte[] expectedBuffer = new byte[HALF_MB];
+    Arrays.fill(expectedBuffer, 0, HALF_MB, (byte) '1');
+    multiObjectsBlockManager.readTail(buffer, 0, HALF_MB, s3URI);
+    assertArrayEquals(expectedBuffer, buffer);
+
+    buffer = new byte[ONE_MB];
+    expectedBuffer = new byte[ONE_MB];
+    Arrays.fill(expectedBuffer, 0, HALF_MB, (byte) '0');
+    Arrays.fill(expectedBuffer, HALF_MB, ONE_MB, (byte) '1');
+    multiObjectsBlockManager.readTail(buffer, 0, ONE_MB, s3URI);
+    assertArrayEquals(expectedBuffer, buffer);
+  }
+
+  @Test
   public void testGetMetadataWithFailedRequest() throws Exception {
     ObjectClient objectClient = mock(ObjectClient.class);
     MultiObjectsBlockManager multiObjectsBlockManager =
@@ -212,6 +290,19 @@ public class MultiObjectsBlockManagerTest {
 
     multiObjectsBlockManager.putColumnMappers(s3URI, columnMappers);
     assertEquals(columnMappers, multiObjectsBlockManager.getColumnMappers(s3URI));
+
+    Set<String> keys =
+        new HashSet() {
+          {
+            add("column1");
+            add("column2");
+            add("column3");
+          }
+        };
+    for (String key : keys) {
+      multiObjectsBlockManager.addRecentColumn(key);
+    }
+    assertEquals(keys, multiObjectsBlockManager.getRecentColumns());
   }
 
   @Test


### PR DESCRIPTION
*Description of changes:*
Changes contains two improvement:

1. When reading data from S3, use the remaining number of bytes to read instead of repeatedly requesting the total number of bytes. This optimization ensures that the request size is adjusted based on the remaining data to be read, preventing over-reading.
2. If the current IOBlock does not contain all the remaining bytes, issue a request for the next block before copying the available data from the current block. This change ensures that the next block is fetched in parallel while the current block's data is being processed, potentially improving throughput.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
