### PR TITLE
Remove unnecessary Maven publish step

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -120,12 +120,6 @@ jobs:
         run: |
           ./gradlew publishToMavenLocal
 
-      - name: TEMPORARY publish updated versions to local Maven
-        run: |
-          mvn install:install-file -Dfile=input-stream/build/libs/input-stream.jar -DgroupId=com.amazon.connector.s3 -DartifactId=input-stream -Dversion=0.0.1 -Dpackaging=jar -DgeneratePom=true
-          mvn install:install-file -Dfile=object-client/build/libs/object-client.jar -DgroupId=com.amazon.connector.s3 -DartifactId=object-client -Dversion=0.0.1 -Dpackaging=jar -DgeneratePom=true
-          mvn install:install-file -Dfile=common/build/libs/common.jar -DgroupId=com.amazon.connector.s3 -DartifactId=common -Dversion=0.0.1 -Dpackaging=jar -DgeneratePom=true
-
       - name: Setup Iceberg SSH deploy key
         uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -21,8 +21,8 @@ permissions:
       contents: read    # This is required for actions/checkout
 
 jobs:
-  BuildCfS3AndUploadArtifact:
-    name: Build CFS3 artifacts
+  BuildAnalyticsAcceleratorAndUploadArtifact:
+    name: Build library artifacts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
 
       - name: Build and publish to local Maven with Gradle
         run: |
-          ./gradlew publishToMavenLocal
+          ./gradlew -PsnapshotBuild=true publishToMavenLocal 
 
       - name: Setup Iceberg SSH deploy key
         uses: webfactory/ssh-agent@v0.9.0
@@ -155,7 +155,7 @@ jobs:
     name: Upload all artifacts to S3
     runs-on: ubuntu-latest
     needs:
-      - BuildCfS3AndUploadArtifact
+      - BuildAnalyticsAcceleratorAndUploadArtifact
       - BuildHadoopAndUploadArtifact
       - BuildIcebergAndUploadArtifact
     steps:

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -275,7 +275,6 @@ val signingEnabled = project.hasProperty("signingEnabled") && project.property("
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
-
             artifact(tasks["shadowJar"])
             artifact(tasks.named("customSourcesJar"))
             artifact(tasks.named("customJavadocJar"))
@@ -307,9 +306,43 @@ publishing {
                 }
             }
         }
+
+        create<MavenPublication>("snapshot") {
+            artifact(tasks["shadowJar"])
+            artifact(tasks.named("customSourcesJar"))
+            artifact(tasks.named("customJavadocJar"))
+
+            groupId = group
+            artifactId = artefact
+            version = "$currentVersion-SNAPSHOT"
+
+            pom {
+                name = "S3 Analytics Accelerator Library for Amazon S3"
+                description = "S3 Analytics Accelerator Library for Amazon S3"
+                url = "https://github.com/awslabs/analytics-accelerator-s3"
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        organization = "Amazon Web Services"
+                        organizationUrl = "https://aws.amazon.com"
+                    }
+                }
+                scm {
+                    url = "https://github.com/awslabs/analytics-accelerator-s3/tree/main"
+                    connection = "scm:git:ssh://git@github.com:awslabs/analytics-accelerator-s3.git"
+                    developerConnection = "scm:git:ssh://git@github.com:awslabs/analytics-accelerator-s3.git"
+                }
+            }
+        }
     }
+
     repositories {
-        maven{
+        maven {
             name = "sonatype"
             url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
            credentials {

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -281,40 +281,9 @@ publishing {
 
             groupId = group
             artifactId = artefact
-            version = currentVersion
 
-            pom {
-                name = "S3 Analytics Accelerator Library for Amazon S3"
-                description = "S3 Analytics Accelerator Library for Amazon S3"
-                url = "https://github.com/awslabs/analytics-accelerator-s3"
-                licenses {
-                    license {
-                        name = "The Apache License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        organization = "Amazon Web Services"
-                        organizationUrl = "https://aws.amazon.com"
-                    }
-                }
-                scm {
-                    url = "https://github.com/awslabs/analytics-accelerator-s3/tree/main"
-                    connection = "scm:git:ssh://git@github.com:awslabs/analytics-accelerator-s3.git"
-                    developerConnection = "scm:git:ssh://git@github.com:awslabs/analytics-accelerator-s3.git"
-                }
-            }
-        }
-
-        create<MavenPublication>("snapshot") {
-            artifact(tasks["shadowJar"])
-            artifact(tasks.named("customSourcesJar"))
-            artifact(tasks.named("customJavadocJar"))
-
-            groupId = group
-            artifactId = artefact
-            version = "$currentVersion-SNAPSHOT"
+            val isSnapshot = findProperty("snapshotBuild") == "true"
+            version = if (isSnapshot) "SNAPSHOT" else currentVersion;
 
             pom {
                 name = "S3 Analytics Accelerator Library for Amazon S3"


### PR DESCRIPTION
This commit removes a stanza from the workflow that was copying old artefacts (common, input-stream, object-client) into Maven, explicitly via Maven commands.

This should not be needed because we have `publishToMavenLocal` and also we do not generate or publish these artefacts anymore.

## Description of change
<!-- Thank you for submitting a pull request!-->
<!-- Please describe your contribution here. What and why? -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

#### Relevant issues

https://github.com/awslabs/analytics-accelerator-s3/issues/181

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
It will be tested upon push, I have no way to run GitHub automation locally.

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

> By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).