### PR TITLE
Further telemetry updates to manage verbosity and control perf

### DIFF
--- a/common/src/main/java/com/amazon/connector/s3/common/telemetry/OperationMeasurement.java
+++ b/common/src/main/java/com/amazon/connector/s3/common/telemetry/OperationMeasurement.java
@@ -10,6 +10,8 @@ import lombok.Value;
 public class OperationMeasurement {
   /** Operation */
   @NonNull Operation operation;
+  /** Telemetry level. * */
+  @NonNull TelemetryLevel level;
   /** Wall clock time corresponding to operation start. */
   long epochTimestampNanos;
   /** Elapsed clock time corresponding to operation start. */
@@ -184,6 +186,7 @@ public class OperationMeasurement {
   public static class OperationMeasurementBuilder {
     private static final long UNSET_NANOS = Long.MIN_VALUE;
     private Operation operation;
+    TelemetryLevel level;
     private long epochTimestampNanos = UNSET_NANOS;
     private long elapsedStartTimeNanos = UNSET_NANOS;
     private long elapsedCompleteTimeNanos = UNSET_NANOS;
@@ -197,6 +200,17 @@ public class OperationMeasurement {
      */
     public OperationMeasurementBuilder operation(@NonNull Operation operation) {
       this.operation = operation;
+      return this;
+    }
+
+    /**
+     * Sets operation.
+     *
+     * @param level level.
+     * @return the current instance of {@link OperationMeasurementBuilder}.
+     */
+    public OperationMeasurementBuilder level(@NonNull TelemetryLevel level) {
+      this.level = level;
       return this;
     }
 
@@ -264,6 +278,7 @@ public class OperationMeasurement {
           "The `elapsedCompleteTimeNanos` must be more or equal than `elapsedStartTimeNanos`.");
       return new OperationMeasurement(
           this.operation,
+          this.level,
           this.epochTimestampNanos,
           this.elapsedStartTimeNanos,
           this.elapsedCompleteTimeNanos,

--- a/common/src/main/java/com/amazon/connector/s3/common/telemetry/OperationSupplier.java
+++ b/common/src/main/java/com/amazon/connector/s3/common/telemetry/OperationSupplier.java
@@ -1,0 +1,5 @@
+package com.amazon.connector.s3.common.telemetry;
+
+/** Syntactic sugar over {@link TelemetrySupplier} */
+@FunctionalInterface
+public interface OperationSupplier extends TelemetrySupplier<Operation> {}

--- a/common/src/main/java/com/amazon/connector/s3/common/telemetry/Telemetry.java
+++ b/common/src/main/java/com/amazon/connector/s3/common/telemetry/Telemetry.java
@@ -9,20 +9,28 @@ public interface Telemetry {
   /**
    * Measures a given {@link Runnable} and record the telemetry as {@link Operation}.
    *
-   * @param operation operation to record this execution as.
+   * @param level telemetry level.
+   * @param operationSupplier operation to record this execution as.
    * @param operationCode - code to execute.
    */
-  void measure(@NonNull Operation operation, @NonNull TelemetryAction operationCode);
+  void measure(
+      @NonNull TelemetryLevel level,
+      @NonNull OperationSupplier operationSupplier,
+      @NonNull TelemetryAction operationCode);
 
   /**
    * Measures a given {@link Supplier <T>} and record the telemetry as {@link Operation}.
    *
-   * @param operation operation to record this execution as.
-   * @param operationCode code to execute.
    * @param <T> return type of the {@link Supplier<T>}.
+   * @param level telemetry level.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode code to execute.
    * @return the value that {@link Supplier<T>} returns.
    */
-  <T> T measure(@NonNull Operation operation, @NonNull TelemetrySupplier<T> operationCode);
+  <T> T measure(
+      @NonNull TelemetryLevel level,
+      @NonNull OperationSupplier operationSupplier,
+      @NonNull TelemetrySupplier<T> operationCode);
 
   /**
    * Measures the execution of the given {@link CompletableFuture} and records the telemetry as
@@ -30,14 +38,17 @@ public interface Telemetry {
    * continuations, so any {@link Operation}s that are created in that context need to carry the
    * parenting chain.
    *
-   * @param operation operation to record this execution as.
+   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param level telemetry level.
+   * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link CompletableFuture} that returns the same result as the one passed
    *     in.
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
    */
   <T> CompletableFuture<T> measure(
-      @NonNull Operation operation, @NonNull CompletableFuture<T> operationCode);
+      @NonNull TelemetryLevel level,
+      @NonNull OperationSupplier operationSupplier,
+      @NonNull CompletableFuture<T> operationCode);
 
   /**
    * This is a helper method to reduce verbosity on completed futures. Blocks on the execution on
@@ -47,18 +58,201 @@ public interface Telemetry {
    * recorded if the future was not completed, which is checked via {@link
    * CompletableFuture#isDone()}
    *
-   * @param operation operation to record this execution as.
+   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param level telemetry level.
+   * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link T} that returns the same result as the one passed in.
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
    */
   default <T> T measureJoin(
-      @NonNull Operation operation, @NonNull CompletableFuture<T> operationCode) {
+      @NonNull TelemetryLevel level,
+      @NonNull OperationSupplier operationSupplier,
+      @NonNull CompletableFuture<T> operationCode) {
     if (operationCode.isDone()) {
       return operationCode.join();
     } else {
-      return this.measure(operation, operationCode::join);
+      return this.measure(level, operationSupplier, operationCode::join);
     }
+  }
+
+  /**
+   * Measures a given {@link Runnable} and record the telemetry as {@link Operation}. This is done
+   * at {@link TelemetryLevel#CRITICAL}.
+   *
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode - code to execute.
+   */
+  default void measureCritical(OperationSupplier operationSupplier, TelemetryAction operationCode) {
+    measure(TelemetryLevel.CRITICAL, operationSupplier, operationCode);
+  }
+
+  /**
+   * Measures a given {@link Supplier <T>} and record the telemetry as {@link Operation}. This is
+   * done at {@link TelemetryLevel#CRITICAL}.
+   *
+   * @param <T> return type of the {@link Supplier<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode code to execute.
+   * @return the value that {@link Supplier<T>} returns.
+   */
+  default <T> T measureCritical(
+      OperationSupplier operationSupplier, TelemetrySupplier<T> operationCode) {
+    return measure(TelemetryLevel.CRITICAL, operationSupplier, operationCode);
+  }
+
+  /**
+   * Measures the execution of the given {@link CompletableFuture} and records the telemetry as
+   * {@link Operation}. We do not currently carry the operation into the context of any
+   * continuations, so any {@link Operation}s that are created in that context need to carry the
+   * parenting chain. This is done at {@link TelemetryLevel#CRITICAL}.
+   *
+   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode the future to measure the execution of.
+   * @return an instance of {@link CompletableFuture} that returns the same result as the one passed
+   *     in.
+   */
+  default <T> CompletableFuture<T> measureCritical(
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+    return measure(TelemetryLevel.CRITICAL, operationSupplier, operationCode);
+  }
+
+  /**
+   * This is a helper method to reduce verbosity on completed futures. Blocks on the execution on
+   * {@link CompletableFuture#join()} and records the telemetry as {@link Operation}. We do not
+   * currently carry the operation into the context of any continuations, so any {@link Operation}s
+   * that are created in that context need to carry the parenting chain. The telemetry is only
+   * recorded if the future was not completed, which is checked via {@link
+   * CompletableFuture#isDone()}. This is done at {@link TelemetryLevel#CRITICAL}.
+   *
+   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode the future to measure the execution of.
+   * @return an instance of {@link T} that returns the same result as the one passed in.
+   */
+  default <T> T measureJoinCritical(
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+    return measureJoin(TelemetryLevel.CRITICAL, operationSupplier, operationCode);
+  }
+
+  /**
+   * Measures a given {@link Runnable} and record the telemetry as {@link Operation}. This is done
+   * at {@link TelemetryLevel#STANDARD}.
+   *
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode - code to execute.
+   */
+  default void measureStandard(OperationSupplier operationSupplier, TelemetryAction operationCode) {
+    measure(TelemetryLevel.STANDARD, operationSupplier, operationCode);
+  }
+
+  /**
+   * Measures a given {@link Supplier <T>} and record the telemetry as {@link Operation}. This is
+   * done at {@link TelemetryLevel#STANDARD}.
+   *
+   * @param <T> return type of the {@link Supplier<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode code to execute.
+   * @return the value that {@link Supplier<T>} returns.
+   */
+  default <T> T measureStandard(
+      OperationSupplier operationSupplier, TelemetrySupplier<T> operationCode) {
+    return measure(TelemetryLevel.STANDARD, operationSupplier, operationCode);
+  }
+
+  /**
+   * Measures the execution of the given {@link CompletableFuture} and records the telemetry as
+   * {@link Operation}. We do not currently carry the operation into the context of any
+   * continuations, so any {@link Operation}s that are created in that context need to carry the
+   * parenting chain. This is done at {@link TelemetryLevel#STANDARD}.
+   *
+   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode the future to measure the execution of.
+   * @return an instance of {@link CompletableFuture} that returns the same result as the one passed
+   *     in.
+   */
+  default <T> CompletableFuture<T> measureStandard(
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+    return measure(TelemetryLevel.STANDARD, operationSupplier, operationCode);
+  }
+
+  /**
+   * This is a helper method to reduce verbosity on completed futures. Blocks on the execution on
+   * {@link CompletableFuture#join()} and records the telemetry as {@link Operation}. We do not
+   * currently carry the operation into the context of any continuations, so any {@link Operation}s
+   * that are created in that context need to carry the parenting chain. The telemetry is only
+   * recorded if the future was not completed, which is checked via {@link
+   * CompletableFuture#isDone()}. This is done at {@link TelemetryLevel#STANDARD}.
+   *
+   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode the future to measure the execution of.
+   * @return an instance of {@link T} that returns the same result as the one passed in.
+   */
+  default <T> T measureJoinStandard(
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+    return measureJoin(TelemetryLevel.STANDARD, operationSupplier, operationCode);
+  }
+
+  /**
+   * Measures a given {@link Runnable} and record the telemetry as {@link Operation}. This is done
+   * at {@link TelemetryLevel#VERBOSE}.
+   *
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode - code to execute.
+   */
+  default void measureVerbose(OperationSupplier operationSupplier, TelemetryAction operationCode) {
+    measure(TelemetryLevel.VERBOSE, operationSupplier, operationCode);
+  }
+
+  /**
+   * Measures a given {@link Supplier <T>} and record the telemetry as {@link Operation}. This is
+   * done at {@link TelemetryLevel#VERBOSE}.
+   *
+   * @param <T> return type of the {@link Supplier<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode code to execute.
+   * @return the value that {@link Supplier<T>} returns.
+   */
+  default <T> T measureVerbose(
+      OperationSupplier operationSupplier, TelemetrySupplier<T> operationCode) {
+    return measure(TelemetryLevel.VERBOSE, operationSupplier, operationCode);
+  }
+
+  /**
+   * Measures the execution of the given {@link CompletableFuture} and records the telemetry as
+   * {@link Operation}. We do not currently carry the operation into the context of any
+   * continuations, so any {@link Operation}s that are created in that context need to carry the
+   * parenting chain. This is done at {@link TelemetryLevel#VERBOSE}.
+   *
+   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode the future to measure the execution of.
+   * @return an instance of {@link CompletableFuture} that returns the same result as the one passed
+   *     in.
+   */
+  default <T> CompletableFuture<T> measureVerbose(
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+    return measure(TelemetryLevel.VERBOSE, operationSupplier, operationCode);
+  }
+
+  /**
+   * This is a helper method to reduce verbosity on completed futures. Blocks on the execution on
+   * {@link CompletableFuture#join()} and records the telemetry as {@link Operation}. We do not
+   * currently carry the operation into the context of any continuations, so any {@link Operation}s
+   * that are created in that context need to carry the parenting chain. The telemetry is only
+   * recorded if the future was not completed, which is checked via {@link
+   * CompletableFuture#isDone()}. This is done at {@link TelemetryLevel#VERBOSE}.
+   *
+   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param operationSupplier operation to record this execution as.
+   * @param operationCode the future to measure the execution of.
+   * @return an instance of {@link T} that returns the same result as the one passed in.
+   */
+  default <T> T measureJoinVerbose(
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+    return measureJoin(TelemetryLevel.VERBOSE, operationSupplier, operationCode);
   }
 
   /**
@@ -72,7 +266,7 @@ public interface Telemetry {
   }
 
   /** An instance of {@link Telemetry} that reports nothing. */
-  static Telemetry NOOP =
+  public static Telemetry NOOP =
       new DefaultTelemetry(
           DefaultEpochClock.DEFAULT,
           DefaultElapsedClock.DEFAULT,

--- a/common/src/main/java/com/amazon/connector/s3/common/telemetry/TelemetryLevel.java
+++ b/common/src/main/java/com/amazon/connector/s3/common/telemetry/TelemetryLevel.java
@@ -7,26 +7,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum TelemetryLevel {
-  CRITICAL("CRITICAL"),
-  STANDARD("STANDARD"),
-  VERBOSE("VERBOSE");
-  private final String name;
-
-  /**
-   * Get numeric priority of telemetry level.
-   *
-   * @return numeric priority of telemetry level.
-   */
-  public int getPriority() {
-    switch (this) {
-      case CRITICAL:
-        return 2;
-      case STANDARD:
-        return 1;
-      case VERBOSE:
-        return 0;
-      default:
-        throw new IllegalArgumentException("Unknown telemetry level: " + this);
-    }
-  }
+  CRITICAL(2),
+  STANDARD(1),
+  VERBOSE(0);
+  private final int value;
 }

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/CollectingTelemetryReporter.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/CollectingTelemetryReporter.java
@@ -12,6 +12,12 @@ public class CollectingTelemetryReporter implements TelemetryReporter {
 
   private final Collection<Operation> operationStarts = new ArrayList<>();
 
+  /** Clears state */
+  public void clear() {
+    this.operationCompletions.clear();
+    this.operationStarts.clear();
+  }
+
   /**
    * Reports the start of an operation
    *

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/GroupTelemetryReporterTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/GroupTelemetryReporterTest.java
@@ -39,6 +39,7 @@ public class GroupTelemetryReporterTest {
         OperationMeasurement.builder()
             .operation(operation)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
+            .level(TelemetryLevel.STANDARD)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)
             .build();

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/LoggingTelemetryReporterTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/LoggingTelemetryReporterTest.java
@@ -22,6 +22,7 @@ public class LoggingTelemetryReporterTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)
@@ -51,6 +52,7 @@ public class LoggingTelemetryReporterTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)
@@ -66,6 +68,7 @@ public class LoggingTelemetryReporterTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .error(new IllegalStateException("Error"))
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/NoOpTelemetryReporterTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/NoOpTelemetryReporterTest.java
@@ -11,6 +11,7 @@ public class NoOpTelemetryReporterTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/OperationContextTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/OperationContextTest.java
@@ -68,7 +68,7 @@ public class OperationContextTest {
   @Test
   void testPopMismatchedStack() {
     OperationContext context = new OperationContext();
-    Operation operation_on_stack =
+    Operation operationOnStack =
         Operation.builder()
             .name("read1")
             .attribute("s3.bucket", "bucket1")
@@ -83,11 +83,28 @@ public class OperationContextTest {
             .attribute("s3.key", "key2")
             .context(context)
             .build();
-    context.pushOperation(operation_on_stack);
+    context.pushOperation(operationOnStack);
     try {
       assertThrows(IllegalStateException.class, () -> context.popOperation(operation));
     } finally {
-      context.popOperation(operation_on_stack);
+      context.popOperation(operationOnStack);
     }
+  }
+
+  @Test
+  void testEmptyStack() {
+    OperationContext context = new OperationContext();
+    Operation operation =
+        Operation.builder()
+            .name("read")
+            .attribute("s3.bucket", "bucket")
+            .attribute("s3.key", "key")
+            .context(context)
+            .build();
+    // This should never be possible in practice, but this does clear teh stack
+    context.popOperation(context.defaultOperation);
+
+    assertThrows(IllegalStateException.class, () -> context.popOperation(operation));
+    assertThrows(IllegalStateException.class, context::getCurrentOperation);
   }
 }

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/OperationMeasurementTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/OperationMeasurementTest.java
@@ -16,6 +16,7 @@ public class OperationMeasurementTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(1)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(12)
@@ -40,6 +41,7 @@ public class OperationMeasurementTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(1)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(12)
@@ -146,6 +148,7 @@ public class OperationMeasurementTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)
@@ -166,6 +169,7 @@ public class OperationMeasurementTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)
@@ -191,6 +195,7 @@ public class OperationMeasurementTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .error(error)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
@@ -217,6 +222,7 @@ public class OperationMeasurementTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)
@@ -240,6 +246,7 @@ public class OperationMeasurementTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)
@@ -263,6 +270,7 @@ public class OperationMeasurementTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/OperationTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/OperationTest.java
@@ -40,13 +40,10 @@ public class OperationTest {
     attributes.put("Foo", Attribute.of("Foo", 42));
     Operation parent = Operation.builder().name("S3.GET").build();
     OperationContext context = new OperationContext();
-    Operation operation =
-        new Operation(
-            "id", "name", TelemetryLevel.CRITICAL, attributes, context, Optional.of(parent));
+    Operation operation = new Operation("id", "name", attributes, context, Optional.of(parent));
 
     assertEquals("id", operation.getId());
     assertEquals("name", operation.getName());
-    assertEquals(TelemetryLevel.CRITICAL, operation.getLevel());
     assertEquals(
         Thread.currentThread().getId(),
         operation.getAttributes().get(CommonAttributes.THREAD_ID.getName()).getValue());
@@ -63,30 +60,18 @@ public class OperationTest {
     OperationContext context = new OperationContext();
     assertThrows(
         NullPointerException.class,
-        () ->
-            new Operation(
-                null, "name", TelemetryLevel.STANDARD, attributes, context, Optional.of(parent)));
+        () -> new Operation(null, "name", attributes, context, Optional.of(parent)));
     assertThrows(
         NullPointerException.class,
-        () ->
-            new Operation(
-                "id", null, TelemetryLevel.STANDARD, attributes, context, Optional.of(parent)));
+        () -> new Operation("id", null, attributes, context, Optional.of(parent)));
     assertThrows(
         NullPointerException.class,
-        () -> new Operation("id", "name", null, attributes, context, Optional.of(parent)));
+        () -> new Operation("id", "name", null, context, Optional.of(parent)));
     assertThrows(
         NullPointerException.class,
-        () ->
-            new Operation(
-                "id", "name", TelemetryLevel.STANDARD, null, context, Optional.of(parent)));
+        () -> new Operation("id", "name", attributes, null, Optional.of(parent)));
     assertThrows(
-        NullPointerException.class,
-        () ->
-            new Operation(
-                "id", "name", TelemetryLevel.STANDARD, attributes, null, Optional.of(parent)));
-    assertThrows(
-        NullPointerException.class,
-        () -> new Operation("id", "name", TelemetryLevel.STANDARD, attributes, context, null));
+        NullPointerException.class, () -> new Operation("id", "name", attributes, context, null));
   }
 
   @Test
@@ -96,12 +81,10 @@ public class OperationTest {
     Operation parent = Operation.builder().name("S3.GET").build();
     OperationContext context = new OperationContext();
     Operation operation =
-        new Operation(
-            "id", "name", TelemetryLevel.CRITICAL, attributes, context, Optional.of(parent), true);
+        new Operation("id", "name", attributes, context, Optional.of(parent), true);
 
     assertEquals("id", operation.getId());
     assertEquals("name", operation.getName());
-    assertEquals(TelemetryLevel.CRITICAL, operation.getLevel());
     assertEquals(
         Thread.currentThread().getId(),
         operation.getAttributes().get(CommonAttributes.THREAD_ID.getName()).getValue());
@@ -119,49 +102,19 @@ public class OperationTest {
 
     assertThrows(
         NullPointerException.class,
-        () ->
-            new Operation(
-                null,
-                "name",
-                TelemetryLevel.STANDARD,
-                attributes,
-                context,
-                Optional.of(parent),
-                true));
+        () -> new Operation(null, "name", attributes, context, Optional.of(parent), true));
     assertThrows(
         NullPointerException.class,
-        () ->
-            new Operation(
-                "id",
-                null,
-                TelemetryLevel.STANDARD,
-                attributes,
-                context,
-                Optional.of(parent),
-                true));
+        () -> new Operation("id", null, attributes, context, Optional.of(parent), true));
     assertThrows(
         NullPointerException.class,
-        () -> new Operation("id", "name", null, attributes, context, Optional.of(parent), true));
+        () -> new Operation("id", "name", null, context, Optional.of(parent), true));
     assertThrows(
         NullPointerException.class,
-        () ->
-            new Operation(
-                "id", "name", TelemetryLevel.STANDARD, null, context, Optional.of(parent), true));
+        () -> new Operation("id", "name", attributes, null, Optional.of(parent), true));
     assertThrows(
         NullPointerException.class,
-        () ->
-            new Operation(
-                "id",
-                "name",
-                TelemetryLevel.STANDARD,
-                attributes,
-                null,
-                Optional.of(parent),
-                true));
-    assertThrows(
-        NullPointerException.class,
-        () ->
-            new Operation("id", "name", TelemetryLevel.STANDARD, attributes, context, null, true));
+        () -> new Operation("id", "name", attributes, context, null, true));
   }
 
   @Test
@@ -260,13 +213,11 @@ public class OperationTest {
     Operation operation =
         Operation.builder()
             .name("S3.GET")
-            .level(TelemetryLevel.CRITICAL)
             .attribute(Attribute.of("s3.bucket", "bucket"))
             .attribute(Attribute.of("s3.key", "key"))
             .build();
     assertNotNull(operation.getId());
     assertEquals("S3.GET", operation.getName());
-    assertEquals(TelemetryLevel.CRITICAL, operation.getLevel());
     assertSame(OperationContext.DEFAULT, operation.getContext());
 
     assertEquals(3, operation.getAttributes().size());
@@ -504,11 +455,6 @@ public class OperationTest {
         NullPointerException.class,
         () -> {
           Operation.builder().name("foo").context(null).build();
-        });
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          Operation.builder().name("foo").level(null).build();
         });
   }
 

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/PrintStreamTelemetryReporterTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/PrintStreamTelemetryReporterTest.java
@@ -49,6 +49,7 @@ public class PrintStreamTelemetryReporterTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)
@@ -74,6 +75,7 @@ public class PrintStreamTelemetryReporterTest {
     OperationMeasurement operationMeasurement =
         OperationMeasurement.builder()
             .operation(operation)
+            .level(TelemetryLevel.STANDARD)
             .epochTimestampNanos(TEST_EPOCH_NANOS)
             .elapsedStartTimeNanos(10)
             .elapsedCompleteTimeNanos(5000000)

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/TelemetryLevelTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/TelemetryLevelTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 public class TelemetryLevelTest {
   @Test
   void testGetPriority() {
-    assertEquals(0, TelemetryLevel.VERBOSE.getPriority());
-    assertEquals(1, TelemetryLevel.STANDARD.getPriority());
-    assertEquals(2, TelemetryLevel.CRITICAL.getPriority());
+    assertEquals(0, TelemetryLevel.VERBOSE.getValue());
+    assertEquals(1, TelemetryLevel.STANDARD.getValue());
+    assertEquals(2, TelemetryLevel.CRITICAL.getValue());
   }
 }

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/TelemetryTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/TelemetryTest.java
@@ -33,6 +33,55 @@ public class TelemetryTest {
     TickingClock elapsedClock = new TickingClock(0L);
     CollectingTelemetryReporter reporter = new CollectingTelemetryReporter();
     DefaultTelemetry defaultTelemetry =
+        new DefaultTelemetry(wallClock, elapsedClock, reporter, TelemetryLevel.CRITICAL);
+
+    Operation operation = Operation.builder().name("name").attribute("foo", "bar").build();
+    final CompletableFuture<Long> completableFuture = new CompletableFuture<>();
+    Thread completionThread =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(5_000);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              elapsedClock.tick(5);
+              completableFuture.complete(42L);
+            });
+
+    elapsedClock.tick(10);
+    wallClock.tick(5);
+
+    // This will complete the future
+    completionThread.start();
+    defaultTelemetry.measureJoinCritical(() -> operation, completableFuture);
+    assertTrue(completableFuture.isDone());
+    assertFalse(completableFuture.isCompletedExceptionally());
+    assertEquals(42, completableFuture.get());
+
+    assertEquals(1, reporter.getOperationCompletions().size());
+    OperationMeasurement operationMeasurement =
+        reporter.getOperationCompletions().stream().findFirst().get();
+    assertEquals(operation, operationMeasurement.getOperation());
+    assertEquals(TelemetryLevel.CRITICAL, operationMeasurement.getLevel());
+    assertEquals(10, operationMeasurement.getElapsedStartTimeNanos());
+    assertEquals(15, operationMeasurement.getElapsedCompleteTimeNanos());
+    assertEquals(5, operationMeasurement.getElapsedTimeNanos());
+    assertEquals(5, operationMeasurement.getEpochTimestampNanos());
+    assertEquals(Optional.empty(), operationMeasurement.getError());
+
+    // Try again - nothing should be recorded
+    long result = defaultTelemetry.measureJoinStandard(() -> operation, completableFuture);
+    assertEquals(1, reporter.getOperationCompletions().size());
+    assertEquals(42, result);
+  }
+
+  @Test
+  void testMeasureJoinStandard() throws Exception {
+    TickingClock wallClock = new TickingClock(0L);
+    TickingClock elapsedClock = new TickingClock(0L);
+    CollectingTelemetryReporter reporter = new CollectingTelemetryReporter();
+    DefaultTelemetry defaultTelemetry =
         new DefaultTelemetry(wallClock, elapsedClock, reporter, TelemetryLevel.STANDARD);
 
     Operation operation = Operation.builder().name("name").attribute("foo", "bar").build();
@@ -54,7 +103,7 @@ public class TelemetryTest {
 
     // This will complete the future
     completionThread.start();
-    Long result = defaultTelemetry.measureJoin(operation, completableFuture);
+    defaultTelemetry.measureJoinStandard(() -> operation, completableFuture);
     assertTrue(completableFuture.isDone());
     assertFalse(completableFuture.isCompletedExceptionally());
     assertEquals(42, completableFuture.get());
@@ -63,6 +112,7 @@ public class TelemetryTest {
     OperationMeasurement operationMeasurement =
         reporter.getOperationCompletions().stream().findFirst().get();
     assertEquals(operation, operationMeasurement.getOperation());
+    assertEquals(TelemetryLevel.STANDARD, operationMeasurement.getLevel());
     assertEquals(10, operationMeasurement.getElapsedStartTimeNanos());
     assertEquals(15, operationMeasurement.getElapsedCompleteTimeNanos());
     assertEquals(5, operationMeasurement.getElapsedTimeNanos());
@@ -70,7 +120,57 @@ public class TelemetryTest {
     assertEquals(Optional.empty(), operationMeasurement.getError());
 
     // Try again - nothing should be recorded
-    result = defaultTelemetry.measureJoin(operation, completableFuture);
+    long result = defaultTelemetry.measureJoinStandard(() -> operation, completableFuture);
+    assertEquals(1, reporter.getOperationCompletions().size());
+    assertEquals(42, result);
+  }
+
+  @Test
+  void testMeasureJoinVerbose() throws Exception {
+    TickingClock wallClock = new TickingClock(0L);
+    TickingClock elapsedClock = new TickingClock(0L);
+    CollectingTelemetryReporter reporter = new CollectingTelemetryReporter();
+    DefaultTelemetry defaultTelemetry =
+        new DefaultTelemetry(wallClock, elapsedClock, reporter, TelemetryLevel.VERBOSE);
+
+    Operation operation = Operation.builder().name("name").attribute("foo", "bar").build();
+    final CompletableFuture<Long> completableFuture = new CompletableFuture<>();
+    Thread completionThread =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(5_000);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              elapsedClock.tick(5);
+              completableFuture.complete(42L);
+            });
+
+    elapsedClock.tick(10);
+    wallClock.tick(5);
+
+    // This will complete the future
+    completionThread.start();
+    Long result = defaultTelemetry.measureJoinVerbose(() -> operation, completableFuture);
+    assertEquals(42L, result);
+    assertTrue(completableFuture.isDone());
+    assertFalse(completableFuture.isCompletedExceptionally());
+    assertEquals(42, completableFuture.get());
+
+    assertEquals(1, reporter.getOperationCompletions().size());
+    OperationMeasurement operationMeasurement =
+        reporter.getOperationCompletions().stream().findFirst().get();
+    assertEquals(operation, operationMeasurement.getOperation());
+    assertEquals(TelemetryLevel.VERBOSE, operationMeasurement.getLevel());
+    assertEquals(10, operationMeasurement.getElapsedStartTimeNanos());
+    assertEquals(15, operationMeasurement.getElapsedCompleteTimeNanos());
+    assertEquals(5, operationMeasurement.getElapsedTimeNanos());
+    assertEquals(5, operationMeasurement.getEpochTimestampNanos());
+    assertEquals(Optional.empty(), operationMeasurement.getError());
+
+    // Try again - nothing should be recorded
+    result = defaultTelemetry.measureJoinStandard(() -> operation, completableFuture);
     assertEquals(1, reporter.getOperationCompletions().size());
     assertEquals(42, result);
   }
@@ -86,7 +186,67 @@ public class TelemetryTest {
     Operation operation = Operation.builder().name("name").attribute("foo", "bar").build();
 
     assertThrows(
-        NullPointerException.class, () -> defaultTelemetry.measureJoin(null, completableFuture));
-    assertThrows(NullPointerException.class, () -> defaultTelemetry.measureJoin(operation, null));
+        NullPointerException.class,
+        () -> defaultTelemetry.measure(null, () -> operation, completableFuture));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> defaultTelemetry.measureJoinStandard(null, completableFuture));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> defaultTelemetry.measureJoinStandard(() -> null, completableFuture));
+    assertThrows(
+        NullPointerException.class,
+        () -> defaultTelemetry.measureJoinStandard(() -> operation, null));
+  }
+
+  @Test
+  void testAllSignatures() {
+    TickingClock wallClock = new TickingClock(0L);
+    TickingClock elapsedClock = new TickingClock(0L);
+    CollectingTelemetryReporter reporter = new CollectingTelemetryReporter();
+    DefaultTelemetry defaultTelemetry =
+        new DefaultTelemetry(wallClock, elapsedClock, reporter, TelemetryLevel.VERBOSE);
+
+    OperationSupplier operationSupplier =
+        () -> Operation.builder().name("name").attribute("foo", "bar").build();
+    TelemetrySupplier<Long> telemetrySupplier = () -> 42L;
+    TelemetryAction telemetryAction = () -> {};
+    CompletableFuture<Long> completableFuture = new CompletableFuture<>();
+    completableFuture.complete(42L);
+    // We test all fields of the OperationMeasurements elsewhere.
+    // Here our main goal to make sure that operation gets logged with the right level
+
+    // Critical
+    defaultTelemetry.measureCritical(operationSupplier, telemetrySupplier);
+    assertMeasuredWithLeve(TelemetryLevel.CRITICAL, reporter);
+    defaultTelemetry.measureCritical(operationSupplier, telemetryAction);
+    assertMeasuredWithLeve(TelemetryLevel.CRITICAL, reporter);
+    defaultTelemetry.measureCritical(operationSupplier, completableFuture);
+    assertMeasuredWithLeve(TelemetryLevel.CRITICAL, reporter);
+
+    // Standard
+    defaultTelemetry.measureStandard(operationSupplier, telemetrySupplier);
+    assertMeasuredWithLeve(TelemetryLevel.STANDARD, reporter);
+    defaultTelemetry.measureStandard(operationSupplier, telemetryAction);
+    assertMeasuredWithLeve(TelemetryLevel.STANDARD, reporter);
+    defaultTelemetry.measureStandard(operationSupplier, completableFuture);
+    assertMeasuredWithLeve(TelemetryLevel.STANDARD, reporter);
+
+    // Verbose
+    defaultTelemetry.measureVerbose(operationSupplier, telemetrySupplier);
+    assertMeasuredWithLeve(TelemetryLevel.VERBOSE, reporter);
+    defaultTelemetry.measureVerbose(operationSupplier, telemetryAction);
+    assertMeasuredWithLeve(TelemetryLevel.VERBOSE, reporter);
+    defaultTelemetry.measureVerbose(operationSupplier, completableFuture);
+    assertMeasuredWithLeve(TelemetryLevel.VERBOSE, reporter);
+  }
+
+  private static void assertMeasuredWithLeve(
+      TelemetryLevel level, CollectingTelemetryReporter reporter) {
+    assertEquals(1, reporter.getOperationCompletions().size());
+    assertEquals(level, reporter.getOperationCompletions().stream().findFirst().get().getLevel());
+    reporter.clear();
   }
 }

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/logical/impl/ParquetLogicalIOImpl.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/logical/impl/ParquetLogicalIOImpl.java
@@ -90,13 +90,14 @@ public class ParquetLogicalIOImpl implements LogicalIO {
 
   @Override
   public int readTail(byte[] buf, int off, int len) throws IOException {
-    return telemetry.measure(
-        Operation.builder()
-            .name(OPERATION_READ_TAIL)
-            .attribute(StreamAttributes.uri(this.s3Uri))
-            .attribute(StreamAttributes.offset(off))
-            .attribute(StreamAttributes.length(len))
-            .build(),
+    return telemetry.measureStandard(
+        () ->
+            Operation.builder()
+                .name(OPERATION_READ_TAIL)
+                .attribute(StreamAttributes.uri(this.s3Uri))
+                .attribute(StreamAttributes.offset(off))
+                .attribute(StreamAttributes.length(len))
+                .build(),
         () -> physicalIO.readTail(buf, off, len));
   }
 

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/Blob.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/Blob.java
@@ -104,12 +104,13 @@ public class Blob implements Closeable {
    * @return the status of execution
    */
   public IOPlanExecution execute(IOPlan plan) {
-    return telemetry.measure(
-        Operation.builder()
-            .name(OPERATION_EXECUTE)
-            .attribute(StreamAttributes.uri(this.s3URI))
-            .attribute(StreamAttributes.ioPlan(plan))
-            .build(),
+    return telemetry.measureStandard(
+        () ->
+            Operation.builder()
+                .name(OPERATION_EXECUTE)
+                .attribute(StreamAttributes.uri(this.s3URI))
+                .attribute(StreamAttributes.ioPlan(plan))
+                .build(),
         () -> {
           try {
             plan.getPrefetchRanges()

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/Block.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/Block.java
@@ -69,13 +69,14 @@ public class Block implements Closeable {
     this.range = new Range(start, end);
 
     this.source =
-        this.telemetry.measure(
-            Operation.builder()
-                .name(OPERATION_BLOCK_GET_ASYNC)
-                .attribute(StreamAttributes.uri(this.s3URI))
-                .attribute(StreamAttributes.range(this.range))
-                .attribute(StreamAttributes.generation(generation))
-                .build(),
+        this.telemetry.measureCritical(
+            () ->
+                Operation.builder()
+                    .name(OPERATION_BLOCK_GET_ASYNC)
+                    .attribute(StreamAttributes.uri(this.s3URI))
+                    .attribute(StreamAttributes.range(this.range))
+                    .attribute(StreamAttributes.generation(generation))
+                    .build(),
             objectClient.getObject(
                 GetRequest.builder()
                     .bucket(this.s3URI.getBucket())
@@ -154,12 +155,13 @@ public class Block implements Closeable {
    * @return the bytes fetched by the issued {@link GetRequest}.
    */
   private byte[] getData() {
-    return this.telemetry.measureJoin(
-        Operation.builder()
-            .name(OPERATION_BLOCK_GET_JOIN)
-            .attribute(StreamAttributes.uri(this.s3URI))
-            .attribute(StreamAttributes.range(this.range))
-            .build(),
+    return this.telemetry.measureJoinCritical(
+        () ->
+            Operation.builder()
+                .name(OPERATION_BLOCK_GET_JOIN)
+                .attribute(StreamAttributes.uri(this.s3URI))
+                .attribute(StreamAttributes.range(this.range))
+                .build(),
         this.data);
   }
 

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/BlockManager.java
@@ -136,15 +136,17 @@ public class BlockManager implements Closeable {
 
     // Fix "end", so we can pass it into the lambda
     final long finalEnd = end;
-    this.telemetry.measure(
-        Operation.builder()
-            .name(OPERATION_MAKE_RANGE_AVAILABLE)
-            .attribute(StreamAttributes.uri(this.s3URI))
-            .attribute(StreamAttributes.position(pos))
-            .attribute(StreamAttributes.length(len))
-            .attribute(StreamAttributes.generation(generation))
-            .attribute(StreamAttributes.end(finalEnd))
-            .build(),
+    final long finalLen = len;
+    this.telemetry.measureStandard(
+        () ->
+            Operation.builder()
+                .name(OPERATION_MAKE_RANGE_AVAILABLE)
+                .attribute(StreamAttributes.uri(this.s3URI))
+                .attribute(StreamAttributes.position(pos))
+                .attribute(StreamAttributes.length(finalLen))
+                .attribute(StreamAttributes.generation(generation))
+                .attribute(StreamAttributes.end(finalEnd))
+                .build(),
         () -> {
 
           // Determine the missing ranges and fetch them

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/IOPlanner.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/IOPlanner.java
@@ -51,13 +51,14 @@ public class IOPlanner {
     Preconditions.checkArgument(
         pos <= lastObjectByte, "`pos` must be less than or equal to `lastObjectByte`");
 
-    return telemetry.measure(
-        Operation.builder()
-            .name(OPERATION_PLAN_READ)
-            .attribute(StreamAttributes.uri(this.s3URI))
-            .attribute(StreamAttributes.position(pos))
-            .attribute(StreamAttributes.end(end))
-            .build(),
+    return telemetry.measureStandard(
+        () ->
+            Operation.builder()
+                .name(OPERATION_PLAN_READ)
+                .attribute(StreamAttributes.uri(this.s3URI))
+                .attribute(StreamAttributes.position(pos))
+                .attribute(StreamAttributes.end(end))
+                .build(),
         () -> {
           List<Range> missingRanges = new LinkedList<>();
 

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/MetadataStore.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/MetadataStore.java
@@ -58,11 +58,12 @@ public class MetadataStore implements Closeable {
    * @return returns the {@link ObjectMetadata}.
    */
   public ObjectMetadata get(S3URI s3URI) {
-    return telemetry.measureJoin(
-        Operation.builder()
-            .name(OPERATION_METADATA_HEAD_JOIN)
-            .attribute(StreamAttributes.uri(s3URI))
-            .build(),
+    return telemetry.measureJoinCritical(
+        () ->
+            Operation.builder()
+                .name(OPERATION_METADATA_HEAD_JOIN)
+                .attribute(StreamAttributes.uri(s3URI))
+                .build(),
         this.asyncGet(s3URI));
   }
 
@@ -77,11 +78,12 @@ public class MetadataStore implements Closeable {
     return this.cache.computeIfAbsent(
         s3URI,
         uri ->
-            telemetry.measure(
-                Operation.builder()
-                    .name(OPERATION_METADATA_HEAD_ASYNC)
-                    .attribute(StreamAttributes.uri(s3URI))
-                    .build(),
+            telemetry.measureCritical(
+                () ->
+                    Operation.builder()
+                        .name(OPERATION_METADATA_HEAD_ASYNC)
+                        .attribute(StreamAttributes.uri(s3URI))
+                        .build(),
                 objectClient.headObject(
                     HeadRequest.builder().bucket(uri.getBucket()).key(uri.getKey()).build())));
   }

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/impl/PhysicalIOImpl.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/impl/PhysicalIOImpl.java
@@ -71,13 +71,14 @@ public class PhysicalIOImpl implements PhysicalIO {
   public int readTail(byte[] buf, int off, int len) throws IOException {
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
 
-    return telemetry.measure(
-        Operation.builder()
-            .name(OPERATION_READ_TAIL)
-            .attribute(StreamAttributes.uri(this.s3URI))
-            .attribute(StreamAttributes.offset(off))
-            .attribute(StreamAttributes.length(len))
-            .build(),
+    return telemetry.measureStandard(
+        () ->
+            Operation.builder()
+                .name(OPERATION_READ_TAIL)
+                .attribute(StreamAttributes.uri(this.s3URI))
+                .attribute(StreamAttributes.offset(off))
+                .attribute(StreamAttributes.length(len))
+                .build(),
         () -> {
           long contentLength = contentLength();
           return blobStore.get(s3URI).read(buf, off, len, contentLength - len);
@@ -86,12 +87,13 @@ public class PhysicalIOImpl implements PhysicalIO {
 
   @Override
   public IOPlanExecution execute(IOPlan ioPlan) {
-    return telemetry.measure(
-        Operation.builder()
-            .name(OPERATION_EXECUTE)
-            .attribute(StreamAttributes.uri(this.s3URI))
-            .attribute(StreamAttributes.ioPlan(ioPlan))
-            .build(),
+    return telemetry.measureStandard(
+        () ->
+            Operation.builder()
+                .name(OPERATION_EXECUTE)
+                .attribute(StreamAttributes.uri(this.s3URI))
+                .attribute(StreamAttributes.ioPlan(ioPlan))
+                .build(),
         () -> blobStore.get(s3URI).execute(ioPlan));
   }
 

--- a/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-import com.amazon.connector.s3.common.telemetry.Telemetry;
 import com.amazon.connector.s3.io.logical.LogicalIO;
 import com.amazon.connector.s3.io.logical.LogicalIOConfiguration;
 import com.amazon.connector.s3.io.logical.impl.ParquetLogicalIOImpl;
@@ -37,7 +36,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   @Test
   void testConstructor() {
     S3SeekableInputStream inputStream =
-        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, TestTelemetry.DEFAULT);
     assertNotNull(inputStream);
   }
 
@@ -46,17 +45,20 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     S3URI s3URI = S3URI.of("bucket", "key");
 
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(
-            metadataStore, fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+            metadataStore,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            PhysicalIOConfiguration.DEFAULT);
 
     S3SeekableInputStream inputStream =
         new S3SeekableInputStream(
             s3URI,
             metadataStore,
             blobStore,
-            Telemetry.NOOP,
+            TestTelemetry.DEFAULT,
             S3SeekableInputStreamConfiguration.DEFAULT,
             new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT));
     assertNotNull(inputStream);
@@ -78,7 +80,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
                 s3URI,
                 metadataStore,
                 blobStore,
-                Telemetry.NOOP,
+                TestTelemetry.DEFAULT,
                 configuration,
                 parquetMetadataStore));
 
@@ -86,13 +88,23 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
         NullPointerException.class,
         () ->
             new S3SeekableInputStream(
-                s3URI, null, blobStore, Telemetry.NOOP, configuration, parquetMetadataStore));
+                s3URI,
+                null,
+                blobStore,
+                TestTelemetry.DEFAULT,
+                configuration,
+                parquetMetadataStore));
 
     assertThrows(
         NullPointerException.class,
         () ->
             new S3SeekableInputStream(
-                s3URI, metadataStore, null, Telemetry.NOOP, configuration, parquetMetadataStore));
+                s3URI,
+                metadataStore,
+                null,
+                TestTelemetry.DEFAULT,
+                configuration,
+                parquetMetadataStore));
 
     assertThrows(
         NullPointerException.class,
@@ -104,31 +116,37 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
         NullPointerException.class,
         () ->
             new S3SeekableInputStream(
-                s3URI, metadataStore, blobStore, Telemetry.NOOP, null, parquetMetadataStore));
+                s3URI,
+                metadataStore,
+                blobStore,
+                TestTelemetry.DEFAULT,
+                null,
+                parquetMetadataStore));
 
     assertThrows(
         NullPointerException.class,
         () ->
             new S3SeekableInputStream(
-                s3URI, metadataStore, blobStore, Telemetry.NOOP, configuration, null));
+                s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, configuration, null));
 
     assertThrows(
         NullPointerException.class,
-        () -> new S3SeekableInputStream(null, mock(LogicalIO.class), Telemetry.NOOP));
+        () -> new S3SeekableInputStream(null, mock(LogicalIO.class), TestTelemetry.DEFAULT));
 
     assertThrows(
         NullPointerException.class,
         () -> new S3SeekableInputStream(s3URI, mock(LogicalIO.class), null));
 
     assertThrows(
-        NullPointerException.class, () -> new S3SeekableInputStream(s3URI, null, Telemetry.NOOP));
+        NullPointerException.class,
+        () -> new S3SeekableInputStream(s3URI, null, TestTelemetry.DEFAULT));
   }
 
   @Test
   void testInitialGetPosition() throws IOException {
     // Given
     S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, TestTelemetry.DEFAULT);
 
     // When: nothing
     // Then: stream position is at 0
@@ -139,7 +157,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   void testReadAdvancesPosition() throws IOException {
     // Given
     S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, TestTelemetry.DEFAULT);
 
     // When: read() is called
     stream.read();
@@ -152,7 +170,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   void testSeek() throws IOException {
     // Given
     S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, TestTelemetry.DEFAULT);
 
     // When
     stream.seek(13);
@@ -165,7 +183,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   void testFullRead() throws IOException {
     // Given
     S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, TestTelemetry.DEFAULT);
 
     // When: all data is requested
     String dataReadOut = IoUtils.toUtf8String(stream);
@@ -178,7 +196,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   void testSeekToVeryEnd() throws IOException {
     // Given
     S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, TestTelemetry.DEFAULT);
 
     // When: we seek to the last byte
     stream.seek(TEST_DATA.length() - 1);
@@ -192,7 +210,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   void testSeekAfterEnd() throws IOException {
     // Given
     S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, TestTelemetry.DEFAULT);
 
     // When: we seek past EOF we get EOFException
     assertThrows(EOFException.class, () -> stream.seek(TEST_DATA.length() + 1));
@@ -228,7 +246,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     // Given
     LogicalIO logicalIO = mock(LogicalIO.class);
     S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_OBJECT, logicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, logicalIO, TestTelemetry.DEFAULT);
 
     // When
     stream.close();
@@ -355,7 +373,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     LogicalIO mockLogicalIO = mock(LogicalIO.class);
     when(mockLogicalIO.metadata()).thenReturn(ObjectMetadata.builder().contentLength(200).build());
     S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_OBJECT, mockLogicalIO, Telemetry.NOOP);
+        new S3SeekableInputStream(TEST_OBJECT, mockLogicalIO, TestTelemetry.DEFAULT);
 
     // When: logical IO returns with a -1 read
     final int INITIAL_POS = 123;
@@ -378,10 +396,13 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
 
     FakeObjectClient fakeObjectClient = new FakeObjectClient(sb.toString());
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(
-            metadataStore, fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+            metadataStore,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            PhysicalIOConfiguration.DEFAULT);
 
     AtomicBoolean haveException = new AtomicBoolean(false);
 
@@ -393,16 +414,16 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
               () -> {
                 try {
                   PhysicalIO physicalIO =
-                      new PhysicalIOImpl(s3URI, metadataStore, blobStore, Telemetry.NOOP);
+                      new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
                   LogicalIO logicalIO =
                       new ParquetLogicalIOImpl(
                           TEST_OBJECT,
                           physicalIO,
-                          Telemetry.NOOP,
+                          TestTelemetry.DEFAULT,
                           LogicalIOConfiguration.DEFAULT,
                           new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT));
                   SeekableInputStream stream =
-                      new S3SeekableInputStream(TEST_OBJECT, logicalIO, Telemetry.NOOP);
+                      new S3SeekableInputStream(TEST_OBJECT, logicalIO, TestTelemetry.DEFAULT);
                   byte[] buffer = new byte[4];
                   stream.readTail(buffer, 0, 4);
                   stream.read(buffer, 0, 4);
@@ -427,7 +448,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   }
 
   private S3SeekableInputStream getTestStream() {
-    return new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, Telemetry.NOOP);
+    return new S3SeekableInputStream(TEST_OBJECT, fakeLogicalIO, TestTelemetry.DEFAULT);
   }
 
   private S3SeekableInputStream getTestStreamWithContent(String content) {
@@ -436,19 +457,22 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
 
     FakeObjectClient fakeObjectClient = new FakeObjectClient(content);
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(
-            metadataStore, fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+            metadataStore,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            PhysicalIOConfiguration.DEFAULT);
 
     return new S3SeekableInputStream(
         TEST_OBJECT,
         new ParquetLogicalIOImpl(
             TEST_OBJECT,
-            new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, Telemetry.NOOP),
-            Telemetry.NOOP,
+            new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
+            TestTelemetry.DEFAULT,
             configuration,
             new ParquetMetadataStore(configuration)),
-        Telemetry.NOOP);
+        TestTelemetry.DEFAULT);
   }
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTestBase.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTestBase.java
@@ -1,6 +1,5 @@
 package com.amazon.connector.s3;
 
-import com.amazon.connector.s3.common.telemetry.Telemetry;
 import com.amazon.connector.s3.io.logical.LogicalIO;
 import com.amazon.connector.s3.io.logical.LogicalIOConfiguration;
 import com.amazon.connector.s3.io.logical.impl.ParquetLogicalIOImpl;
@@ -20,16 +19,17 @@ public class S3SeekableInputStreamTestBase {
   protected final PhysicalIOConfiguration physicalIOConfiguration = PhysicalIOConfiguration.DEFAULT;
   protected final FakeObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
   protected final MetadataStore metadataStore =
-      new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+      new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
   protected final BlobStore blobStore =
-      new BlobStore(metadataStore, fakeObjectClient, Telemetry.NOOP, physicalIOConfiguration);
+      new BlobStore(
+          metadataStore, fakeObjectClient, TestTelemetry.DEFAULT, physicalIOConfiguration);
   protected final LogicalIOConfiguration logicalIOConfiguration = LogicalIOConfiguration.DEFAULT;
 
   protected final LogicalIO fakeLogicalIO =
       new ParquetLogicalIOImpl(
           TEST_OBJECT,
-          new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, Telemetry.NOOP),
-          Telemetry.NOOP,
+          new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
+          TestTelemetry.DEFAULT,
           logicalIOConfiguration,
           new ParquetMetadataStore(logicalIOConfiguration));
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/TestTelemetry.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/TestTelemetry.java
@@ -1,0 +1,19 @@
+package com.amazon.connector.s3;
+
+import com.amazon.connector.s3.common.telemetry.*;
+
+public final class TestTelemetry {
+  private TestTelemetry() {}
+
+  /**
+   * Default telemetry to use for tests - combination of NoOp telemetry with VERBOSE level provides
+   * the best code coverage
+   */
+  public static Telemetry DEFAULT =
+      Telemetry.getTelemetry(
+          TelemetryConfiguration.builder()
+              .loggingEnabled(false)
+              .stdOutEnabled(false)
+              .level(TelemetryLevel.VERBOSE.toString())
+              .build());
+}

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import com.amazon.connector.s3.ObjectClient;
-import com.amazon.connector.s3.common.telemetry.Telemetry;
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.io.logical.LogicalIOConfiguration;
 import com.amazon.connector.s3.io.physical.PhysicalIO;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
@@ -30,7 +30,7 @@ public class ParquetLogicalIOImplTest {
         new ParquetLogicalIOImpl(
             S3URI.of("foo", "bar"),
             mock(PhysicalIO.class),
-            Telemetry.NOOP,
+            TestTelemetry.DEFAULT,
             mock(LogicalIOConfiguration.class),
             mock(ParquetMetadataStore.class)));
   }
@@ -43,7 +43,7 @@ public class ParquetLogicalIOImplTest {
             new ParquetLogicalIOImpl(
                 TEST_URI,
                 null,
-                Telemetry.NOOP,
+                TestTelemetry.DEFAULT,
                 mock(LogicalIOConfiguration.class),
                 mock(ParquetMetadataStore.class)));
     assertThrows(
@@ -52,7 +52,7 @@ public class ParquetLogicalIOImplTest {
             new ParquetLogicalIOImpl(
                 TEST_URI,
                 mock(PhysicalIO.class),
-                Telemetry.NOOP,
+                TestTelemetry.DEFAULT,
                 null,
                 mock(ParquetMetadataStore.class)));
     assertThrows(
@@ -70,7 +70,7 @@ public class ParquetLogicalIOImplTest {
             new ParquetLogicalIOImpl(
                 TEST_URI,
                 mock(PhysicalIO.class),
-                Telemetry.NOOP,
+                TestTelemetry.DEFAULT,
                 mock(LogicalIOConfiguration.class),
                 null));
   }
@@ -89,7 +89,7 @@ public class ParquetLogicalIOImplTest {
         new ParquetLogicalIOImpl(
             TEST_URI,
             physicalIO,
-            Telemetry.NOOP,
+            TestTelemetry.DEFAULT,
             configuration,
             new ParquetMetadataStore(configuration));
 
@@ -108,16 +108,18 @@ public class ParquetLogicalIOImplTest {
             CompletableFuture.completedFuture(ObjectMetadata.builder().contentLength(0).build()));
     S3URI s3URI = S3URI.of("test", "test");
     MetadataStore metadataStore =
-        new MetadataStore(mockClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
-        new BlobStore(metadataStore, mockClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
-    PhysicalIOImpl physicalIO = new PhysicalIOImpl(s3URI, metadataStore, blobStore, Telemetry.NOOP);
+        new BlobStore(
+            metadataStore, mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
+    PhysicalIOImpl physicalIO =
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(
                 TEST_URI,
                 physicalIO,
-                Telemetry.NOOP,
+                TestTelemetry.DEFAULT,
                 LogicalIOConfiguration.DEFAULT,
                 new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
   }
@@ -130,16 +132,18 @@ public class ParquetLogicalIOImplTest {
             CompletableFuture.completedFuture(ObjectMetadata.builder().contentLength(-1).build()));
     S3URI s3URI = S3URI.of("test", "test");
     MetadataStore metadataStore =
-        new MetadataStore(mockClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
-        new BlobStore(metadataStore, mockClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
-    PhysicalIOImpl physicalIO = new PhysicalIOImpl(s3URI, metadataStore, blobStore, Telemetry.NOOP);
+        new BlobStore(
+            metadataStore, mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
+    PhysicalIOImpl physicalIO =
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(
                 TEST_URI,
                 physicalIO,
-                Telemetry.NOOP,
+                TestTelemetry.DEFAULT,
                 LogicalIOConfiguration.DEFAULT,
                 new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
   }

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlobStoreTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlobStoreTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.amazon.connector.s3.ObjectClient;
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.common.telemetry.Telemetry;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
 import com.amazon.connector.s3.object.ObjectMetadata;
@@ -56,7 +57,8 @@ public class BlobStoreTest {
     when(metadataStore.get(any()))
         .thenReturn(ObjectMetadata.builder().contentLength(TEST_DATA.length()).build());
     BlobStore blobStore =
-        new BlobStore(metadataStore, objectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new BlobStore(
+            metadataStore, objectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
 
     // When: a Blob is asked for
     Blob blob = blobStore.get(S3URI.of("test", "test"));

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlobTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlobTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.amazon.connector.s3.common.telemetry.Telemetry;
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
 import com.amazon.connector.s3.io.physical.plan.IOPlan;
 import com.amazon.connector.s3.io.physical.plan.IOPlanExecution;
@@ -27,14 +27,16 @@ public class BlobTest {
   void testCreateBoundaries() {
     assertThrows(
         NullPointerException.class,
-        () -> new Blob(null, mock(MetadataStore.class), mock(BlockManager.class), Telemetry.NOOP));
+        () ->
+            new Blob(
+                null, mock(MetadataStore.class), mock(BlockManager.class), TestTelemetry.DEFAULT));
     assertThrows(
         NullPointerException.class,
-        () -> new Blob(TEST_URI, null, mock(BlockManager.class), Telemetry.NOOP));
+        () -> new Blob(TEST_URI, null, mock(BlockManager.class), TestTelemetry.DEFAULT));
 
     assertThrows(
         NullPointerException.class,
-        () -> new Blob(TEST_URI, mock(MetadataStore.class), null, Telemetry.NOOP));
+        () -> new Blob(TEST_URI, mock(MetadataStore.class), null, TestTelemetry.DEFAULT));
     assertThrows(
         NullPointerException.class,
         () -> new Blob(TEST_URI, mock(MetadataStore.class), mock(BlockManager.class), null));
@@ -111,7 +113,7 @@ public class BlobTest {
     // Given: test blob and an IOPlan
     MetadataStore metadataStore = mock(MetadataStore.class);
     BlockManager blockManager = mock(BlockManager.class);
-    Blob blob = new Blob(TEST_URI, metadataStore, blockManager, Telemetry.NOOP);
+    Blob blob = new Blob(TEST_URI, metadataStore, blockManager, TestTelemetry.DEFAULT);
     List<Range> ranges = new LinkedList<>();
     ranges.add(new Range(0, 100));
     ranges.add(new Range(999, 1000));
@@ -131,7 +133,7 @@ public class BlobTest {
     // Given: test blob
     MetadataStore metadataStore = mock(MetadataStore.class);
     BlockManager blockManager = mock(BlockManager.class);
-    Blob blob = new Blob(TEST_URI, metadataStore, blockManager, Telemetry.NOOP);
+    Blob blob = new Blob(TEST_URI, metadataStore, blockManager, TestTelemetry.DEFAULT);
 
     // When: blob is closed
     blob.close();
@@ -143,15 +145,15 @@ public class BlobTest {
   private Blob getTestBlob(String data) {
     FakeObjectClient fakeObjectClient = new FakeObjectClient(data);
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlockManager blockManager =
         new BlockManager(
             TEST_URI,
             fakeObjectClient,
             metadataStore,
-            Telemetry.NOOP,
+            TestTelemetry.DEFAULT,
             PhysicalIOConfiguration.DEFAULT);
 
-    return new Blob(TEST_URI, metadataStore, blockManager, Telemetry.NOOP);
+    return new Blob(TEST_URI, metadataStore, blockManager, TestTelemetry.DEFAULT);
   }
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlockManagerTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlockManagerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazon.connector.s3.ObjectClient;
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.common.telemetry.Telemetry;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
 import com.amazon.connector.s3.object.ObjectContent;
@@ -171,6 +172,10 @@ public class BlockManagerTest {
     MetadataStore metadataStore = mock(MetadataStore.class);
     when(metadataStore.get(any())).thenReturn(ObjectMetadata.builder().contentLength(size).build());
     return new BlockManager(
-        testUri, objectClient, metadataStore, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        testUri,
+        objectClient,
+        metadataStore,
+        TestTelemetry.DEFAULT,
+        PhysicalIOConfiguration.DEFAULT);
   }
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlockStoreTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlockStoreTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.amazon.connector.s3.common.telemetry.Telemetry;
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
 import com.amazon.connector.s3.request.ReadMode;
 import com.amazon.connector.s3.util.FakeObjectClient;
@@ -25,11 +25,12 @@ public class BlockStoreTest {
     // Given: empty BlockStore
     FakeObjectClient fakeObjectClient = new FakeObjectClient("test-data");
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
 
     // When: a new block is added
-    blockStore.add(new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 3, 5, 0, ReadMode.SYNC));
+    blockStore.add(
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 3, 5, 0, ReadMode.SYNC));
 
     // Then: getBlock can retrieve the same block
     Optional<Block> b = blockStore.getBlock(4);
@@ -46,12 +47,15 @@ public class BlockStoreTest {
     final String X_TIMES_16 = "xxxxxxxxxxxxxxxx";
     FakeObjectClient fakeObjectClient = new FakeObjectClient(X_TIMES_16);
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
 
-    blockStore.add(new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 2, 3, 0, ReadMode.SYNC));
-    blockStore.add(new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 5, 10, 0, ReadMode.SYNC));
-    blockStore.add(new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 12, 15, 0, ReadMode.SYNC));
+    blockStore.add(
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC));
+    blockStore.add(
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC));
+    blockStore.add(
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC));
 
     // When & Then: we query for the next missing byte, the result is correct
     assertEquals(OptionalLong.of(0), blockStore.findNextMissingByte(0));
@@ -70,12 +74,15 @@ public class BlockStoreTest {
     final String X_TIMES_16 = "xxxxxxxxxxxxxxxx";
     FakeObjectClient fakeObjectClient = new FakeObjectClient(X_TIMES_16);
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
 
-    blockStore.add(new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 2, 3, 0, ReadMode.SYNC));
-    blockStore.add(new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 5, 10, 0, ReadMode.SYNC));
-    blockStore.add(new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 12, 15, 0, ReadMode.SYNC));
+    blockStore.add(
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC));
+    blockStore.add(
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC));
+    blockStore.add(
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC));
 
     // When & Then: we query for the next available byte, the result is correct
     assertEquals(OptionalLong.of(2), blockStore.findNextLoadedByte(0));

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/BlockTest.java
@@ -3,7 +3,7 @@ package com.amazon.connector.s3.io.physical.data;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.amazon.connector.s3.ObjectClient;
-import com.amazon.connector.s3.common.telemetry.Telemetry;
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.request.ReadMode;
 import com.amazon.connector.s3.util.FakeObjectClient;
 import com.amazon.connector.s3.util.S3URI;
@@ -19,7 +19,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, TEST_DATA.length(), 0, ReadMode.SYNC);
+            TEST_URI,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            0,
+            TEST_DATA.length(),
+            0,
+            ReadMode.SYNC);
 
     // When: bytes are requested from the block
     int r1 = block.read(0);
@@ -39,7 +45,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, TEST_DATA.length(), 0, ReadMode.SYNC);
+            TEST_URI,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            0,
+            TEST_DATA.length(),
+            0,
+            ReadMode.SYNC);
 
     // When: bytes are requested from the block
     byte[] b1 = new byte[4];
@@ -63,17 +75,26 @@ public class BlockTest {
         NullPointerException.class,
         () ->
             new Block(
-                null, fakeObjectClient, Telemetry.NOOP, 0, TEST_DATA.length(), 0, ReadMode.SYNC));
+                null,
+                fakeObjectClient,
+                TestTelemetry.DEFAULT,
+                0,
+                TEST_DATA.length(),
+                0,
+                ReadMode.SYNC));
     assertThrows(
         NullPointerException.class,
-        () -> new Block(TEST_URI, null, Telemetry.NOOP, 0, TEST_DATA.length(), 0, ReadMode.SYNC));
+        () ->
+            new Block(
+                TEST_URI, null, TestTelemetry.DEFAULT, 0, TEST_DATA.length(), 0, ReadMode.SYNC));
     assertThrows(
         NullPointerException.class,
         () -> new Block(TEST_URI, fakeObjectClient, null, 0, TEST_DATA.length(), 0, ReadMode.SYNC));
     assertThrows(
         NullPointerException.class,
         () ->
-            new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, TEST_DATA.length(), 0, null));
+            new Block(
+                TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, TEST_DATA.length(), 0, null));
   }
 
   @Test
@@ -86,27 +107,30 @@ public class BlockTest {
             new Block(
                 TEST_URI,
                 fakeObjectClient,
-                Telemetry.NOOP,
+                TestTelemetry.DEFAULT,
                 -1,
                 TEST_DATA.length(),
                 0,
                 ReadMode.SYNC));
     assertThrows(
         IllegalArgumentException.class,
-        () -> new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, -5, 0, ReadMode.SYNC));
+        () ->
+            new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, -5, 0, ReadMode.SYNC));
     assertThrows(
         IllegalArgumentException.class,
-        () -> new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 20, 1, 0, ReadMode.SYNC));
+        () ->
+            new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 20, 1, 0, ReadMode.SYNC));
     assertThrows(
         IllegalArgumentException.class,
-        () -> new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, 5, -1, ReadMode.SYNC));
+        () ->
+            new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, 5, -1, ReadMode.SYNC));
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new Block(
                 TEST_URI,
                 fakeObjectClient,
-                Telemetry.NOOP,
+                TestTelemetry.DEFAULT,
                 -5,
                 0,
                 TEST_DATA.length(),
@@ -120,7 +144,13 @@ public class BlockTest {
     byte[] b = new byte[4];
     Block block =
         new Block(
-            TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, TEST_DATA.length(), 0, ReadMode.SYNC);
+            TEST_URI,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            0,
+            TEST_DATA.length(),
+            0,
+            ReadMode.SYNC);
     assertThrows(IllegalArgumentException.class, () -> block.read(-10));
     assertThrows(NullPointerException.class, () -> block.read(null, 0, 3, 1));
     assertThrows(IllegalArgumentException.class, () -> block.read(b, -5, 3, 1));
@@ -134,7 +164,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, TEST_DATA.length(), 0, ReadMode.SYNC);
+            TEST_URI,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            0,
+            TEST_DATA.length(),
+            0,
+            ReadMode.SYNC);
     assertTrue(block.contains(0));
     assertFalse(block.contains(TEST_DATA.length() + 1));
   }
