### PR TITLE
Enabled Java `-XLint` warnings and made them errors. 

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
@@ -62,6 +62,13 @@ java {
     }
 }
 
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Werror") // treat warnings as errors
+    options.compilerArgs.add("-Xlint:all")
+    options.compilerArgs.add("-Xlint:-serial") // we do not use Java serialization at all, reduce noise
+    options.compilerArgs.add("-Xlint:-classfile") // TODO: log4j dependency triggers this. Fix this when we remove it
+    options.isDeprecation = true
+}
 
 
 tasks.named<Test>("test") {

--- a/common/src/test/java/com/amazon/connector/s3/SpotBugsLambdaWorkaround.java
+++ b/common/src/test/java/com/amazon/connector/s3/SpotBugsLambdaWorkaround.java
@@ -24,6 +24,7 @@ public final class SpotBugsLambdaWorkaround {
    * @param <C> return type
    */
   @SneakyThrows
+  @SuppressWarnings("try")
   public static <T extends Throwable, C extends Closeable> void assertThrowsClosableResult(
       Class<T> expectedType, ThrowingSupplier<C> executable) {
     try (C result = executable.get()) {

--- a/common/src/test/java/com/amazon/connector/s3/common/PreconditionsTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/PreconditionsTest.java
@@ -570,6 +570,7 @@ public class PreconditionsTest {
     return params;
   }
 
+  @SuppressWarnings("unchecked")
   private static <T> T getArbitraryInstance(Class<T> type) {
     if (type == char.class) {
       return (T) Character.class.cast(' ');

--- a/common/src/test/java/com/amazon/connector/s3/common/telemetry/PrintStreamTelemetryReporterTest.java
+++ b/common/src/test/java/com/amazon/connector/s3/common/telemetry/PrintStreamTelemetryReporterTest.java
@@ -129,7 +129,7 @@ public class PrintStreamTelemetryReporterTest {
         () -> {
           try (PrintStreamTelemetryReporter reporter =
               new PrintStreamTelemetryReporter(System.out)) {
-            new PrintStreamTelemetryReporter(System.out).reportComplete(null);
+            reporter.reportComplete(null);
           }
         });
   }

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/logical/impl/ParquetColumnPrefetchStore.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/logical/impl/ParquetColumnPrefetchStore.java
@@ -81,13 +81,13 @@ public class ParquetColumnPrefetchStore {
         configuration,
         new LinkedHashMap<S3URI, ColumnMappers>() {
           @Override
-          protected boolean removeEldestEntry(final Map.Entry eldest) {
+          protected boolean removeEldestEntry(final Map.Entry<S3URI, ColumnMappers> eldest) {
             return this.size() > configuration.getParquetMetadataStoreSize();
           }
         },
         new LinkedHashMap<Integer, LinkedList<String>>() {
           @Override
-          protected boolean removeEldestEntry(final Map.Entry eldest) {
+          protected boolean removeEldestEntry(final Map.Entry<Integer, LinkedList<String>> eldest) {
             return this.size() > configuration.getMaxColumnAccessCountStoreSize();
           }
         });

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/logical/parquet/ParquetParser.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/logical/parquet/ParquetParser.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import org.apache.parquet.format.FileMetaData;
-import org.apache.parquet.format.InterningProtocol;
 import shaded.parquet.org.apache.thrift.TException;
 import shaded.parquet.org.apache.thrift.protocol.TCompactProtocol;
 import shaded.parquet.org.apache.thrift.protocol.TProtocol;
@@ -62,8 +61,9 @@ class ParquetParser {
     return protocol(new TIOStreamTransport(from));
   }
 
-  private static InterningProtocol protocol(TIOStreamTransport t) {
-    return new InterningProtocol(new TCompactProtocol(t));
+  @SuppressWarnings("deprecation")
+  private static org.apache.parquet.format.InterningProtocol protocol(TIOStreamTransport t) {
+    return new org.apache.parquet.format.InterningProtocol(new TCompactProtocol(t));
   }
 
   private static int readIntLittleEndian(InputStream in) throws IOException {

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/BlobStore.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/BlobStore.java
@@ -43,7 +43,7 @@ public class BlobStore implements Closeable {
         Collections.synchronizedMap(
             new LinkedHashMap<S3URI, Blob>() {
               @Override
-              protected boolean removeEldestEntry(final Map.Entry eldest) {
+              protected boolean removeEldestEntry(final Map.Entry<S3URI, Blob> eldest) {
                 return this.size() > configuration.getBlobStoreCapacity();
               }
             });

--- a/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/MetadataStore.java
+++ b/input-stream/src/main/java/com/amazon/connector/s3/io/physical/data/MetadataStore.java
@@ -49,7 +49,8 @@ public class MetadataStore implements Closeable {
         Collections.synchronizedMap(
             new LinkedHashMap<S3URI, CompletableFuture<ObjectMetadata>>() {
               @Override
-              protected boolean removeEldestEntry(final Map.Entry eldest) {
+              protected boolean removeEldestEntry(
+                  final Map.Entry<S3URI, CompletableFuture<ObjectMetadata>> eldest) {
                 return this.size() > configuration.getMetadataStoreCapacity();
               }
             });

--- a/input-stream/src/referenceTest/java/com/amazon/connector/s3/property/SeekableStreamPropertiesTest.java
+++ b/input-stream/src/referenceTest/java/com/amazon/connector/s3/property/SeekableStreamPropertiesTest.java
@@ -64,10 +64,9 @@ public class SeekableStreamPropertiesTest extends StreamArbitraries {
 
   @Property
   void canCloseStreamMultipleTimes(@ForAll("streamSizes") int size) throws IOException {
-    try (InMemoryS3SeekableInputStream s =
-        new InMemoryS3SeekableInputStream("test-bucket", "test-key", size)) {
-      s.close();
-      s.close();
-    }
+    InMemoryS3SeekableInputStream s =
+        new InMemoryS3SeekableInputStream("test-bucket", "test-key", size);
+    s.close();
+    s.close();
   }
 }

--- a/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/S3SeekableInputStreamTest.java
@@ -167,15 +167,11 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   void testLogicalIOGetsClosed() throws IOException {
     // Given
     LogicalIO logicalIO = mock(LogicalIO.class);
-    try (S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_URI, logicalIO, TestTelemetry.DEFAULT)) {
-
-      // When
-      stream.close();
-
-      // Then
-      verify(logicalIO, times(1)).close();
-    }
+    S3SeekableInputStream stream =
+        new S3SeekableInputStream(TEST_URI, logicalIO, TestTelemetry.DEFAULT);
+    stream.close();
+    // Then
+    verify(logicalIO, times(1)).close();
   }
 
   @Test

--- a/input-stream/src/test/java/com/amazon/connector/s3/SpotBugsLambdaWorkaround.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/SpotBugsLambdaWorkaround.java
@@ -23,6 +23,7 @@ public final class SpotBugsLambdaWorkaround {
    * @param <C> return type
    */
   @SneakyThrows
+  @SuppressWarnings("try")
   public static <T extends Throwable, C extends Closeable> void assertThrowsClosableResult(
       Class<T> expectedType, ThrowingSupplier<C> executable) {
     try (C result = executable.get()) {

--- a/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/MetadataStoreTest.java
+++ b/input-stream/src/test/java/com/amazon/connector/s3/io/physical/data/MetadataStoreTest.java
@@ -38,6 +38,7 @@ public class MetadataStoreTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void test__close__closesAllElements() {
     // Given:
     // - a MetadataStore with caching turned on

--- a/object-client/src/test/java/com/amazon/connector/s3/SpotBugsLambdaWorkaround.java
+++ b/object-client/src/test/java/com/amazon/connector/s3/SpotBugsLambdaWorkaround.java
@@ -24,6 +24,7 @@ public final class SpotBugsLambdaWorkaround {
    * @param <C> return type
    */
   @SneakyThrows
+  @SuppressWarnings("try")
   public static <T extends Throwable, C extends Closeable> void assertThrowsClosableResult(
       Class<T> expectedType, ThrowingSupplier<C> executable) {
     try (C result = executable.get()) {


### PR DESCRIPTION
### Summary of changes
- To maintain a higher bar on code quality, enabled `-Xlint` warnings and made them break the build via `-WError`
  - Disabled `-XLint:serial` - we do not use Java serialization and this one triggers a lot of noise
  - Disabled `-XLint:classfile` untill we get rid of `log4j`
- Fixed or suppressed the violations as appropriate   


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
