### PR TITLE
Make signing optional for publishToMavenLocal

### DIFF
--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -256,6 +256,8 @@ java {
     withSourcesJar()
 }
 
+val signingEnabled = project.hasProperty("signingEnabled") && project.property("signingEnabled") == "true"
+
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
@@ -306,5 +308,9 @@ publishing {
 }
 
 signing {
-    sign(publishing.publications["mavenJava"])
+    if (signingEnabled) {
+        sign(publishing.publications["mavenJava"])
+    } else {
+        logger.lifecycle("Signing is disabled because signingEnabled property is either not set or set to false.")
+    }
 }


### PR DESCRIPTION
## Description of change
- Added logic to conditionally enable GPG signing based on the `signingEnabled` property
- Allow contributors to test and publish to local without signing requirements

#### Relevant issues
NA

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Tested the two use case:
* Running `./gradlew publishToMavenLocal` without `gradle.properties` file now succeed.
* Running `./gradlew publish` with `signingEnabled=true` in `gradle.properties` file succeed.

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).