### PR TITLE
Add task publishing to Maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,12 @@
 bin
 build
 
-#Ignore junk and IDE files
+# Ignore junk and IDE files
 .DS_Store
 .gitattributes
 *.iml
 .vscode/
 
 .
+
+gradle.properties

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/RandomAccessReadable.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/RandomAccessReadable.java
@@ -33,6 +33,7 @@ public interface RandomAccessReadable extends Closeable {
    *
    * @param pos the position to read
    * @return an unsigned int representing the byte that was read
+   * @throws IOException if an error occurs while reading the file
    */
   int read(long pos) throws IOException;
 
@@ -44,6 +45,7 @@ public interface RandomAccessReadable extends Closeable {
    * @param len length of data to be read
    * @param pos the position to begin reading from
    * @return the total number of bytes read into the buffer
+   * @throws IOException if an error occurs while reading the file
    */
   int read(byte[] buf, int off, int len, long pos) throws IOException;
 
@@ -55,6 +57,7 @@ public interface RandomAccessReadable extends Closeable {
    * @param off start position in buffer at which data is written
    * @param len the number of bytes to read; the n-th byte should be the last byte of the stream.
    * @return the total number of bytes read into the buffer
+   * @throws IOException if an error occurs while reading the file
    */
   int readTail(byte[] buf, int off, int len) throws IOException;
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/SeekableInputStream.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/SeekableInputStream.java
@@ -54,6 +54,7 @@ public abstract class SeekableInputStream extends InputStream {
    * @param off start position in buffer at which data is written
    * @param n the number of bytes to read; the n-th byte should be the last byte of the stream.
    * @return the total number of bytes read into the buffer
+   * @throws IOException if an error occurs while reading the file
    */
   public abstract int readTail(byte[] buf, int off, int n) throws IOException;
 }


### PR DESCRIPTION
## Description of change
Add task publishing to Maven

#### Relevant issues


#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
- Ran `./graldew publishToMavenLocal` to check only main, sources and javadoc JAR were generated.
- Ran `./gradlew publish` to check that repository was in Stage area in Sonatype.

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).