### PR TITLE
[Fix] Resolve dependency conflict in uber JAR

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,10 @@ crt = "0.29.10"
 lombok = "1.18.32"
 parquetFormat = "2.10.0"
 log4j = "2.23.1"
+commons-io = "2.16.1"
+jqwik = "1.8.5"
+jqwik-testcontainers = "0.5.2"
+testcontainers-testcontainers = "1.16.2"
 
 [libraries]
 # S3-related dependencies
@@ -25,6 +29,8 @@ spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.re
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 
+commons-io = { module = "commons-io:commons-io", version.ref = "commons-io"}
+
 # Unit tests
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-jupiter-launcher = { module = "org.junit.platform:junit-platform-launcher" }
@@ -33,5 +39,8 @@ mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 
 # Reference tests
+jqwik = { module = "net.jqwik:jqwik", version.ref = "jqwik" }
+jqwik-testcontainers = { module = "net.jqwik:jqwik-testcontainers", version.ref = "jqwik-testcontainers" }
 s3mock-testcontainers = { module = "com.adobe.testing:s3mock-testcontainers", version.ref = "s3mock" }
+testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers-testcontainers" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -34,11 +34,7 @@ dependencies {
     implementation(libs.parquet.format)
     implementation(libs.log4j.api)
     implementation(libs.log4j.core)
-
-    // TODO: remove this dependency and move to 'common'
-    //  ticket: https://app.asana.com/0/1206885953994785/1207927953313329/f
-    implementation("commons-io:commons-io:2.16.1")
-
+    implementation(libs.commons.io)
 
     jmhImplementation(libs.s3)
 
@@ -54,9 +50,9 @@ dependencies {
     referenceTestImplementation(libs.s3mock.testcontainers)
     referenceTestImplementation(libs.testcontainers.junit.jupiter)
 
-    referenceTestImplementation("net.jqwik:jqwik:1.8.5")
-    referenceTestImplementation("net.jqwik:jqwik-testcontainers:0.5.2")
-    referenceTestImplementation("org.testcontainers:testcontainers:1.16.2")
+    referenceTestImplementation(libs.jqwik)
+    referenceTestImplementation(libs.jqwik.testcontainers)
+    referenceTestImplementation(libs.testcontainers)
 
     referenceTestRuntimeOnly(libs.junit.jupiter.launcher)
 }
@@ -81,6 +77,7 @@ tasks.named("compileReferenceTestJava", JavaCompile::class) {
 val shadowJar = tasks.withType<ShadowJar> {
     relocate("org.apache.parquet.format", "com.amazon.shaded.apache.parquet.format")
     relocate("shaded.parquet.org.apache.thrift", "com.amazon.shaded.parquet.org.apache.thrift")
+    relocate("org.apache.commons.io", "com.amazon.shaded.org.apache.commons.io")
 }
 
 


### PR DESCRIPTION
We realised that commons-io was causing depency conflicts when the seekable stream is built into Hadoop.  For now, we shade this dependency, we may want to remove it later or lift it into the 'common' module.

While I was here, I moved some reference test dependency descriptions into the common .toml file.

### Testing

Before this change:

Running `jar -tf input-stream-all.jar| grep commons/io` shows:
```
org/apache/commons/io/IOUtils.class
```

After this change:
```
com/amazon/shaded/org/apache/commons/io/IOUtils.class
```


> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
