### PR TITLE
Fix iceberg spark runtime jar path

### DIFF
--- a/.github/workflows/build-iceberg-upload.yml
+++ b/.github/workflows/build-iceberg-upload.yml
@@ -65,4 +65,4 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload iceberg-spark-runtime JAR to S3FileIO treatment bucket
-        run: aws s3 cp /home/runner/work/s3-connector-framework/s3-connector-framework/iceberg/spark/v3.5/spark-runtime/build/libs/iceberg-spark-runtime-3.5_2.12-1.6.0-SNAPSHOT.jar  s3://${{ env.S3_BUCKET }}/s3fileio/iceberg-spark-runtime-3.5_2.12-1.6.0-SNAPSHOT.jar
+        run: aws s3 cp /home/runner/work/s3-connector-framework/s3-connector-framework/iceberg/spark/v3.5/spark-runtime/build/libs/iceberg-spark-runtime-3.5_2.12-01a7908.jar  s3://${{ env.S3_BUCKET }}/s3fileio/iceberg-spark-runtime-3.5_2.12-1.6.0-SNAPSHOT.jar


### PR DESCRIPTION
### Description

Github action workflow to upload iceberg is failing currently due to path name not being what we expect. This change fixes this path to the correct jar name.

```
Run aws s3 cp /home/runner/work/s3-connector-framework/s3-connector-framework/iceberg/spark/v3.5/spark-runtime/build/libs/iceberg-spark-runtime-3.5_2.12-1.6.0-SNAPSHOT.jar  s3://seekable-stream-jars/s3fileio/iceberg-spark-runtime-3.5_2.12-1.6.0-SNAPSHOT.jar

The user-provided path /home/runner/work/s3-connector-framework/s3-connector-framework/iceberg/spark/v3.5/spark-runtime/build/libs/iceberg-spark-runtime-3.5_2.12-1.6.0-SNAPSHOT.jar does not exist.
```

### Testing
Checked out and rebuild the iceberg staging repo to find the correct jar path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
