### PR TITLE
Gradle test-logger plugin integration

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,4 +15,5 @@ repositories {
 dependencies {
     implementation(libs.spotless)
     implementation(libs.spotbugs)
+    implementation(libs.test.logger)
 }

--- a/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-common-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import com.adarshr.gradle.testlogger.theme.ThemeType
 import com.github.spotbugs.snom.Confidence
 import com.github.spotbugs.snom.Effort
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -23,6 +24,9 @@ plugins {
     // SpotBugs
     id("com.github.spotbugs")
 
+    // Test logger
+    id("com.adarshr.test-logger")
+
     checkstyle
 }
 
@@ -47,6 +51,25 @@ spotbugs {
     excludeFilter = file("spotbugs-exclude.xml")
     effort = Effort.MAX
     reportLevel = Confidence.LOW
+}
+
+testlogger {
+    theme = ThemeType.MOCHA
+    showExceptions = true
+    showStackTraces = true
+    showFullStackTraces = false
+    showCauses = true
+    slowThreshold = 2000 // everything over two seconds is considered slow
+    showSummary = true
+    showSimpleNames = false
+    showPassed = true
+    showSkipped = true
+    showFailed = true
+    showOnlySlow = false
+    showStandardStreams = false
+    showPassedStandardStreams = true
+    showSkippedStandardStreams = true
+    showFailedStandardStreams = true
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ log4j = "2.23.1"
 jqwik = "1.8.5"
 jqwik-testcontainers = "0.5.2"
 testcontainers-testcontainers = "1.16.2"
+test-logger="4.0.0"
 
 [libraries]
 # S3-related dependencies
@@ -27,6 +28,7 @@ parquet-format = { module = "org.apache.parquet:parquet-format", version.ref = "
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 spotbugs = { module = "com.github.spotbugs.snom:spotbugs-gradle-plugin", version.ref = "spotbugs" }
+test-logger = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "test-logger" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 


### PR DESCRIPTION
### Summary of changes:
This adds integration with [Gradle Test Logger](https://github.com/radarsh/gradle-test-logger-plugin) plugin. It gives a more details on which tests are being run, flags slow tests and outputs more context and color on failures. 

Example of the output (no color):
```
  com.amazon.connector.s3.common.telemetry.DefaultTelemetryTest
       ✔ testMeasureSupplierWithAboveLevel()
       ✔ testFlushAndClose()
       ✔ testMeasureAction()
```

```
com.amazon.connector.s3.S3SdkObjectClientTest

    ✘ testCloseCallsInnerCloseWhenInstructed() (1.3s)

      org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
          at com.amazon.connector.s3.S3SdkObjectClientTest.testCloseCallsInnerCloseWhenInstructed(S3SdkObjectClientTest.java:73)
    ✔ testGetObjectWithRange()
    ✔ testForNullsInConstructor()
    ✔ testConstructorThrowsOnNullArgument()
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