@@ -145,7 +181,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, TEST_DATA.length(), 0, ReadMode.SYNC);
+            TEST_URI,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            0,
+            TEST_DATA.length(),
+            0,
+            ReadMode.SYNC);
     assertThrows(IllegalArgumentException.class, () -> block.contains(-1));
   }
 
@@ -155,7 +197,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI, fakeObjectClient, Telemetry.NOOP, 0, TEST_DATA.length(), 0, ReadMode.SYNC);
+            TEST_URI,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            0,
+            TEST_DATA.length(),
+            0,
+            ReadMode.SYNC);
     block.close();
     block.close();
   }

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/IOPlannerTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/IOPlannerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.common.telemetry.Telemetry;
 import com.amazon.connector.s3.io.physical.plan.Range;
 import com.amazon.connector.s3.object.ObjectMetadata;
@@ -40,7 +41,7 @@ public class IOPlannerTest {
         .thenReturn(ObjectMetadata.builder().contentLength(OBJECT_SIZE).build());
     BlockStore blockStore = new BlockStore(TEST_URI, mockMetadataStore);
     S3URI s3Uri = S3URI.of("bucket", "key");
-    IOPlanner ioPlanner = new IOPlanner(s3Uri, blockStore, Telemetry.NOOP);
+    IOPlanner ioPlanner = new IOPlanner(s3Uri, blockStore, TestTelemetry.DEFAULT);
 
     assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(-5, 10, 100));
     assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(10, 5, 100));
