### PR TITLE
Add support to seek beyond end of stream

### DIFF
--- a/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/InMemoryS3SeekableInputStream.java
+++ b/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/InMemoryS3SeekableInputStream.java
@@ -111,4 +111,9 @@ public class InMemoryS3SeekableInputStream extends SeekableInputStream {
   public int read() throws IOException {
     return this.delegate.read();
   }
+
+  @Override
+  public void close() throws IOException {
+    this.delegate.close();
+  }
 }

--- a/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/SeekableStreamPropertiesTest.java
+++ b/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/SeekableStreamPropertiesTest.java
@@ -43,10 +43,8 @@ public class SeekableStreamPropertiesTest extends StreamArbitraries {
       throws IOException {
     try (InMemoryS3SeekableInputStream s =
         new InMemoryS3SeekableInputStream("test-bucket", "test-key", size)) {
-
-      int jumpInSideObject = pos % size;
-      s.seek(jumpInSideObject);
-      return s.getPos() == jumpInSideObject;
+      s.seek(pos);
+      return s.getPos() == pos;
     }
   }
 
@@ -77,6 +75,7 @@ public class SeekableStreamPropertiesTest extends StreamArbitraries {
     }
   }
 
+
   @Property
   void canCloseStreamMultipleTimes(@ForAll("streamSizes") int size) throws IOException {
     InMemoryS3SeekableInputStream s =
@@ -84,4 +83,14 @@ public class SeekableStreamPropertiesTest extends StreamArbitraries {
     s.close();
     s.close();
   }
+
+  @Property
+  void accessToClosedStreamThrows(@ForAll("streamSizes") int size) throws IOException {
+    InMemoryS3SeekableInputStream s =
+            new InMemoryS3SeekableInputStream("test-bucket", "test-key", size);
+      s.close();
+      assertThrows(IOException.class, () -> s.seek(123));
+      assertThrows(IOException.class, () -> s.read());
+  }
+
 }

--- a/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/SeekableStreamPropertiesTest.java
+++ b/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/SeekableStreamPropertiesTest.java
@@ -75,7 +75,6 @@ public class SeekableStreamPropertiesTest extends StreamArbitraries {
     }
   }
 
