### PR TITLE
Prepare repo for public by adding dependabot and PR/Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to submit a bug report!
+  - type: markdown
+    attributes:
+      value: |
+        **Note: Security issues should not be reported here.**
+        Please follow the [security policy for this repository](../../CONTRIBUTING.md#security-issue-notifications)).
+  - type: input
+    id: dats3-version
+    attributes:
+      label: Data Accelerator Toolkit for Amazon S3 Version
+      description: |
+        Which version of Data Accelerator Toolkit for Amazon S3 are you using?
+        If you are building from source or a fork, please state that.
+      placeholder: x.y
+    validations:
+      required: true
+  - type: input
+    id: region
+    attributes:
+      label: AWS Region
+      description: Which AWS region did you experience the bug in?
+      placeholder: us-east-1
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Describe the running environment
+      description: |
+        What else can you share about the environment you are running the project in?
+        For example, was this using Amazon EC2? Which type/OS version/architecture?
+      placeholder: Running in EC2 <instance type> on Amazon Linux 2.
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened?
+      description: Please also tell us what you expected to happen.
+      placeholder: A description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: File a feature request. This might be a feature you'd like to see added, or one you'd like to contribute.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to share ideas for new features.
+  - type: textarea
+    id: feature-desc
+    attributes:
+      label: Tell us more about this new feature.
+      placeholder: I would like to see...
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description of change
+
+<!-- Thank you for submitting a pull request!-->
+<!-- Please describe your contribution here. What and why? -->
+<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
+
+Relevant issues: 
+
+<!-- Please add issue numbers. -->
+
+## Does this change impact existing behavior?
+
+<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->
+
+## Testing
+<!-- Please describe how these changes were tested. -->
+
+## Does this change need a changelog entry in any of the crates?
+
+- [ ] I have updated the CHANGELOG or README if appropriate
+
+---
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).


### PR DESCRIPTION
## Description of changes

Adding Issue Templates for Bug Reporting and Feature Requests.
Adding Dependabot configuration
Adding PR template.

## Testing

Please see output templates on the source repo/branch. 
I couldn't find a way to test dependabot.yml. Testing issue have been open since 2022: https://github.com/dependabot/dependabot-core/issues/4605

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