@@ -56,7 +57,7 @@ public class IOPlannerTest {
         .thenReturn(ObjectMetadata.builder().contentLength(OBJECT_SIZE).build());
     BlockStore blockStore = new BlockStore(TEST_URI, mockMetadataStore);
     S3URI s3Uri = S3URI.of("bucket", "key");
-    IOPlanner ioPlanner = new IOPlanner(s3Uri, blockStore, Telemetry.NOOP);
+    IOPlanner ioPlanner = new IOPlanner(s3Uri, blockStore, TestTelemetry.DEFAULT);
 
     // When: a read plan is requested for a range
     List<Range> missingRanges = ioPlanner.planRead(10, 100, OBJECT_SIZE - 1);
@@ -77,9 +78,9 @@ public class IOPlannerTest {
     BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
     FakeObjectClient fakeObjectClient = new FakeObjectClient(new String(content));
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, Telemetry.NOOP, 100, 200, 0, ReadMode.SYNC));
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 100, 200, 0, ReadMode.SYNC));
     S3URI s3Uri = S3URI.of("bucket", "key");
-    IOPlanner ioPlanner = new IOPlanner(s3Uri, blockStore, Telemetry.NOOP);
+    IOPlanner ioPlanner = new IOPlanner(s3Uri, blockStore, TestTelemetry.DEFAULT);
 
     // When: a read plan is requested for a range (0, 400)
     List<Range> missingRanges = ioPlanner.planRead(0, 400, OBJECT_SIZE - 1);
