### PR TITLE
Fix S3 upload for Iceberg

### DIFF
--- a/.github/workflows/build-iceberg-upload.yml
+++ b/.github/workflows/build-iceberg-upload.yml
@@ -65,4 +65,6 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload iceberg-spark-runtime JAR to S3FileIO treatment bucket
-        run: aws s3 cp /home/runner/work/s3-connector-framework/s3-connector-framework/iceberg/spark/v3.5/spark-runtime/build/libs/iceberg-spark-runtime-3.5_2.12-01a7908.jar  s3://${{ env.S3_BUCKET }}/s3fileio/iceberg-spark-runtime-3.5_2.12-1.6.0-SNAPSHOT.jar
+        run: |
+          JAR_PATH=$(ls -S /home/runner/work/s3-connector-framework/s3-connector-framework/iceberg/spark/v3.5/spark-runtime/build/libs/iceberg-spark-runtime-*.jar | head -1)
+          aws s3 cp $JAR_PATH s3://${{ env.S3_BUCKET }}/s3fileio/iceberg-spark-runtime-3.5_2.12-1.6.0-SNAPSHOT.jar


### PR DESCRIPTION
The commit ID had a mismatch. This changes things so that we do not depend on the commit ID.

### Testing
- Tested locally in a few directories, could not test end-to-end. Will resubmit the job once it is merged.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
