### PR TITLE
Renames ParquetMetadataStore to ParquetColumnPrefetchStore.

### DIFF
--- a/input-stream/src/main/java/com/amazon/connector/s3/io/logical/impl/ParquetColumnPrefetchStore.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/logical/impl/ParquetColumnPrefetchStore.java
@@ -24,7 +24,7 @@ import java.util.Set;
 @SuppressFBWarnings(
     value = "SE_BAD_FIELD",
     justification = "The closure classes trigger this. We never use serialization on this class")
-public class ParquetMetadataStore {
+public class ParquetColumnPrefetchStore {
 
   /**
    * * This is a mapping of S3 URI's of Parquet files to their {@link ColumnMappers}. When a stream
@@ -76,7 +76,7 @@ public class ParquetMetadataStore {
    *
    * @param configuration object containing information about the metadata store size
    */
-  public ParquetMetadataStore(LogicalIOConfiguration configuration) {
+  public ParquetColumnPrefetchStore(LogicalIOConfiguration configuration) {
     this(
         configuration,
         new LinkedHashMap<S3URI, ColumnMappers>() {
@@ -101,7 +101,7 @@ public class ParquetMetadataStore {
    * @param columnMappersStore Store of column mappings
    * @param recentlyReadColumnsPerSchema List of recent read columns for each schema
    */
-  ParquetMetadataStore(
+  ParquetColumnPrefetchStore(
       LogicalIOConfiguration configuration,
       Map<S3URI, ColumnMappers> columnMappersStore,
       Map<Integer, LinkedList<String>> recentlyReadColumnsPerSchema) {

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/logical/impl/ParquetLogicalIOImpl.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/logical/impl/ParquetLogicalIOImpl.java
@@ -22,20 +22,20 @@ public class ParquetLogicalIOImpl extends DefaultLogicalIOImpl {
    * @param physicalIO underlying physical IO that knows how to fetch bytes
    * @param telemetry an instance of {@link Telemetry} to use
    * @param logicalIOConfiguration configuration for this logical IO implementation
-   * @param parquetMetadataStore object where Parquet usage information is aggregated
+   * @param parquetColumnPrefetchStore object where Parquet usage information is aggregated
    */
   public ParquetLogicalIOImpl(
       @NonNull S3URI s3Uri,
       @NonNull PhysicalIO physicalIO,
       @NonNull Telemetry telemetry,
       @NonNull LogicalIOConfiguration logicalIOConfiguration,
-      @NonNull ParquetMetadataStore parquetMetadataStore) {
+      @NonNull ParquetColumnPrefetchStore parquetColumnPrefetchStore) {
     super(physicalIO);
 
     // Initialise prefetcher and start prefetching
     this.parquetPrefetcher =
         new ParquetPrefetcher(
-            s3Uri, physicalIO, telemetry, logicalIOConfiguration, parquetMetadataStore);
+            s3Uri, physicalIO, telemetry, logicalIOConfiguration, parquetColumnPrefetchStore);
     this.parquetPrefetcher.prefetchFooterAndBuildMetadata();
   }
 

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/logical/parquet/ParquetMetadataParsingTask.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/logical/parquet/ParquetMetadataParsingTask.java
@@ -1,6 +1,6 @@
 package com.amazon.connector.s3.io.logical.parquet;
 
-import com.amazon.connector.s3.io.logical.impl.ParquetMetadataStore;
+import com.amazon.connector.s3.io.logical.impl.ParquetColumnPrefetchStore;
 import com.amazon.connector.s3.util.S3URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 public class ParquetMetadataParsingTask {
   private final S3URI s3URI;
   private final ParquetParser parquetParser;
-  private final ParquetMetadataStore parquetMetadataStore;
+  private final ParquetColumnPrefetchStore parquetColumnPrefetchStore;
 
   private static final Logger LOG = LoggerFactory.getLogger(ParquetMetadataParsingTask.class);
 
@@ -29,10 +29,11 @@ public class ParquetMetadataParsingTask {
    * Creates a new instance of {@link ParquetMetadataParsingTask}.
    *
    * @param s3URI the S3Uri of the object
-   * @param parquetMetadataStore object containing Parquet usage information
+   * @param parquetColumnPrefetchStore object containing Parquet usage information
    */
-  public ParquetMetadataParsingTask(S3URI s3URI, ParquetMetadataStore parquetMetadataStore) {
-    this(s3URI, parquetMetadataStore, new ParquetParser());
+  public ParquetMetadataParsingTask(
+      S3URI s3URI, ParquetColumnPrefetchStore parquetColumnPrefetchStore) {
+    this(s3URI, parquetColumnPrefetchStore, new ParquetParser());
   }
 
   /**
@@ -40,16 +41,16 @@ public class ParquetMetadataParsingTask {
    * is useful for testing as it allows dependency injection.
    *
    * @param s3URI the S3Uri of the object
-   * @param parquetMetadataStore object containing Parquet usage information
+   * @param parquetColumnPrefetchStore object containing Parquet usage information
    * @param parquetParser parser for getting the file metadata
    */
   ParquetMetadataParsingTask(
       @NonNull S3URI s3URI,
-      @NonNull ParquetMetadataStore parquetMetadataStore,
+      @NonNull ParquetColumnPrefetchStore parquetColumnPrefetchStore,
       @NonNull ParquetParser parquetParser) {
     this.s3URI = s3URI;
     this.parquetParser = parquetParser;
-    this.parquetMetadataStore = parquetMetadataStore;
+    this.parquetColumnPrefetchStore = parquetColumnPrefetchStore;
   }
 
   /**
@@ -63,7 +64,7 @@ public class ParquetMetadataParsingTask {
       FileMetaData fileMetaData =
           parquetParser.parseParquetFooter(fileTail.getFileTail(), fileTail.getFileTailLength());
       ColumnMappers columnMappers = buildColumnMaps(fileMetaData);
-      parquetMetadataStore.putColumnMappers(this.s3URI, columnMappers);
+      parquetColumnPrefetchStore.putColumnMappers(this.s3URI, columnMappers);
       return columnMappers;
     } catch (Exception e) {
       LOG.error(

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/logical/parquet/ParquetPrefetchRemainingColumnTask.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/logical/parquet/ParquetPrefetchRemainingColumnTask.java
@@ -2,7 +2,7 @@ package com.amazon.connector.s3.io.logical.parquet;
 
 import com.amazon.connector.s3.common.telemetry.Operation;
 import com.amazon.connector.s3.common.telemetry.Telemetry;
-import com.amazon.connector.s3.io.logical.impl.ParquetMetadataStore;
+import com.amazon.connector.s3.io.logical.impl.ParquetColumnPrefetchStore;
 import com.amazon.connector.s3.io.physical.PhysicalIO;
 import com.amazon.connector.s3.io.physical.plan.IOPlan;
 import com.amazon.connector.s3.io.physical.plan.IOPlanExecution;
@@ -20,7 +20,7 @@ public class ParquetPrefetchRemainingColumnTask {
   private final S3URI s3Uri;
   private final Telemetry telemetry;
   private final PhysicalIO physicalIO;
-  private final ParquetMetadataStore parquetMetadataStore;
+  private final ParquetColumnPrefetchStore parquetColumnPrefetchStore;
 
   private static final String OPERATION_PARQUET_PREFETCH_COLUMN_CHUNK =
       "parquet.task.prefetch.column.chunk";
@@ -32,17 +32,17 @@ public class ParquetPrefetchRemainingColumnTask {
    * @param s3URI the object's S3 URI
    * @param physicalIO physicalIO instance
    * @param telemetry an instance of {@link Telemetry} to use
-   * @param parquetMetadataStore object containing Parquet usage information
+   * @param parquetColumnPrefetchStore object containing Parquet usage information
    */
   public ParquetPrefetchRemainingColumnTask(
       @NonNull S3URI s3URI,
       @NonNull Telemetry telemetry,
       @NonNull PhysicalIO physicalIO,
-      @NonNull ParquetMetadataStore parquetMetadataStore) {
+      @NonNull ParquetColumnPrefetchStore parquetColumnPrefetchStore) {
     this.s3Uri = s3URI;
     this.telemetry = telemetry;
     this.physicalIO = physicalIO;
-    this.parquetMetadataStore = parquetMetadataStore;
+    this.parquetColumnPrefetchStore = parquetColumnPrefetchStore;
   }
 
   /**
@@ -53,7 +53,7 @@ public class ParquetPrefetchRemainingColumnTask {
    * @return ranges prefetched
    */
   public IOPlanExecution prefetchRemainingColumnChunk(long position, int len) {
-    ColumnMappers columnMappers = parquetMetadataStore.getColumnMappers(s3Uri);
+    ColumnMappers columnMappers = parquetColumnPrefetchStore.getColumnMappers(s3Uri);
     if (columnMappers != null) {
       ColumnMetadata columnMetadata = columnMappers.getOffsetIndexToColumnMap().get(position);
       if (columnMetadata != null) {

--- a/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTest.java
@@ -6,8 +6,8 @@ import static org.mockito.Mockito.*;
 
 import com.amazon.connector.s3.io.logical.LogicalIO;
 import com.amazon.connector.s3.io.logical.LogicalIOConfiguration;
+import com.amazon.connector.s3.io.logical.impl.ParquetColumnPrefetchStore;
 import com.amazon.connector.s3.io.logical.impl.ParquetLogicalIOImpl;
-import com.amazon.connector.s3.io.logical.impl.ParquetMetadataStore;
 import com.amazon.connector.s3.io.physical.PhysicalIO;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
 import com.amazon.connector.s3.io.physical.data.BlobStore;
@@ -366,7 +366,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
                           physicalIO,
                           TestTelemetry.DEFAULT,
                           LogicalIOConfiguration.DEFAULT,
-                          new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT));
+                          new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT));
                   try (SeekableInputStream stream =
                       new S3SeekableInputStream(TEST_URI, logicalIO, TestTelemetry.DEFAULT)) {
                     byte[] buffer = new byte[4];
@@ -416,7 +416,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
             new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
             TestTelemetry.DEFAULT,
             LogicalIOConfiguration.DEFAULT,
-            new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)),
+            new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)),
         TestTelemetry.DEFAULT);
   }
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTestBase.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTestBase.java
@@ -2,8 +2,8 @@ package com.amazon.connector.s3;
 
 import com.amazon.connector.s3.io.logical.LogicalIO;
 import com.amazon.connector.s3.io.logical.LogicalIOConfiguration;
+import com.amazon.connector.s3.io.logical.impl.ParquetColumnPrefetchStore;
 import com.amazon.connector.s3.io.logical.impl.ParquetLogicalIOImpl;
-import com.amazon.connector.s3.io.logical.impl.ParquetMetadataStore;
 import com.amazon.connector.s3.io.physical.PhysicalIOConfiguration;
 import com.amazon.connector.s3.io.physical.data.BlobStore;
 import com.amazon.connector.s3.io.physical.data.MetadataStore;
@@ -31,5 +31,5 @@ public class S3SeekableInputStreamTestBase {
           new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
           TestTelemetry.DEFAULT,
           logicalIOConfiguration,
-          new ParquetMetadataStore(logicalIOConfiguration));
+          new ParquetColumnPrefetchStore(logicalIOConfiguration));
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/logical/impl/ParquetColumnPrefetchStoreTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/logical/impl/ParquetColumnPrefetchStoreTest.java
@@ -17,11 +17,11 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-public class ParquetMetadataStoreTest {
+public class ParquetColumnPrefetchStoreTest {
 
   @Test
   void testConstructor() {
-    assertNotNull(new ParquetMetadataStore(mock(LogicalIOConfiguration.class)));
+    assertNotNull(new ParquetColumnPrefetchStore(mock(LogicalIOConfiguration.class)));
   }
 
   @Test
@@ -36,18 +36,18 @@ public class ParquetMetadataStoreTest {
     ColumnMetadata sk_test3 = new ColumnMetadata(0, "sk_test3", 0, 500, schemaHash);
 
     Map<Integer, LinkedList<String>> recentlyReadColumnsPerSchema = new HashMap<>();
-    ParquetMetadataStore parquetMetadataStore =
-        new ParquetMetadataStore(
+    ParquetColumnPrefetchStore parquetColumnPrefetchStore =
+        new ParquetColumnPrefetchStore(
             LogicalIOConfiguration.builder().maxColumnAccessCountStoreSize(3).build(),
             columnMappersStore,
             recentlyReadColumnsPerSchema);
 
-    parquetMetadataStore.addRecentColumn(sk_test);
-    parquetMetadataStore.addRecentColumn(sk_test2);
-    parquetMetadataStore.addRecentColumn(sk_test);
-    parquetMetadataStore.addRecentColumn(sk_test2);
-    parquetMetadataStore.addRecentColumn(sk_test3);
-    parquetMetadataStore.addRecentColumn(sk_test3);
+    parquetColumnPrefetchStore.addRecentColumn(sk_test);
+    parquetColumnPrefetchStore.addRecentColumn(sk_test2);
+    parquetColumnPrefetchStore.addRecentColumn(sk_test);
+    parquetColumnPrefetchStore.addRecentColumn(sk_test2);
+    parquetColumnPrefetchStore.addRecentColumn(sk_test3);
+    parquetColumnPrefetchStore.addRecentColumn(sk_test3);
 
     assertEquals(recentlyReadColumnsPerSchema.get(schemaHash).size(), 3);
 
@@ -65,6 +65,7 @@ public class ParquetMetadataStoreTest {
     expectedUniqueColumns.add("sk_test3");
 
     assertEquals(
-        parquetMetadataStore.getUniqueRecentColumnsForSchema(schemaHash), expectedUniqueColumns);
+        parquetColumnPrefetchStore.getUniqueRecentColumnsForSchema(schemaHash),
+        expectedUniqueColumns);
   }
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -33,7 +33,7 @@ public class ParquetLogicalIOImplTest {
             mock(PhysicalIO.class),
             TestTelemetry.DEFAULT,
             mock(LogicalIOConfiguration.class),
-            mock(ParquetMetadataStore.class)));
+            mock(ParquetColumnPrefetchStore.class)));
   }
 
   @Test
@@ -46,7 +46,7 @@ public class ParquetLogicalIOImplTest {
                 null,
                 TestTelemetry.DEFAULT,
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class)));
+                mock(ParquetColumnPrefetchStore.class)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -55,7 +55,7 @@ public class ParquetLogicalIOImplTest {
                 mock(PhysicalIO.class),
                 TestTelemetry.DEFAULT,
                 null,
-                mock(ParquetMetadataStore.class)));
+                mock(ParquetColumnPrefetchStore.class)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -64,7 +64,7 @@ public class ParquetLogicalIOImplTest {
                 mock(PhysicalIO.class),
                 null,
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class)));
+                mock(ParquetColumnPrefetchStore.class)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -92,7 +92,7 @@ public class ParquetLogicalIOImplTest {
             physicalIO,
             TestTelemetry.DEFAULT,
             configuration,
-            new ParquetMetadataStore(configuration));
+            new ParquetColumnPrefetchStore(configuration));
 
     // When: close called
     logicalIO.close();