@@ -99,7 +100,7 @@ public class IOPlannerTest {
     MetadataStore metadataStore = getTestMetadataStoreWithContentLength(OBJECT_SIZE);
     BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
     S3URI s3Uri = S3URI.of("bucket", "key");
-    IOPlanner ioPlanner = new IOPlanner(s3Uri, blockStore, Telemetry.NOOP);
+    IOPlanner ioPlanner = new IOPlanner(s3Uri, blockStore, TestTelemetry.DEFAULT);
 
     // When: a read plan is requested for a range (0, 400)
     List<Range> missingRanges = ioPlanner.planRead(0, 400, OBJECT_SIZE - 1);

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/MetadataStoreTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/MetadataStoreTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazon.connector.s3.ObjectClient;
-import com.amazon.connector.s3.common.telemetry.Telemetry;
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
 import com.amazon.connector.s3.object.ObjectMetadata;
 import com.amazon.connector.s3.request.HeadRequest;
@@ -25,7 +25,7 @@ public class MetadataStoreTest {
     when(objectClient.headObject(any()))
         .thenReturn(CompletableFuture.completedFuture(mock(ObjectMetadata.class)));
     MetadataStore metadataStore =
-        new MetadataStore(objectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(objectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     S3URI key = S3URI.of("foo", "bar");
 
     // When: get(..) is called multiple times
@@ -57,7 +57,7 @@ public class MetadataStoreTest {
     when(objectClient.headObject(h2)).thenReturn(objectMetadataCompletableFuture);
 
     MetadataStore metadataStore =
-        new MetadataStore(objectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(objectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
 
     // When: MetadataStore is closed
     metadataStore.get(S3URI.of("b", "key1"));

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/impl/PhysicalIOImplTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/impl/PhysicalIOImplTest.java
@@ -2,7 +2,7 @@ package com.amazon.connector.s3.io.physical.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.amazon.connector.s3.common.telemetry.Telemetry;
+import com.amazon.connector.s3.TestTelemetry;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
 import com.amazon.connector.s3.io.physical.data.BlobStore;
 import com.amazon.connector.s3.io.physical.data.MetadataStore;
@@ -21,12 +21,15 @@ public class PhysicalIOImplTest {
     final String TEST_DATA = "abcdef0123456789";
     FakeObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(
-            metadataStore, fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+            metadataStore,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, Telemetry.NOOP);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -41,12 +44,15 @@ public class PhysicalIOImplTest {
     final String TEST_DATA = "x";
     FakeObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(
-            metadataStore, fakeObjectClient, Telemetry.NOOP, PhysicalIOConfiguration.DEFAULT);
+            metadataStore,
+            fakeObjectClient,
+            TestTelemetry.DEFAULT,
+            PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, Telemetry.NOOP);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
 
     // When: we read
     // Then: returned data is correct


### PR DESCRIPTION
### Telemetry updates
This focuses on managing verbosity in `Telemetry` and minimizing its impact to the code performance.
After the changes, the cost of telemetry for tight loop of of compute calls (I chose UUID generation) was under 8% (for 100k calls a second). For the code with remote calls, this should be negligible, or so is the hope. Profiling of the benchmark will show.
The goal of the change was to:
- Make telemetry almost free for calls that don't end up being recorded.
- Make telemetry very low overhead for calls that do. 

### Description of changes
####  Moved `level` out of `Operation` into `OperationMeasurement`. 
Instead, the `level` is explicitly passed to each `measure` call. This allows the Telemetry to delay `Operation` instantiation until we are ready to record. Most importantly, we can make the decision whether to record _before_ we even look at the `Telemetry` object. This is important for the next point.

####  Changed all signatures to take `OperationSupplier` rather than `Operation`
Creating `Operations` for noisy calls results in a bunch of garbage on the heap. By replacing `Operation` with `OperationSupplier` we only create operations when we know we can record them. This is further made possible by the previous point - we can make a decision whether to record without having to look at the `Operation`. 

####  Added more `measure` signatures
As a level got added to each `measure` call, new signatures were added for fluency for each signature/level - `measureStandard`, `measureVerbose`, `measureCritical`.

####  Minor performance related changes to reduce telemetry overhead
Small bit-twiddly changes based on the local profiling (IntelliJ profiler is pretty awesome for this), which includes:
- Reducing overhead of random ID generation
- Inlining some calls by hand to reduce thread-local lookups
- Replacing `equals` with `==` in cases where we really mean "same" over "equal".
- Changed `TelemetryLevel` enum to be int based for lower overhead.
- Miscellanea 

### What is coming
I did not added back any instrumentation for noisy calls yet. This is yet to come, pending the outcome of this.

### Example
#### Code
Same as in the [original PR](https://github.com/awslabs/s3-connector-framework/pull/74), but note two differenes:
- `() -> operation` is used instead of `operation` - this defers the instantiation.
- `measureStandard` is used instead of `measure`.

```
 void examples() throws Exception {
    fetchBlock("s3://bucket/key", 0, 1024);
  }

  private void fetchBlock(String key, long start, long size) throws Exception {
    telemetry.measureStandard(
        () -> Operation.builder()
            .name("connector.fecth.block")
            .attribute("key", key)
            .attribute("start", start)
            .attribute("size", size)
            .build(),
        () -> {
          // Do something
          Thread.sleep(50);
          // Then call S3
          se3Get(key, start, start + size);
        });
  }

  private void se3Get(String key, long rangeStart, long rangeEnd) throws Exception {
    telemetry.measureStandard(
        () -> Operation.builder()
            .name("s3.get")
            .attribute("key", key)
            .attribute("rangeStart", rangeStart)
            .attribute("rangeEnd", rangeEnd)
            .build(),
        () -> {
          Thread.sleep(500);
        });
  }
```
#### Output
```
[2024-08-15T09:21:07.670Z] [  start] [JVzrR6HcR7U] connector.fecth.block(thread_id=1, size=1024, start=0, key=s3://bucket/key)
[2024-08-15T09:21:07.727Z] [  start] [GZuyDMpa4gg<-JVzrR6HcR7U] s3.get(thread_id=1, rangeStart=0, key=s3://bucket/key, rangeEnd=1024)
[2024-08-15T09:21:07.727Z] [success] [GZuyDMpa4gg<-JVzrR6HcR7U] s3.get(thread_id=1, rangeStart=0, key=s3://bucket/key, rangeEnd=1024): 503,911,252 ns
[2024-08-15T09:21:07.670Z] [success] [JVzrR6HcR7U] connector.fecth.block(thread_id=1, size=1024, start=0, key=s3://bucket/key): 562,781,878 ns
```

### Example from one of the JMH runs
```
[2024-08-18T04:29:01.641Z] [  start] [258tfcotmun0b] metadata.store.head.async(thread_id=12, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.643Z] [  start] [-6u345i79ksu8e] metadata.store.head.join(thread_id=12, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.641Z] [success] [258tfcotmun0b] metadata.store.head.async(thread_id=12, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 182,124,492 ns
[2024-08-18T04:29:01.643Z] [success] [-6u345i79ksu8e] metadata.store.head.join(thread_id=12, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 181,306,528 ns
[2024-08-18T04:29:01.825Z] [  start] [-9pr25u26o7kc] physical.io.execute(ioplan=[[0-1048575]], thread_id=12, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.828Z] [  start] [22iafemmkfgsp<--9pr25u26o7kc] blob.execute(ioplan=[[0-1048575]], thread_id=12, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.831Z] [  start] [-22nbp4naljc1<-22iafemmkfgsp] block.manager.make.range.available(generation=0, thread_id=12, length=1048576, end=1048575, position=0, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.842Z] [  start] [-7kougeqju442u<--22nbp4naljc1] io.planner.read(thread_id=12, end=1048575, position=0, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.842Z] [success] [-7kougeqju442u<--22nbp4naljc1] io.planner.read(thread_id=12, end=1048575, position=0, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 20,401,257 ns
[2024-08-18T04:29:01.898Z] [  start] [-1nrtsujf91i7r<--22nbp4naljc1] block.get.async(generation=0, thread_id=12, range=[0-1048575], uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.831Z] [success] [-22nbp4naljc1<-22iafemmkfgsp] block.manager.make.range.available(generation=0, thread_id=12, length=1048576, end=1048575, position=0, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 68,062,556 ns
[2024-08-18T04:29:01.828Z] [success] [22iafemmkfgsp<--9pr25u26o7kc] blob.execute(ioplan=[[0-1048575]], thread_id=12, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 71,768,402 ns
[2024-08-18T04:29:01.825Z] [success] [-9pr25u26o7kc] physical.io.execute(ioplan=[[0-1048575]], thread_id=12, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 74,653,830 ns
[2024-08-18T04:29:01.903Z] [  start] [3qsuaq2r4ui76] physical.io.read.tail(thread_id=30, offset=0, length=1048576, uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.903Z] [  start] [-fbv3us80pnvi] block.get.join(thread_id=12, range=[0-1048575], uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.903Z] [  start] [4g3vp07j1u4hj<-3qsuaq2r4ui76] block.get.join(thread_id=30, range=[0-1048575], uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt)
[2024-08-18T04:29:01.898Z] [success] [-1nrtsujf91i7r<--22nbp4naljc1] block.get.async(generation=0, thread_id=12, range=[0-1048575], uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 245,161,145 ns
[2024-08-18T04:29:01.903Z] [success] [4g3vp07j1u4hj<-3qsuaq2r4ui76] block.get.join(thread_id=30, range=[0-1048575], uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 255,558,431 ns
[2024-08-18T04:29:01.903Z] [success] [-fbv3us80pnvi] block.get.join(thread_id=12, range=[0-1048575], uri=s3://lvovitch-amazon-reviews-pds-iceberg/reviews.db/apparel_reviews/data/sequential/random-1mb.txt): 255,887,640 ns
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
