### PR TITLE
Prefetch dictionaries and column data separately

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetPrefetcher.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetPrefetcher.java
@@ -180,7 +180,7 @@ public class ParquetPrefetcher {
       return columnMappersCompletableFuture.thenApply(
           (ColumnMappers columnMappers) ->
               parquetPredictivePrefetchingTask.prefetchRecentColumns(
-                  columnMappers, ParquetUtils.constructRowGroupsToPrefetch()));
+                  columnMappers, ParquetUtils.constructRowGroupsToPrefetch(), false));
     }
 
     return CompletableFuture.completedFuture(

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ColumnMetadata.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ColumnMetadata.java
@@ -22,6 +22,8 @@ import lombok.Data;
 public class ColumnMetadata {
   private final int rowGroupIndex;
   private final String columnName;
+  private final long dataPageOffset;
+  private final long dictionaryOffset;
   private final long startPos;
   private final long compressedSize;
   private final int schemaHash;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetMetadataParsingTask.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetMetadataParsingTask.java
@@ -109,6 +109,8 @@ public class ParquetMetadataParsingTask {
               new ColumnMetadata(
                   rowGroupIndex,
                   columnName,
+                  columnChunk.getMeta_data().getData_page_offset(),
+                  columnChunk.getMeta_data().getDictionary_page_offset(),
                   columnChunk.getMeta_data().getDictionary_page_offset(),
                   columnChunk.getMeta_data().getTotal_compressed_size(),
                   concatenatedColumnNames.hashCode());
@@ -122,6 +124,8 @@ public class ParquetMetadataParsingTask {
               new ColumnMetadata(
                   rowGroupIndex,
                   columnName,
+                  columnChunk.getMeta_data().getData_page_offset(),
+                  0,
                   columnChunk.getFile_offset(),
                   columnChunk.getMeta_data().getTotal_compressed_size(),
                   concatenatedColumnNames.hashCode());

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTask.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTask.java
@@ -116,16 +116,26 @@ public class ParquetPredictivePrefetchingTask {
   public List<ColumnMetadata> addToRecentColumnList(long position, int len) {
     if (parquetColumnPrefetchStore.getColumnMappers(s3Uri) != null) {
       ColumnMappers columnMappers = parquetColumnPrefetchStore.getColumnMappers(s3Uri);
+      List<ColumnMetadata> addedColumns = new ArrayList<>();
+
       if (columnMappers.getOffsetIndexToColumnMap().containsKey(position)) {
         ColumnMetadata columnMetadata = columnMappers.getOffsetIndexToColumnMap().get(position);
-        parquetColumnPrefetchStore.addRecentColumn(columnMetadata);
-        // Maybe prefetch all recent columns for the current row group, if they have not been
-        // prefetched already.
-        prefetchCurrentRowGroup(columnMappers, columnMetadata);
 
-        List<ColumnMetadata> addedColumns =
-            addAdjacentColumnsInLength(columnMetadata, columnMappers, position, len);
-        addedColumns.add(columnMetadata);
+        // If the column has a dictionary and the length of the read is <= the size of the dictionary, then assume current read is for a dictionary only.
+        if (columnMetadata.getDictionaryOffset() != 0 && len <= (columnMetadata.getDataPageOffset() - columnMetadata.getDictionaryOffset())) {
+          parquetColumnPrefetchStore.addRecentDictionary(columnMetadata);
+          prefetchDictionariesForCurrentRowGroup(columnMappers, columnMetadata);
+          addedColumns.add(columnMetadata);
+        } else {
+          parquetColumnPrefetchStore.addRecentColumn(columnMetadata);
+          // Maybe prefetch all recent columns for the current row group, if they have not been
+          // prefetched already.
+          prefetchColumnsForCurrentRowGroup(columnMappers, columnMetadata);
+
+          addedColumns =
+              addAdjacentColumnsInLength(columnMetadata, columnMappers, position, len);
+          addedColumns.add(columnMetadata);
+        }
 
         return addedColumns;
       } else if (len > DEFAULT_MIN_ADJACENT_COLUMN_LENGTH) {
@@ -144,6 +154,15 @@ public class ParquetPredictivePrefetchingTask {
     return Collections.emptyList();
   }
 
+
+  private void prefetchDictionariesForCurrentRowGroup(ColumnMappers columnMappers, ColumnMetadata columnMetadata) {
+    if (logicalIOConfiguration.getPrefetchingMode() == PrefetchMode.ROW_GROUP &&
+        !parquetColumnPrefetchStore.isDictionaryRowGroupPrefetched(s3Uri, columnMetadata.getRowGroupIndex())) {
+      prefetchRecentColumns(columnMappers, ParquetUtils.constructRowGroupsToPrefetch(columnMetadata), true);
+      parquetColumnPrefetchStore.storeDictionaryPrefetchedRowGroupIndex(s3Uri, columnMetadata.getRowGroupIndex());
+    }
+  }
+
   /**
    * When PrefetchMode is ROW_GROUP, only prefetch recent columns when a read to a column is
    * detected, and NOT on an open of the file. For prefetching, only prefetch recent columns that
@@ -154,15 +173,13 @@ public class ParquetPredictivePrefetchingTask {
    * @param columnMappers Parquet file column mappings
    * @param columnMetadata Column metadata of the current column being read
    */
-  private void prefetchCurrentRowGroup(ColumnMappers columnMappers, ColumnMetadata columnMetadata) {
+  private void prefetchColumnsForCurrentRowGroup(ColumnMappers columnMappers, ColumnMetadata columnMetadata) {
     // When prefetch mode is per row group, only prefetch columns from the current row group.
     if (logicalIOConfiguration.getPrefetchingMode() == PrefetchMode.ROW_GROUP
-        && !parquetColumnPrefetchStore.isRowGroupPrefetched(
-            s3Uri, columnMetadata.getRowGroupIndex())) {
+        && !parquetColumnPrefetchStore.isColumnRowGroupPrefetched(s3Uri, columnMetadata.getRowGroupIndex())) {
       prefetchRecentColumns(
-          columnMappers, ParquetUtils.constructRowGroupsToPrefetch(columnMetadata));
-      parquetColumnPrefetchStore.storePrefetchedRowGroupIndex(
-          s3Uri, columnMetadata.getRowGroupIndex());
+          columnMappers, ParquetUtils.constructRowGroupsToPrefetch(columnMetadata), false);
+      parquetColumnPrefetchStore.storeColumnPrefetchedRowGroupIndex(s3Uri, columnMetadata.getRowGroupIndex());
     }
   }
 
@@ -174,7 +191,7 @@ public class ParquetPredictivePrefetchingTask {
    * @return ranges prefetched
    */
   public IOPlanExecution prefetchRecentColumns(
-      ColumnMappers columnMappers, List<Integer> rowGroupsToPrefetch) {
+      ColumnMappers columnMappers, List<Integer> rowGroupsToPrefetch, Boolean isDictionary) {
     return telemetry.measureStandard(
         () ->
             Operation.builder()
@@ -184,21 +201,36 @@ public class ParquetPredictivePrefetchingTask {
         () -> {
           try {
             List<Range> prefetchRanges = new ArrayList<>();
+
             for (String recentColumn :
-                getRecentColumns(columnMappers.getOffsetIndexToColumnMap())) {
+                getRecentColumns(columnMappers.getOffsetIndexToColumnMap(), isDictionary)) {
               if (columnMappers.getColumnNameToColumnMap().containsKey(recentColumn)) {
-                LOG.debug(
-                    "Column {} found in schema for {}, adding to prefetch list",
-                    recentColumn,
-                    this.s3Uri.getKey());
                 List<ColumnMetadata> columnMetadataList =
                     columnMappers.getColumnNameToColumnMap().get(recentColumn);
                 for (ColumnMetadata columnMetadata : columnMetadataList) {
                   if (rowGroupsToPrefetch.contains(columnMetadata.getRowGroupIndex())) {
-                    prefetchRanges.add(
-                        new Range(
-                            columnMetadata.getStartPos(),
-                            columnMetadata.getStartPos() + columnMetadata.getCompressedSize() - 1));
+                    if (isDictionary && columnMetadata.getDictionaryOffset() != 0) {
+                      prefetchRanges.add(
+                          new Range(
+                              columnMetadata.getDictionaryOffset(),
+                              columnMetadata.getDictionaryOffset() + (columnMetadata.getDataPageOffset() - columnMetadata.getDictionaryOffset() - 1))
+                      );
+                      LOG.info(
+                          "Column dictionary {} found in schema for {}, and rowGroupIndex {}, adding to prefetch list",
+                          recentColumn,
+                          this.s3Uri.getKey(),
+                          columnMetadata.getRowGroupIndex());
+                    } else {
+                      prefetchRanges.add(
+                          new Range(
+                              columnMetadata.getStartPos(),
+                              columnMetadata.getStartPos() + columnMetadata.getCompressedSize() - 1));
+                      LOG.info(
+                          "Column {} found in schema for {}, and rowGroupIndex {}, adding to prefetch list",
+                          recentColumn,
+                          this.s3Uri.getKey(),
+                          columnMetadata.getRowGroupIndex());
+                    }
                   }
                 }
               }
@@ -306,13 +338,18 @@ public class ParquetPredictivePrefetchingTask {
     return addedColumns;
   }
 
-  private Set<String> getRecentColumns(Map<Long, ColumnMetadata> offsetIndexToColumnMap) {
+  private Set<String> getRecentColumns(Map<Long, ColumnMetadata> offsetIndexToColumnMap, boolean isDictionary) {
     if (!offsetIndexToColumnMap.isEmpty()) {
       Map.Entry<Long, ColumnMetadata> firstColumnData =
           offsetIndexToColumnMap.entrySet().iterator().next();
 
       int schemaHash = firstColumnData.getValue().getSchemaHash();
-      return parquetColumnPrefetchStore.getUniqueRecentColumnsForSchema(schemaHash);
+
+      if (isDictionary) {
+        return parquetColumnPrefetchStore.getUniqueRecentDictionaryForSchema(schemaHash);
+      } else {
+        return parquetColumnPrefetchStore.getUniqueRecentColumnsForSchema(schemaHash);
+      }
     }
 
     return Collections.emptySet();

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetPrefetcherTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetPrefetcherTest.java
@@ -17,6 +17,7 @@ package software.amazon.s3.analyticsaccelerator.io.logical.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -319,7 +320,7 @@ public class ParquetPrefetcherTest {
     verify(parquetMetadataParsingTask, times(1)).storeColumnMappers(any(FileTail.class));
     // Then: predictive reads are also triggered
     verify(parquetPredictivePrefetchingTask, times(1))
-        .prefetchRecentColumns(any(ColumnMappers.class), anyList());
+        .prefetchRecentColumns(any(ColumnMappers.class), anyList(), anyBoolean());
   }
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchRemainingColumnTaskTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchRemainingColumnTaskTest.java
@@ -98,7 +98,8 @@ public class ParquetPrefetchRemainingColumnTaskTest {
     HashMap<Long, ColumnMetadata> offsetIndexToColumnMap = new HashMap<>();
     offsetIndexToColumnMap.put(
         200L,
-        new ColumnMetadata(0, "ss_sold_date_sk", 200, 10 * ONE_MB, "ss_sold_date_sk".hashCode()));
+        new ColumnMetadata(
+            0, "ss_sold_date_sk", 2 * ONE_MB, 200, 200, 10 * ONE_MB, "ss_sold_date_sk".hashCode()));
 
     ParquetColumnPrefetchStore mockedParquetColumnPrefetchStore =
         mock(ParquetColumnPrefetchStore.class);
@@ -128,7 +129,8 @@ public class ParquetPrefetchRemainingColumnTaskTest {
     HashMap<Long, ColumnMetadata> offsetIndexToColumnMap = new HashMap<>();
     offsetIndexToColumnMap.put(
         200L,
-        new ColumnMetadata(0, "ss_sold_date_sk", 200, 10 * ONE_MB, "ss_sold_date_sk".hashCode()));
+        new ColumnMetadata(
+            0, "ss_sold_date_sk", 5 * ONE_MB, 200, 200, 10 * ONE_MB, "ss_sold_date_sk".hashCode()));
 
     ParquetColumnPrefetchStore mockedParquetColumnPrefetchStore =
         mock(ParquetColumnPrefetchStore.class);


### PR DESCRIPTION
## Description of change

Highly selective queries, may only want to read the dictionaries, and only when the predicate matches, prefetch columns.

Previously, we were prefetching entire column chunks which was leading us to prefetch more data required. This PR tracks two different lists

1/ Recently read dictionaries
2/ Recently read columns

For queries like `select a, b, c from ss where c = 124`, we would always want to read the dictionary for c, but may not need column data for a, b and c, if the predicate does not match. With this change, we only prefetch column data a,b,c when reading for columns actually starts. 

That is, when the query engine reads the first column, say a, we will prefetch b and c. 

#### Relevant issues

See https://github.com/awslabs/analytics-accelerator-s3/issues/173 for more details

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?

No

#### Does this contribution introduce any new public APIs or behaviors?

No

#### How was the contribution tested?

Tested with local Spark runs against a TPC-DS dataset. 

#### Does this contribution need a changelog entry?
- [X] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).