@@ -122,7 +122,7 @@ public class ParquetLogicalIOImplTest {
                 physicalIO,
                 TestTelemetry.DEFAULT,
                 LogicalIOConfiguration.DEFAULT,
-                new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
+                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
   }
 
   @Test
@@ -146,6 +146,6 @@ public class ParquetLogicalIOImplTest {
                 physicalIO,
                 TestTelemetry.DEFAULT,
                 LogicalIOConfiguration.DEFAULT,
-                new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
+                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
   }
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/logical/impl/ParquetPrefetcherTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/logical/impl/ParquetPrefetcherTest.java
@@ -45,7 +45,7 @@ public class ParquetPrefetcherTest {
             mock(PhysicalIO.class),
             mock(Telemetry.class),
             mock(LogicalIOConfiguration.class),
-            mock(ParquetMetadataStore.class)));
+            mock(ParquetColumnPrefetchStore.class)));
   }
 
   @Test
@@ -56,7 +56,7 @@ public class ParquetPrefetcherTest {
             new ParquetPrefetcher(
                 null,
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class),
+                mock(ParquetColumnPrefetchStore.class),
                 mock(Telemetry.class),
                 mock(ParquetMetadataParsingTask.class),
                 mock(ParquetPrefetchTailTask.class),
@@ -70,7 +70,7 @@ public class ParquetPrefetcherTest {
             new ParquetPrefetcher(
                 mock(S3URI.class),
                 null,
-                mock(ParquetMetadataStore.class),
+                mock(ParquetColumnPrefetchStore.class),
                 mock(Telemetry.class),
                 mock(ParquetMetadataParsingTask.class),
                 mock(ParquetPrefetchTailTask.class),
@@ -96,7 +96,7 @@ public class ParquetPrefetcherTest {
             new ParquetPrefetcher(
                 mock(S3URI.class),
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class),
+                mock(ParquetColumnPrefetchStore.class),
                 null,
                 mock(ParquetMetadataParsingTask.class),
                 mock(ParquetPrefetchTailTask.class),
@@ -109,7 +109,7 @@ public class ParquetPrefetcherTest {
             new ParquetPrefetcher(
                 mock(S3URI.class),
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class),
+                mock(ParquetColumnPrefetchStore.class),
                 mock(Telemetry.class),
                 null,
                 mock(ParquetPrefetchTailTask.class),
@@ -122,7 +122,7 @@ public class ParquetPrefetcherTest {
             new ParquetPrefetcher(
                 mock(S3URI.class),
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class),
+                mock(ParquetColumnPrefetchStore.class),
                 mock(Telemetry.class),
                 mock(ParquetMetadataParsingTask.class),
                 null,
@@ -135,7 +135,7 @@ public class ParquetPrefetcherTest {
             new ParquetPrefetcher(
                 mock(S3URI.class),
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class),
+                mock(ParquetColumnPrefetchStore.class),
                 mock(Telemetry.class),
                 mock(ParquetMetadataParsingTask.class),
                 mock(ParquetPrefetchTailTask.class),
@@ -148,7 +148,7 @@ public class ParquetPrefetcherTest {
             new ParquetPrefetcher(
                 mock(S3URI.class),
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class),
+                mock(ParquetColumnPrefetchStore.class),
                 mock(Telemetry.class),
                 mock(ParquetMetadataParsingTask.class),
                 mock(ParquetPrefetchTailTask.class),
@@ -161,7 +161,7 @@ public class ParquetPrefetcherTest {
             new ParquetPrefetcher(
                 mock(S3URI.class),
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class),
+                mock(ParquetColumnPrefetchStore.class),
                 mock(Telemetry.class),
                 mock(ParquetMetadataParsingTask.class),
                 mock(ParquetPrefetchTailTask.class),
@@ -177,7 +177,7 @@ public class ParquetPrefetcherTest {
                 mock(PhysicalIO.class),
                 mock(Telemetry.class),
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class)));
+                mock(ParquetColumnPrefetchStore.class)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -186,7 +186,7 @@ public class ParquetPrefetcherTest {
                 null,
                 mock(Telemetry.class),
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class)));
+                mock(ParquetColumnPrefetchStore.class)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -195,7 +195,7 @@ public class ParquetPrefetcherTest {
                 mock(PhysicalIO.class),
                 null,
                 mock(LogicalIOConfiguration.class),
-                mock(ParquetMetadataStore.class)));
+                mock(ParquetColumnPrefetchStore.class)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -204,7 +204,7 @@ public class ParquetPrefetcherTest {
                 mock(PhysicalIO.class),
                 mock(Telemetry.class),
                 null,
-                mock(ParquetMetadataStore.class)));
+                mock(ParquetColumnPrefetchStore.class)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -231,7 +231,7 @@ public class ParquetPrefetcherTest {
     ParquetPrefetcher parquetPrefetcher =
         getTestPrefetcher(
             logicalIOConfiguration,
-            mock(ParquetMetadataStore.class),
+            mock(ParquetColumnPrefetchStore.class),
             mock(ParquetMetadataParsingTask.class),
             mock(ParquetPrefetchTailTask.class),
             mock(ParquetReadTailTask.class),
@@ -263,7 +263,7 @@ public class ParquetPrefetcherTest {
     ParquetPrefetcher parquetPrefetcher =
         getTestPrefetcher(
             logicalIOConfiguration,
-            mock(ParquetMetadataStore.class),
+            mock(ParquetColumnPrefetchStore.class),
             mock(ParquetMetadataParsingTask.class),
             mock(ParquetPrefetchTailTask.class),
             mock(ParquetReadTailTask.class),
@@ -292,7 +292,7 @@ public class ParquetPrefetcherTest {
     ParquetPrefetcher parquetPrefetcher =
         getTestPrefetcher(
             logicalIOConfiguration,
-            mock(ParquetMetadataStore.class),
+            mock(ParquetColumnPrefetchStore.class),
             parquetMetadataParsingTask,
             parquetPrefetchTailTask,
             parquetReadTailTask,
@@ -328,7 +328,7 @@ public class ParquetPrefetcherTest {
     ParquetPrefetcher parquetPrefetcher =
         getTestPrefetcher(
             logicalIOConfiguration,
-            mock(ParquetMetadataStore.class),
+            mock(ParquetColumnPrefetchStore.class),
             parquetMetadataParsingTask,
             parquetPrefetchTailTask,
             parquetReadTailTask,
@@ -362,7 +362,7 @@ public class ParquetPrefetcherTest {
     ParquetPrefetcher parquetPrefetcher =
         getTestPrefetcher(
             logicalIOConfiguration,
-            mock(ParquetMetadataStore.class),
+            mock(ParquetColumnPrefetchStore.class),
             parquetMetadataParsingTask,
             parquetPrefetchTailTask,
             parquetReadTailTask,
@@ -393,7 +393,7 @@ public class ParquetPrefetcherTest {
     ParquetPrefetcher parquetPrefetcher =
         getTestPrefetcher(
             logicalIOConfiguration,
-            mock(ParquetMetadataStore.class),
+            mock(ParquetColumnPrefetchStore.class),
             mock(ParquetMetadataParsingTask.class),
             parquetPrefetchTailTask,
             mock(ParquetReadTailTask.class),
@@ -417,7 +417,7 @@ public class ParquetPrefetcherTest {
     ParquetPrefetcher parquetPrefetcher =
         getTestPrefetcher(
             logicalIOConfiguration,
-            mock(ParquetMetadataStore.class),
+            mock(ParquetColumnPrefetchStore.class),
             mock(ParquetMetadataParsingTask.class),
             mock(ParquetPrefetchTailTask.class),
             mock(ParquetReadTailTask.class),
@@ -451,7 +451,7 @@ public class ParquetPrefetcherTest {
 
   private ParquetPrefetcher getTestPrefetcher(
       LogicalIOConfiguration logicalIOConfiguration,
-      ParquetMetadataStore parquetMetadataStore,
+      ParquetColumnPrefetchStore parquetColumnPrefetchStore,
       ParquetMetadataParsingTask parquetMetadataParsingTask,
       ParquetPrefetchTailTask parquetPrefetchTailTask,
       ParquetReadTailTask parquetReadTailTask,
@@ -461,7 +461,7 @@ public class ParquetPrefetcherTest {
     return new ParquetPrefetcher(
         TEST_URI,
         logicalIOConfiguration,
-        parquetMetadataStore,
+        parquetColumnPrefetchStore,
         Telemetry.NOOP,
         parquetMetadataParsingTask,
         parquetPrefetchTailTask,

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/logical/parquet/ParquetMetadataParsingTaskTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/logical/parquet/ParquetMetadataParsingTaskTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.amazon.connector.s3.io.logical.LogicalIOConfiguration;
-import com.amazon.connector.s3.io.logical.impl.ParquetMetadataStore;
+import com.amazon.connector.s3.io.logical.impl.ParquetColumnPrefetchStore;
 import com.amazon.connector.s3.util.S3URI;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.FileInputStream;
@@ -43,7 +43,7 @@ public class ParquetMetadataParsingTaskTest {
   void testConstructor() {
     assertNotNull(
         new ParquetMetadataParsingTask(
-            TEST_URI, new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
+            TEST_URI, new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
   }
 
   @Test
@@ -52,14 +52,14 @@ public class ParquetMetadataParsingTaskTest {
         NullPointerException.class,
         () ->
             new ParquetMetadataParsingTask(
-                null, new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
+                null, new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
     assertThrows(NullPointerException.class, () -> new ParquetMetadataParsingTask(TEST_URI, null));
     assertThrows(
         NullPointerException.class,
         () ->
             new ParquetMetadataParsingTask(
                 null,
-                new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT),
+                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT),
                 mock(ParquetParser.class)));
 
     assertThrows(
@@ -70,7 +70,7 @@ public class ParquetMetadataParsingTaskTest {
         NullPointerException.class,
         () ->
             new ParquetMetadataParsingTask(
-                TEST_URI, new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT), null));
+                TEST_URI, new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT), null));
   }
 
   @ParameterizedTest
@@ -221,7 +221,7 @@ public class ParquetMetadataParsingTaskTest {
     ParquetMetadataParsingTask parquetMetadataParsingTask =
         new ParquetMetadataParsingTask(
             TEST_URI,
-            new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT),
+            new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT),
             mockedParquetParser);
     CompletableFuture<ColumnMappers> parquetMetadataTaskFuture =
         CompletableFuture.supplyAsync(
@@ -249,7 +249,7 @@ public class ParquetMetadataParsingTaskTest {
     ParquetMetadataParsingTask parquetMetadataParsingTask =
         new ParquetMetadataParsingTask(
             TEST_URI,
-            new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT),
+            new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT),
             mockedParquetParser);
 
     return parquetMetadataParsingTask.storeColumnMappers(new FileTail(ByteBuffer.allocate(0), 0));

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/logical/parquet/ParquetPrefetchRemainingColumnTaskTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/logical/parquet/ParquetPrefetchRemainingColumnTaskTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.amazon.connector.s3.common.telemetry.Telemetry;
 import com.amazon.connector.s3.io.logical.LogicalIOConfiguration;
-import com.amazon.connector.s3.io.logical.impl.ParquetMetadataStore;
+import com.amazon.connector.s3.io.logical.impl.ParquetColumnPrefetchStore;
 import com.amazon.connector.s3.io.physical.PhysicalIO;
 import com.amazon.connector.s3.io.physical.impl.PhysicalIOImpl;
 import com.amazon.connector.s3.io.physical.plan.IOPlan;
@@ -39,7 +39,7 @@ public class ParquetPrefetchRemainingColumnTaskTest {
             TEST_URI,
             Telemetry.NOOP,
             mock(PhysicalIO.class),
-            new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
+            new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
   }
 
   @Test
@@ -51,7 +51,7 @@ public class ParquetPrefetchRemainingColumnTaskTest {
                 null,
                 Telemetry.NOOP,
                 mock(PhysicalIO.class),
-                new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
+                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
 
     assertThrows(
         NullPointerException.class,
@@ -60,7 +60,7 @@ public class ParquetPrefetchRemainingColumnTaskTest {
                 TEST_URI,
                 null,
                 mock(PhysicalIO.class),
-                new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
+                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -68,7 +68,7 @@ public class ParquetPrefetchRemainingColumnTaskTest {
                 TEST_URI,
                 Telemetry.NOOP,
                 null,
-                new ParquetMetadataStore(LogicalIOConfiguration.DEFAULT)));
+                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -83,9 +83,10 @@ public class ParquetPrefetchRemainingColumnTaskTest {
         200L,
         new ColumnMetadata(0, "ss_sold_date_sk", 200, 10 * ONE_MB, "ss_sold_date_sk".hashCode()));
 
-    ParquetMetadataStore mockedParquetMetadataStore = mock(ParquetMetadataStore.class);
+    ParquetColumnPrefetchStore mockedParquetColumnPrefetchStore =
+        mock(ParquetColumnPrefetchStore.class);
     PhysicalIOImpl mockedPhysicalIO = mock(PhysicalIOImpl.class);
-    when(mockedParquetMetadataStore.getColumnMappers(TEST_URI))
+    when(mockedParquetColumnPrefetchStore.getColumnMappers(TEST_URI))
         .thenReturn(new ColumnMappers(offsetIndexToColumnMap, new HashMap<>()));
 
     List<Range> expectedRanges = new ArrayList<>();
@@ -98,7 +99,7 @@ public class ParquetPrefetchRemainingColumnTaskTest {
 
     ParquetPrefetchRemainingColumnTask parquetPrefetchRemainingColumnTask =
         new ParquetPrefetchRemainingColumnTask(
-            TEST_URI, Telemetry.NOOP, mockedPhysicalIO, mockedParquetMetadataStore);
+            TEST_URI, Telemetry.NOOP, mockedPhysicalIO, mockedParquetColumnPrefetchStore);
     parquetPrefetchRemainingColumnTask.prefetchRemainingColumnChunk(200, 5 * ONE_MB);
 
     verify(mockedPhysicalIO).execute(any(IOPlan.class));
@@ -112,14 +113,15 @@ public class ParquetPrefetchRemainingColumnTaskTest {
         200L,
         new ColumnMetadata(0, "ss_sold_date_sk", 200, 10 * ONE_MB, "ss_sold_date_sk".hashCode()));
 
-    ParquetMetadataStore mockedParquetMetadataStore = mock(ParquetMetadataStore.class);
+    ParquetColumnPrefetchStore mockedParquetColumnPrefetchStore =
+        mock(ParquetColumnPrefetchStore.class);
     PhysicalIOImpl mockedPhysicalIO = mock(PhysicalIOImpl.class);
 
-    when(mockedParquetMetadataStore.getColumnMappers(TEST_URI))
+    when(mockedParquetColumnPrefetchStore.getColumnMappers(TEST_URI))
         .thenReturn(new ColumnMappers(offsetIndexToColumnMap, new HashMap<>()));
     ParquetPrefetchRemainingColumnTask parquetPrefetchRemainingColumnTask =
         new ParquetPrefetchRemainingColumnTask(
-            TEST_URI, Telemetry.NOOP, mockedPhysicalIO, mockedParquetMetadataStore);
+            TEST_URI, Telemetry.NOOP, mockedPhysicalIO, mockedParquetColumnPrefetchStore);
 
     doThrow(new IOException("Error in prefetch")).when(mockedPhysicalIO).execute(any(IOPlan.class));
 


### PR DESCRIPTION
*Description of changes:*

Renames ParquetMetadataStore to ParquetColumnPrefetchStore to better reflect the tasks purpose as it is only used for prefetching tasks. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
