### PR TITLE
Set appropriate groupId

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -28,6 +28,7 @@ publishing {
         create<MavenPublication>("common") {
             // TODO: update this when we figure out versioning
             //  ticket: https://app.asana.com/0/1206885953994785/1207481230403504/f
+            groupId = "com.amazon.connector.s3"
             version = "1.0.0"
 
             from(components["java"])

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -135,6 +135,7 @@ publishing {
         create<MavenPublication>("inputStream") {
             // TODO: update this when we figure out versioning
             //  ticket: https://app.asana.com/0/1206885953994785/1207481230403504/f
+            groupId = "com.amazon.connector.s3"
             version = "1.0.0"
 
             from(components["java"])

--- a/object-client/build.gradle.kts
+++ b/object-client/build.gradle.kts
@@ -29,6 +29,7 @@ publishing {
         create<MavenPublication>("objectClient") {
             // TODO: update this when we figure out versioning
             //  ticket: https://app.asana.com/0/1206885953994785/1207481230403504/f
+            groupId = "com.amazon.connector.s3"
             version = "1.0.0"
 
             from(components["java"])


### PR DESCRIPTION
This commit sets the groupId for our build artefacts to `com.amazon.connector.s3`. We agreed on this name, but it is likely to change after beta.

Tested the change with the FileIO integration by doing `./gradlew publishToMavenLocal` and confirmed that re-build works.



> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
