### PR TITLE
Change default of sequential prefetch base to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Change default of sequential prefetch base to 2.0
 * Added CHANGELOG
 
 ## v0.1 (October 16, 2024)

--- a/input-stream/src/main/java/software/amazon/s3/dataaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/dataaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -37,7 +37,7 @@ public class PhysicalIOConfiguration {
   private static final long DEFAULT_READ_AHEAD_BYTES = 64 * ONE_KB;
   private static final long DEFAULT_MAX_RANGE_SIZE = 8 * ONE_MB;
   private static final long DEFAULT_PART_SIZE = 8 * ONE_MB;
-  private static final double DEFAULT_SEQUENTIAL_PREFETCH_BASE = 4.0;
+  private static final double DEFAULT_SEQUENTIAL_PREFETCH_BASE = 2.0;
   private static final double DEFAULT_SEQUENTIAL_PREFETCH_SPEED = 1.0;
 
   /** Capacity, in blobs. {@link PhysicalIOConfiguration#DEFAULT_CAPACITY_BLOB_STORE} by default. */

--- a/input-stream/src/test/java/software/amazon/s3/dataaccelerator/io/physical/prefetcher/SequentialReadProgressionTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/dataaccelerator/io/physical/prefetcher/SequentialReadProgressionTest.java
@@ -31,8 +31,8 @@ public class SequentialReadProgressionTest {
 
     // When & Then: size is requested for a generation --> size is correct
     assertEquals(2 * ONE_MB, sequentialReadProgression.getSizeForGeneration(0));
-    assertEquals(8 * ONE_MB, sequentialReadProgression.getSizeForGeneration(1));
-    assertEquals(32 * ONE_MB, sequentialReadProgression.getSizeForGeneration(2));
-    assertEquals(128 * ONE_MB, sequentialReadProgression.getSizeForGeneration(3));
+    assertEquals(4 * ONE_MB, sequentialReadProgression.getSizeForGeneration(1));
+    assertEquals(8 * ONE_MB, sequentialReadProgression.getSizeForGeneration(2));
+    assertEquals(16 * ONE_MB, sequentialReadProgression.getSizeForGeneration(3));
   }
 }


### PR DESCRIPTION
## Description of change

We have been suspecting for a while that our sequential prefetching changes are overly aggressive. I managed to confirm this now for both FileIO and S3A.
    
This change makes EQ2 and EQ4 queries regress less on AQBE 100MB 3TB single rowgroup datasets (17% improvement in EQ4, 8% improvement in EQ2) for S3FileIO based on local runs.
    
Additionally, Q80 improved by 4%, other queries stayed within 2% of previous S3 DAT version.
    
Intuitively, the 8MB -> 32MB transition was a bit too aggressive anyway.

#### Relevant issues
- Make fewer queries regress.

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?

No, but changing the default would be customer visible if we had any customers.

#### Does this contribution introduce any new public APIs or behaviors?

No.

#### How was the contribution tested?

- Unit tests
- Local runs with both S3A and S3FileIO on AQBE

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

> By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).