-
   @Property
   void canCloseStreamMultipleTimes(@ForAll("streamSizes") int size) throws IOException {
     InMemoryS3SeekableInputStream s =
@@ -87,10 +86,9 @@ public class SeekableStreamPropertiesTest extends StreamArbitraries {
   @Property
   void accessToClosedStreamThrows(@ForAll("streamSizes") int size) throws IOException {
     InMemoryS3SeekableInputStream s =
-            new InMemoryS3SeekableInputStream("test-bucket", "test-key", size);
-      s.close();
-      assertThrows(IOException.class, () -> s.seek(123));
-      assertThrows(IOException.class, () -> s.read());
+        new InMemoryS3SeekableInputStream("test-bucket", "test-key", size);
+    s.close();
+    assertThrows(IOException.class, () -> s.seek(123));
+    assertThrows(IOException.class, () -> s.read());
   }
-
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -404,9 +404,12 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     S3SeekableInputStream seekableInputStream = getTestStream();
     seekableInputStream.close();
     SpotBugsLambdaWorkaround.assertReadResult(IOException.class, seekableInputStream::read, -1);
-    SpotBugsLambdaWorkaround.assertReadResult(IOException.class, () -> seekableInputStream.read(new byte[8]), -1);
-    SpotBugsLambdaWorkaround.assertReadResult(IOException.class, () -> seekableInputStream.read(new byte[8], 0, 8), -1);
-    SpotBugsLambdaWorkaround.assertReadResult(IOException.class, () -> seekableInputStream.readTail(new byte[8], 0, 8), -1);
+    SpotBugsLambdaWorkaround.assertReadResult(
+        IOException.class, () -> seekableInputStream.read(new byte[8]), -1);
+    SpotBugsLambdaWorkaround.assertReadResult(
+        IOException.class, () -> seekableInputStream.read(new byte[8], 0, 8), -1);
+    SpotBugsLambdaWorkaround.assertReadResult(
+        IOException.class, () -> seekableInputStream.readTail(new byte[8], 0, 8), -1);
   }
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -142,13 +141,12 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
 
   @Test
   void testSeekAfterEnd() throws IOException {
-    // Given
-    try (S3SeekableInputStream stream =
-        new S3SeekableInputStream(TEST_URI, fakeLogicalIO, TestTelemetry.DEFAULT)) {
-
-      // When: we seek past EOF we get EOFException
-      assertThrows(EOFException.class, () -> stream.seek(TEST_DATA.length() + 1));
-    }
+    S3SeekableInputStream stream = getTestStream();
+    assertDoesNotThrow(() -> stream.seek(Long.MAX_VALUE));
+    assertDoesNotThrow(() -> stream.seek(TEST_DATA.length()));
+    assertEquals(TEST_DATA.length(), stream.getPos());
+    assertDoesNotThrow(() -> stream.seek(TEST_DATA.length() + 10));
+    assertEquals(TEST_DATA.length() + 10, stream.getPos());
   }
 
   @Test
@@ -168,11 +166,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   void testInvalidSeek() throws IOException {
     // Given
     try (S3SeekableInputStream stream = getTestStream()) {
-
       // When: seek is to an invalid position then exception is thrown
-      assertThrows(Exception.class, () -> stream.seek(TEST_DATA.length()));
-      assertThrows(Exception.class, () -> stream.seek(TEST_DATA.length() + 10));
-      assertThrows(Exception.class, () -> stream.seek(Long.MAX_VALUE));
       assertThrows(Exception.class, () -> stream.seek(-1));
       assertThrows(Exception.class, () -> stream.seek(Long.MIN_VALUE));
     }
@@ -403,6 +397,23 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     if (thrown.get() != null) {
       fail("Unexpected exception", thrown.get());
     }
+  }
+
+  @Test
+  public void testReadOnClosedStream() throws IOException {
+    S3SeekableInputStream seekableInputStream = getTestStream();
+    seekableInputStream.close();
+    assertThrows(IOException.class, seekableInputStream::read);
+    assertThrows(IOException.class, () -> seekableInputStream.read(new byte[8]));
+    assertThrows(IOException.class, () -> seekableInputStream.read(new byte[8], 0, 8));
+    assertThrows(IOException.class, () -> seekableInputStream.readTail(new byte[8], 0, 8));
+  }
+
+  @Test
+  public void testSeekOnClosedStream() throws IOException {
+    S3SeekableInputStream seekableInputStream = getTestStream();
+    seekableInputStream.close();
+    assertThrows(IOException.class, () -> seekableInputStream.seek(0));
   }
 
   private S3SeekableInputStream getTestStream() {

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -403,10 +403,10 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   public void testReadOnClosedStream() throws IOException {
     S3SeekableInputStream seekableInputStream = getTestStream();
     seekableInputStream.close();
-    assertThrows(IOException.class, seekableInputStream::read);
-    assertThrows(IOException.class, () -> seekableInputStream.read(new byte[8]));
-    assertThrows(IOException.class, () -> seekableInputStream.read(new byte[8], 0, 8));
-    assertThrows(IOException.class, () -> seekableInputStream.readTail(new byte[8], 0, 8));
+    SpotBugsLambdaWorkaround.assertReadResult(IOException.class, seekableInputStream::read, -1);
+    SpotBugsLambdaWorkaround.assertReadResult(IOException.class, () -> seekableInputStream.read(new byte[8]), -1);
+    SpotBugsLambdaWorkaround.assertReadResult(IOException.class, () -> seekableInputStream.read(new byte[8], 0, 8), -1);
+    SpotBugsLambdaWorkaround.assertReadResult(IOException.class, () -> seekableInputStream.readTail(new byte[8], 0, 8), -1);
   }
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/SpotBugsLambdaWorkaround.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/SpotBugsLambdaWorkaround.java
@@ -49,18 +49,18 @@ public final class SpotBugsLambdaWorkaround {
     fail(String.format("Exception of type '%s' was expected. Nothing was thrown", expectedType));
   }
 
-
   /**
-   * In situations where a read method of a class extending InputStream, spotbugs wants to
-   * assert return value is checked (@link https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html).
+   * In situations where a read method of a class extending InputStream, spotbugs wants to assert
+   * return value is checked (@link https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html).
    *
    * @param expectedType exception type expected
    * @param executable code that returns something, and expected to throw
+   * @param expected expected return value, though will never be executed as executable is throwing
    * @param <T> exception type
    * @param <R> return type
    */
-  public static <T extends Throwable, R> void assertReadResult (
-          Class<T> expectedType, ThrowingSupplier<R> executable, R expected) {
+  public static <T extends Throwable, R> void assertReadResult(
+      Class<T> expectedType, ThrowingSupplier<R> executable, R expected) {
     try {
       R result = executable.get();
       assertEquals(expected, result);

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/SpotBugsLambdaWorkaround.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/SpotBugsLambdaWorkaround.java
@@ -48,4 +48,26 @@ public final class SpotBugsLambdaWorkaround {
     }
     fail(String.format("Exception of type '%s' was expected. Nothing was thrown", expectedType));
   }
+
+
+  /**
+   * In situations where a read method of a class extending InputStream, spotbugs wants to
+   * assert return value is checked (@link https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html).
+   *
+   * @param expectedType exception type expected
+   * @param executable code that returns something, and expected to throw
+   * @param <T> exception type
+   * @param <R> return type
+   */
+  public static <T extends Throwable, R> void assertReadResult (
+          Class<T> expectedType, ThrowingSupplier<R> executable, R expected) {
+    try {
+      R result = executable.get();
+      assertEquals(expected, result);
+    } catch (Throwable throwable) {
+      assertInstanceOf(expectedType, throwable);
+      return;
+    }
+    fail(String.format("Exception of type '%s' was expected. Nothing was thrown", expectedType));
+  }
 }


### PR DESCRIPTION
## Description of change
This pull request adds support to seek beyond stream end. 
Since seek is done lazily this is the correct behaviour. It also adds closed checks to read operations.

With this PR, we are reconciling S3SeekableStream behaviour with its' documentation. 

#### Relevant issues
[Issue#83 ](https://github.com/awslabs/analytics-accelerator-s3/issues/83)

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
Yes. Seek will no longer Throw EOF exception when position to seek is > contentLength.

#### Does this contribution introduce any new public APIs or behaviors?
Yes, Seek to beyond stream end will no longer throw. Read/Seek operations on closed stream will throw. 


#### How was the contribution tested?
Added new unit tests and property based tests. Removed %size from `seekChangesPosition` property tests to ensure validSizes can go beyond stream size. 

#### Does this contribution need a changelog entry?
- [X] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).