### PR TITLE
Split footer requests into two

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfiguration.java
@@ -15,6 +15,8 @@
  */
 package software.amazon.s3.analyticsaccelerator.io.logical;
 
+import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_GB;
+import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_KB;
 import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
 import lombok.Builder;
@@ -28,8 +30,17 @@ import software.amazon.s3.analyticsaccelerator.util.PrefetchMode;
 @Builder
 @EqualsAndHashCode
 public class LogicalIOConfiguration {
-  private static final boolean DEFAULT_FOOTER_CACHING_ENABLED = true;
-  private static final long DEFAULT_FOOTER_CACHING_SIZE = ONE_MB;
+  private static final boolean DEFAULT_FOOTER_PREFETCH_ENABLED = true;
+  private static final boolean DEFAULT_PAGE_INDEX_PREFETCH_ENABLED = true;
+
+  private static final long DEFAULT_FILE_METADATA_PREFETCH_SIZE = 32 * ONE_KB;
+  private static final long DEFAULT_LARGE_FILE_METADATA_PREFETCH_SIZE = ONE_MB;
+
+  private static final long DEFAULT_FILE_PAGE_INDEX_PREFETCH_SIZE = ONE_MB;
+  private static final long DEFAULT_LARGE_FILE_PAGE_INDEX_PREFETCH_SIZE = 8 * ONE_MB;
+
+  private static final long DEFAULT_LARGE_FILE_SIZE = ONE_GB;
+
   private static final boolean DEFAULT_SMALL_OBJECT_PREFETCHING_ENABLED = true;
   private static final long DEFAULT_SMALL_OBJECT_SIZE_THRESHOLD = 3 * ONE_MB;
   private static final int DEFAULT_PARQUET_METADATA_STORE_SIZE = 45;
@@ -37,13 +48,37 @@ public class LogicalIOConfiguration {
   private static final String DEFAULT_PARQUET_FORMAT_SELECTOR_REGEX = "^.*.(parquet|par)$";
   private static final PrefetchMode DEFAULT_PREFETCHING_MODE = PrefetchMode.ROW_GROUP;
 
-  @Builder.Default private boolean footerCachingEnabled = DEFAULT_FOOTER_CACHING_ENABLED;
+  @Builder.Default private boolean footerPrefetchEnabled = DEFAULT_FOOTER_PREFETCH_ENABLED;
 
-  private static final String FOOTER_CACHING_ENABLED_KEY = "footer.caching.enabled";
+  private static final String FOOTER_PREFETCH_ENABLED_KEY = "footer.prefetch.enabled";
 
-  @Builder.Default private long footerCachingSize = DEFAULT_FOOTER_CACHING_SIZE;
+  @Builder.Default private boolean pageIndexPrefetchEnabled = DEFAULT_PAGE_INDEX_PREFETCH_ENABLED;
 
-  private static final String FOOTER_CACHING_SIZE_KEY = "footer.caching.size";
+  private static final String PAGE_INDEX_PREFETCH_ENABLED_KEY = "page.index.prefetch.enabled";
+
+  @Builder.Default private long fileMetadataPrefetchSize = DEFAULT_FILE_METADATA_PREFETCH_SIZE;
+
+  private static final String FILE_METADATA_PREFETCH_SIZE_KEY = "file.metadata.prefetch.size";
+
+  @Builder.Default
+  private long largeFileMetadataPrefetchSize = DEFAULT_LARGE_FILE_METADATA_PREFETCH_SIZE;
+
+  private static final String LARGE_FILE_METADATA_PREFETCH_SIZE_KEY =
+      "large.file.metadata.prefetch.size";
+
+  @Builder.Default private long filePageIndexPrefetchSize = DEFAULT_FILE_PAGE_INDEX_PREFETCH_SIZE;
+
+  private static final String FILE_PAGE_INDEX_PREFETCH_SIZE_KEY = "file.page.index.prefetch.size";
+
+  @Builder.Default
+  private long largeFilePageIndexPrefetchSize = DEFAULT_LARGE_FILE_PAGE_INDEX_PREFETCH_SIZE;
+
+  private static final String LARGE_FILE_PAGE_INDEX_PREFETCH_SIZE_KEY =
+      "large.file.page.index.prefetch.size";
+
+  @Builder.Default private long largeFileSize = DEFAULT_LARGE_FILE_SIZE;
+
+  private static final String LARGE_FILE_SIZE = "large.file.size";
 
   @Builder.Default
   private boolean smallObjectsPrefetchingEnabled = DEFAULT_SMALL_OBJECT_PREFETCHING_ENABLED;
@@ -85,10 +120,25 @@ public class LogicalIOConfiguration {
    */
   public static LogicalIOConfiguration fromConfiguration(ConnectorConfiguration configuration) {
     return LogicalIOConfiguration.builder()
-        .footerCachingEnabled(
-            configuration.getBoolean(FOOTER_CACHING_ENABLED_KEY, DEFAULT_FOOTER_CACHING_ENABLED))
-        .footerCachingSize(
-            configuration.getLong(FOOTER_CACHING_SIZE_KEY, DEFAULT_FOOTER_CACHING_SIZE))
+        .footerPrefetchEnabled(
+            configuration.getBoolean(FOOTER_PREFETCH_ENABLED_KEY, DEFAULT_FOOTER_PREFETCH_ENABLED))
+        .pageIndexPrefetchEnabled(
+            configuration.getBoolean(
+                PAGE_INDEX_PREFETCH_ENABLED_KEY, DEFAULT_PAGE_INDEX_PREFETCH_ENABLED))
+        .fileMetadataPrefetchSize(
+            configuration.getLong(
+                FILE_METADATA_PREFETCH_SIZE_KEY, DEFAULT_FILE_METADATA_PREFETCH_SIZE))
+        .largeFileMetadataPrefetchSize(
+            configuration.getLong(
+                LARGE_FILE_METADATA_PREFETCH_SIZE_KEY, DEFAULT_LARGE_FILE_METADATA_PREFETCH_SIZE))
+        .filePageIndexPrefetchSize(
+            configuration.getLong(
+                FILE_PAGE_INDEX_PREFETCH_SIZE_KEY, DEFAULT_FILE_PAGE_INDEX_PREFETCH_SIZE))
+        .largeFilePageIndexPrefetchSize(
+            configuration.getLong(
+                LARGE_FILE_PAGE_INDEX_PREFETCH_SIZE_KEY,
+                DEFAULT_LARGE_FILE_PAGE_INDEX_PREFETCH_SIZE))
+        .largeFileSize(configuration.getLong(LARGE_FILE_SIZE, DEFAULT_LARGE_FILE_SIZE))
         .smallObjectsPrefetchingEnabled(
             configuration.getBoolean(
                 SMALL_OBJECTS_PREFETCHING_ENABLED_KEY, DEFAULT_SMALL_OBJECT_PREFETCHING_ENABLED))

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfiguration.java
@@ -32,15 +32,11 @@ import software.amazon.s3.analyticsaccelerator.util.PrefetchMode;
 public class LogicalIOConfiguration {
   private static final boolean DEFAULT_FOOTER_PREFETCH_ENABLED = true;
   private static final boolean DEFAULT_PAGE_INDEX_PREFETCH_ENABLED = true;
-
   private static final long DEFAULT_FILE_METADATA_PREFETCH_SIZE = 32 * ONE_KB;
   private static final long DEFAULT_LARGE_FILE_METADATA_PREFETCH_SIZE = ONE_MB;
-
   private static final long DEFAULT_FILE_PAGE_INDEX_PREFETCH_SIZE = ONE_MB;
   private static final long DEFAULT_LARGE_FILE_PAGE_INDEX_PREFETCH_SIZE = 8 * ONE_MB;
-
   private static final long DEFAULT_LARGE_FILE_SIZE = ONE_GB;
-
   private static final boolean DEFAULT_SMALL_OBJECT_PREFETCHING_ENABLED = true;
   private static final long DEFAULT_SMALL_OBJECT_SIZE_THRESHOLD = 3 * ONE_MB;
   private static final int DEFAULT_PARQUET_METADATA_STORE_SIZE = 45;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetPrefetcher.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetPrefetcher.java
@@ -154,7 +154,7 @@ public class ParquetPrefetcher {
    *     result of this call
    */
   private CompletableFuture<IOPlanExecution> prefetchFooterAndBuildMetadataImpl() {
-    if (logicalIOConfiguration.isFooterCachingEnabled()) {
+    if (logicalIOConfiguration.isFooterPrefetchEnabled()) {
       parquetPrefetchTailTask.prefetchTail();
     }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/FooterPrefetchSize.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/FooterPrefetchSize.java
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package software.amazon.s3.analyticsaccelerator.util;
+package software.amazon.s3.analyticsaccelerator.io.logical.parquet;
 
-/** S3SeekableInputStream constants. */
-public final class Constants {
-  /** Prevent instantiation, this is meant to be a facade */
-  private Constants() {}
+import lombok.Data;
 
-  public static final int ONE_KB = 1024;
-  public static final int ONE_MB = 1024 * 1024;
-  public static final int ONE_GB = 1024 * 1024 * 1024;
-  public static final int PARQUET_MAGIC_STR_LENGTH = 4;
-  public static final int PARQUET_FOOTER_LENGTH_SIZE = 4;
-  public static final long DEFAULT_MIN_ADJACENT_COLUMN_LENGTH = 500 * ONE_KB;
+/** Stores sizes to prefetch for file metadata and page index structures. */
+@Data
+public class FooterPrefetchSize {
+  private final long fileMetadataPrefetchSize;
+  private final long pageIndexPrefetchSize;
+
+  /**
+   * Gets total size of data to be read from the tail of the file
+   *
+   * @return size of file tail read
+   */
+  public long getSize() {
+    return fileMetadataPrefetchSize + pageIndexPrefetchSize;
+  }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTask.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTask.java
@@ -16,7 +16,6 @@
 package software.amazon.s3.analyticsaccelerator.io.logical.parquet;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import lombok.NonNull;
 import org.slf4j.Logger;
@@ -73,10 +72,10 @@ public class ParquetPrefetchTailTask {
         () -> {
           try {
             long contentLength = physicalIO.metadata().getContentLength();
-            Optional<Range> tailRangeOptional =
-                ParquetUtils.getFileTailRange(logicalIOConfiguration, 0, contentLength);
+            List<Range> ranges =
+                ParquetUtils.getFileTailPrefetchRanges(logicalIOConfiguration, 0, contentLength);
+            IOPlan ioPlan = new IOPlan(ranges);
             // Create a non-empty IOPlan only if we have a valid range to work with
-            IOPlan ioPlan = tailRangeOptional.map(IOPlan::new).orElse(IOPlan.EMPTY_PLAN);
             physicalIO.execute(ioPlan);
             return ioPlan.getPrefetchRanges();
           } catch (Exception e) {

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamConfigurationTest.java
@@ -80,8 +80,8 @@ public class S3SeekableInputStreamConfigurationTest {
         S3SeekableInputStreamConfiguration.fromConfiguration(configuration);
 
     assertNotNull(streamConfiguration.getLogicalIOConfiguration());
-    assertFalse(streamConfiguration.getLogicalIOConfiguration().isFooterCachingEnabled());
-    assertEquals(20, streamConfiguration.getLogicalIOConfiguration().getFooterCachingSize());
+    assertFalse(streamConfiguration.getLogicalIOConfiguration().isPageIndexPrefetchEnabled());
+    assertEquals(20, streamConfiguration.getLogicalIOConfiguration().getFileMetadataPrefetchSize());
     // This should be equal to Default since Property Prefix is not s3.connector.
     assertEquals(
         LogicalIOConfiguration.DEFAULT.getPrefetchingMode(),
@@ -108,8 +108,8 @@ public class S3SeekableInputStreamConfigurationTest {
    */
   public static ConnectorConfiguration getConfiguration() {
     Map<String, String> properties = new HashMap<>();
-    properties.put(TEST_PREFIX + "." + LOGICAL_IO_PREFIX + ".footer.caching.enabled", "false");
-    properties.put(TEST_PREFIX + "." + LOGICAL_IO_PREFIX + ".footer.caching.size", "20");
+    properties.put(TEST_PREFIX + "." + LOGICAL_IO_PREFIX + ".page.index.prefetch.enabled", "false");
+    properties.put(TEST_PREFIX + "." + LOGICAL_IO_PREFIX + ".file.metadata.prefetch.size", "20");
     properties.put("invalidPrefix.logicalio.predictive.prefetching.enabled", "false");
     properties.put(TEST_PREFIX + "." + PHYSICAL_IO_PREFIX + ".metadatastore.capacity", "10");
     properties.put(TEST_PREFIX + "." + PHYSICAL_IO_PREFIX + ".blocksizebytes", "20");

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
@@ -63,7 +63,7 @@ public class S3SeekableInputStreamFactoryTest {
             mock(ObjectClient.class),
             S3SeekableInputStreamConfiguration.builder()
                 .logicalIOConfiguration(
-                    LogicalIOConfiguration.builder().footerCachingEnabled(false).build())
+                    LogicalIOConfiguration.builder().footerPrefetchEnabled(false).build())
                 .build());
     S3SeekableInputStream inputStream =
         s3SeekableInputStreamFactory.createStream(S3URI.of("bucket", "key"));
@@ -75,7 +75,7 @@ public class S3SeekableInputStreamFactoryTest {
     S3SeekableInputStreamConfiguration configuration =
         S3SeekableInputStreamConfiguration.builder()
             .logicalIOConfiguration(
-                LogicalIOConfiguration.builder().footerCachingEnabled(false).build())
+                LogicalIOConfiguration.builder().footerPrefetchEnabled(false).build())
             .build();
     S3SeekableInputStreamFactory s3SeekableInputStreamFactory =
         new S3SeekableInputStreamFactory(mock(ObjectClient.class), configuration);
@@ -101,7 +101,7 @@ public class S3SeekableInputStreamFactoryTest {
     S3SeekableInputStreamConfiguration configuration =
         S3SeekableInputStreamConfiguration.builder()
             .logicalIOConfiguration(
-                LogicalIOConfiguration.builder().footerCachingEnabled(false).build())
+                LogicalIOConfiguration.builder().footerPrefetchEnabled(false).build())
             .build();
     S3SeekableInputStreamFactory s3SeekableInputStreamFactory =
         new S3SeekableInputStreamFactory(mock(ObjectClient.class), configuration);

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfigurationTest.java
@@ -34,9 +34,12 @@ public class LogicalIOConfigurationTest {
   @Test
   void testNonDefaults() {
     LogicalIOConfiguration configuration =
-        LogicalIOConfiguration.builder().footerCachingEnabled(true).footerCachingSize(10).build();
-    assertTrue(configuration.isFooterCachingEnabled());
-    assertEquals(10, configuration.getFooterCachingSize());
+        LogicalIOConfiguration.builder()
+            .footerPrefetchEnabled(true)
+            .filePageIndexPrefetchSize(10)
+            .build();
+    assertTrue(configuration.isFooterPrefetchEnabled());
+    assertEquals(10, configuration.getFilePageIndexPrefetchSize());
   }
 
   @Test
@@ -48,8 +51,8 @@ public class LogicalIOConfigurationTest {
     LogicalIOConfiguration logicalIOConfiguration =
         LogicalIOConfiguration.fromConfiguration(mappedConfiguration);
 
-    assertFalse(logicalIOConfiguration.isFooterCachingEnabled());
-    assertEquals(20, logicalIOConfiguration.getFooterCachingSize());
+    assertFalse(logicalIOConfiguration.isPageIndexPrefetchEnabled());
+    assertEquals(20, logicalIOConfiguration.getFileMetadataPrefetchSize());
     // This should be equal to Default since Property Prefix is not s3.connector.
     assertEquals(
         LogicalIOConfiguration.DEFAULT.getPrefetchingMode(),

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -98,7 +98,7 @@ public class ParquetLogicalIOImplTest {
     PhysicalIO physicalIO = mock(PhysicalIO.class);
     LogicalIOConfiguration configuration =
         LogicalIOConfiguration.builder()
-            .footerCachingEnabled(false)
+            .footerPrefetchEnabled(false)
             .prefetchingMode(PrefetchMode.OFF)
             .build();
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetPrefetcherTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetPrefetcherTest.java
@@ -392,7 +392,7 @@ public class ParquetPrefetcherTest {
   public void testConfigurationsPrefetchFooterAndBuildMetadataFooterCachingDisabled() {
     // Given: config with footer caching disabled
     LogicalIOConfiguration logicalIOConfiguration =
-        LogicalIOConfiguration.builder().footerCachingEnabled(false).build();
+        LogicalIOConfiguration.builder().footerPrefetchEnabled(false).build();
 
     ParquetPrefetchTailTask parquetPrefetchTailTask = mock(ParquetPrefetchTailTask.class);
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTaskTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTaskTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
@@ -86,7 +87,8 @@ public class ParquetPrefetchTailTaskTest {
         getPrefetchRangeList(
             configuration.getFileMetadataPrefetchSize(),
             configuration.getFilePageIndexPrefetchSize(),
-            configuration.getSmallObjectSizeThreshold());
+            configuration.getSmallObjectSizeThreshold(),
+            5L * configuration.getLargeFileSize());
 
     for (Map.Entry<Long, List<Range>> contentLengthToRangeList : contentSizeToRanges.entrySet()) {
       PhysicalIOImpl mockedPhysicalIO = mock(PhysicalIOImpl.class);
@@ -124,7 +126,7 @@ public class ParquetPrefetchTailTaskTest {
   }
 
   private HashMap<Long, List<Range>> getPrefetchRangeList(
-      long footerSize, long pageIndexSize, long smallFileSize) {
+      long footerSize, long pageIndexSize, long smallFileSize, long largeFileSize) {
     return new HashMap<Long, List<Range>>() {
       {
         put(
@@ -164,6 +166,14 @@ public class ParquetPrefetchTailTaskTest {
                     new Range(
                         smallFileSize + 10 - footerSize - pageIndexSize,
                         smallFileSize + 10 - footerSize - 1));
+              }
+            });
+        put(
+            largeFileSize,
+            new ArrayList<Range>() {
+              {
+                add(new Range(largeFileSize - ONE_MB, largeFileSize - 1));
+                add(new Range(largeFileSize - ONE_MB - (8 * ONE_MB), largeFileSize - ONE_MB - 1));
               }
             });
       }


### PR DESCRIPTION
## Description of change

Previously, we were making a single 1MB request for the tail of the file. 

This 1MB was chosen as it was big enough to contain the fileMetadata + pageIndex structures for most file sizes. 

However for larger files, this 1MB is not enough. Further, the fileMetadata is ALWAYS required first and is much smaller than the the pageIndex data. To help with this, this PR:

* Splits the request into two. One smaller prefetch request for the fileMetadata only, and another larger prefetch request for the pageIndex structures.
* Introduces new configs that can be used to set prefetch request sizes for these file sizes.
* Renames some existing configs to better suit their purposed (footerCachingEnabled becomes footerPrefetchEnabled). 
* Adds config for pageIndex prefetching, as this data is not always required, depending on the engine. 

#### Relevant issues

N/A

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?

It renames footerCachingEnabled to footerPrefetchEnabled, to better suit it's purpose. I do not believe this has any impact currently. 

#### Does this contribution introduce any new public APIs or behaviors?

N/A

#### How was the contribution tested?

Ran unit tests, and with in proc Spark application to test requests are split correctly.

#### Does this contribution need a changelog entry?
- [X] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).