### PR TITLE
Generate custom sources and Javadoc JARs for all sub modules

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("buildlogic.java-library-conventions")
     id("io.freefair.lombok") version "8.10.2"
     `maven-publish`
+    java
 }
 
 dependencies {
@@ -20,4 +21,11 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
+}
+
+tasks.javadoc {
+    options {
+        (this as StandardJavadocDocletOptions).apply {
+            addStringOption("Xdoclint:none", "-quiet")}
+    }
 }

--- a/object-client/build.gradle.kts
+++ b/object-client/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("buildlogic.java-library-conventions")
     id("io.freefair.lombok") version "8.10.2"
     `maven-publish`
+    java
 }
 
 dependencies {
@@ -22,4 +23,11 @@ dependencies {
 
 tasks.test {
     environment("AWS_REGION", "eu-west-1")
+}
+
+tasks.javadoc {
+    options {
+        (this as StandardJavadocDocletOptions).apply {
+            addStringOption("Xdoclint:none", "-quiet")}
+    }
 }


### PR DESCRIPTION
## Description of change
- Changed `customSourcesJar` task to aggregate source files for all sub modules
- Changed `customJavadocJar` task to aggregate javadoc for all sub modules
- 
#### Relevant issues
NA

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Used `./gradlew publishToMavenLocal` to check content of generated source JAR and javadoc JAR.

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).