### PR TITLE
S3SdkObjectClient: better lifetime controls on `close()`

### DIFF
--- a/object-client/src/main/java/com/amazon/connector/s3/S3SdkObjectClient.java
+++ b/object-client/src/main/java/com/amazon/connector/s3/S3SdkObjectClient.java
@@ -15,12 +15,12 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 
 /** Object client, based on AWS SDK v2 */
 public class S3SdkObjectClient implements ObjectClient {
-  public static final String HEADER_USER_AGENT = "User-Agent";
+  private static final String HEADER_USER_AGENT = "User-Agent";
   private static final String HEADER_REFERER = "Referer";
 
-  @Getter private S3AsyncClient s3AsyncClient = null;
-  private final Telemetry telemetry;
-  private final UserAgent userAgent;
+  @Getter @NonNull private final S3AsyncClient s3AsyncClient;
+  @NonNull private final Telemetry telemetry;
+  @NonNull private final UserAgent userAgent;
   private final boolean closeAsyncClient;
 
   /**
@@ -30,7 +30,7 @@ public class S3SdkObjectClient implements ObjectClient {
    *
    * @param s3AsyncClient Underlying client to be used for making requests to S3.
    */
-  public S3SdkObjectClient(@NonNull S3AsyncClient s3AsyncClient) {
+  public S3SdkObjectClient(S3AsyncClient s3AsyncClient) {
     this(s3AsyncClient, ObjectClientConfiguration.DEFAULT);
   }
 
@@ -42,7 +42,7 @@ public class S3SdkObjectClient implements ObjectClient {
    * @param s3AsyncClient Underlying client to be used for making requests to S3.
    * @param closeAsyncClient if true, close the passed client on close.
    */
-  public S3SdkObjectClient(@NonNull S3AsyncClient s3AsyncClient, boolean closeAsyncClient) {
+  public S3SdkObjectClient(S3AsyncClient s3AsyncClient, boolean closeAsyncClient) {
     this(s3AsyncClient, ObjectClientConfiguration.DEFAULT, closeAsyncClient);
   }
 
@@ -54,8 +54,7 @@ public class S3SdkObjectClient implements ObjectClient {
    * @param objectClientConfiguration Configuration for object client.
    */
   public S3SdkObjectClient(
-      @NonNull S3AsyncClient s3AsyncClient,
-      @NonNull ObjectClientConfiguration objectClientConfiguration) {
+      S3AsyncClient s3AsyncClient, ObjectClientConfiguration objectClientConfiguration) {
     this(s3AsyncClient, objectClientConfiguration, true);
   }
 

--- a/object-client/src/test/java/com/amazon/connector/s3/S3SdkObjectClientTest.java
+++ b/object-client/src/test/java/com/amazon/connector/s3/S3SdkObjectClientTest.java
@@ -31,9 +31,27 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 @SuppressFBWarnings(
-    value = "NP_NONNULL_PARAM_VIOLATION",
-    justification = "We mean to pass nulls to checks")
+    value = {"NP_NONNULL_PARAM_VIOLATION", "SIC_INNER_SHOULD_BE_STATIC_ANON"},
+    justification =
+        "We mean to pass nulls to checks. Also, closures cannot be made static in this case")
 public class S3SdkObjectClientTest {
+  @Test
+  void testForNullsInConstructor() {
+    try (S3AsyncClient client = mock(S3AsyncClient.class)) {
+      SpotBugsLambdaWorkaround.assertThrowsClosableResult(
+          NullPointerException.class,
+          () -> new S3SdkObjectClient(null, ObjectClientConfiguration.DEFAULT, true));
+      SpotBugsLambdaWorkaround.assertThrowsClosableResult(
+          NullPointerException.class, () -> new S3SdkObjectClient(client, null, true));
+      SpotBugsLambdaWorkaround.assertThrowsClosableResult(
+          NullPointerException.class,
+          () -> new S3SdkObjectClient(null, ObjectClientConfiguration.DEFAULT));
+      SpotBugsLambdaWorkaround.assertThrowsClosableResult(
+          NullPointerException.class, () -> new S3SdkObjectClient(null, true));
+      SpotBugsLambdaWorkaround.assertThrowsClosableResult(
+          NullPointerException.class, () -> new S3SdkObjectClient(null));
+    }
+  }
 
   @Test
   void testCloseCallsInnerCloseWhenInstructed() {
@@ -144,6 +162,7 @@ public class S3SdkObjectClientTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private static S3AsyncClient createMockClient() {
     S3AsyncClient s3AsyncClient = mock(S3AsyncClient.class);
 

--- a/object-client/src/test/java/com/amazon/connector/s3/SpotBugsLambdaWorkaround.java
+++ b/object-client/src/test/java/com/amazon/connector/s3/SpotBugsLambdaWorkaround.java
@@ -1,0 +1,36 @@
+package com.amazon.connector.s3;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.Closeable;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+
+/**
+ * This class is here to help work around certain SpotBugs quirks. Specifically, SpotBugs don't
+ * allow to apply suppressions to Lambdas
+ */
+public final class SpotBugsLambdaWorkaround {
+  /**
+   * In situations where a method or constructor return a class that implements Closeable, Spotbugs
+   * wants to see it closed. When testing bounds and expecting exceptions, this is unnecessary, and
+   * trying to work around this in tests results in a lot of boilerplate. This method absorbs all
+   * the boilerplate and acts as `assertThrows`.
+   *
+   * @param expectedType exception type expected
+   * @param executable code that returns something Closeable, and expected to throw
+   * @param <T> exception type
+   * @param <C> return type
+   */
+  @SneakyThrows
+  public static <T extends Throwable, C extends Closeable> void assertThrowsClosableResult(
+      Class<T> expectedType, ThrowingSupplier<C> executable) {
+    try (C result = executable.get()) {
+    } catch (Throwable throwable) {
+      assertInstanceOf(expectedType, throwable);
+      return;
+    }
+    fail(String.format("Exception of type '%s' was expected. Nothing was thrown", expectedType));
+  }
+}


### PR DESCRIPTION
### Summary of changes

Today the `S3SdkObjectClient` takes an `S3AsyncClient` and effectively takes an ownership of it, by closing it in its own `close`.  Further,  the `S3AsyncClient` is not exposed via any getters. 
This can be problematic in situations when `S3AsyncClient` is shared between our code and other code and forces the customer to create a dedicated client just for our use. 

To allow for better flexibility, this change: 
- Adds several constructors to `S3SdkObjectClient` that take a `boolean` to indicate whether the `close` should also close the underlying `S3AsyncClient`. This is set to `true` by default, preserving existing behavior
- Adds a getter for `S3AsyncClient` to `S3SdkObjectClient` to allow for cases where `S3SdkObjectClient` is the primary holder of the lifetime, but occasionally the "raw" client needs to be accessed. 
- Adds new tests for new and existing functionality 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
