### PR TITLE
A few minor optimisations 

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Optional;
 import lombok.Getter;
 import lombok.NonNull;
+import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIO;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.DefaultLogicalIOImpl;
@@ -94,13 +95,17 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
    * Create an instance of S3SeekableInputStream with provided metadata.
    *
    * @param s3URI the object's S3 URI
-   * @param objectMetadata object metadata
+   * @param contentLength content length
    * @return An instance of the input stream.
    */
-  public S3SeekableInputStream createStream(
-      @NonNull S3URI s3URI, @NonNull ObjectMetadata objectMetadata) {
+  public S3SeekableInputStream createStream(@NonNull S3URI s3URI, long contentLength) {
+    Preconditions.checkArgument(contentLength >= 0, "`len` must be non-negative");
+
     return new S3SeekableInputStream(
-        s3URI, createLogicalIO(s3URI, Optional.of(objectMetadata)), telemetry);
+        s3URI,
+        createLogicalIO(
+            s3URI, Optional.of(ObjectMetadata.builder().contentLength(contentLength).build())),
+        telemetry);
   }
 
   LogicalIO createLogicalIO(S3URI s3URI, Optional<ObjectMetadata> objectMetadata) {

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTask.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTask.java
@@ -207,7 +207,10 @@ public class ParquetPredictivePrefetchingTask {
                 .build(),
         () -> {
           try {
-            List<Range> prefetchRanges = new ArrayList<>();
+            // Ranges for dictionary data only
+            List<Range> dictionaryRanges = new ArrayList<>();
+            // Ranges for column data
+            List<Range> columnRanges = new ArrayList<>();
 
             for (String recentColumn :
                 getRecentColumns(columnMappers.getOffsetIndexToColumnMap(), isDictionary)) {
@@ -220,7 +223,7 @@ public class ParquetPredictivePrefetchingTask {
                     // bytes for the columns. This prevents over-reading for highly selective
                     // queries, as we prefetch column data only if the predicate matches.
                     if (isDictionary && columnMetadata.getDictionaryOffset() != 0) {
-                      prefetchRanges.add(
+                      dictionaryRanges.add(
                           new Range(
                               columnMetadata.getDictionaryOffset(),
                               columnMetadata.getDictionaryOffset()
@@ -233,7 +236,7 @@ public class ParquetPredictivePrefetchingTask {
                           this.s3Uri.getKey(),
                           columnMetadata.getRowGroupIndex());
                     } else {
-                      prefetchRanges.add(
+                      columnRanges.add(
                           new Range(
                               columnMetadata.getStartPos(),
                               columnMetadata.getStartPos()
@@ -250,9 +253,13 @@ public class ParquetPredictivePrefetchingTask {
               }
             }
 
-            IOPlan ioPlan =
-                (prefetchRanges.isEmpty()) ? IOPlan.EMPTY_PLAN : new IOPlan(prefetchRanges);
-            return physicalIO.execute(ioPlan);
+            IOPlan dictionaryIoPlan =
+                (dictionaryRanges.isEmpty()) ? IOPlan.EMPTY_PLAN : new IOPlan(dictionaryRanges);
+            physicalIO.execute(dictionaryIoPlan);
+
+            IOPlan columnIoPlan =
+                (columnRanges.isEmpty()) ? IOPlan.EMPTY_PLAN : new IOPlan(columnRanges);
+            return physicalIO.execute(columnIoPlan);
           } catch (Throwable t) {
             LOG.warn("Unable to prefetch columns for {}.", this.s3Uri.getKey(), t);
             return IOPlanExecution.builder().state(IOPlanState.SKIPPED).build();

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTask.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTask.java
@@ -230,7 +230,7 @@ public class ParquetPredictivePrefetchingTask {
                                   + (columnMetadata.getDataPageOffset()
                                       - columnMetadata.getDictionaryOffset()
                                       - 1)));
-                      LOG.info(
+                      LOG.debug(
                           "Column dictionary {} found in schema for {}, and rowGroupIndex {}, adding to prefetch list",
                           recentColumn,
                           this.s3Uri.getKey(),
@@ -242,7 +242,7 @@ public class ParquetPredictivePrefetchingTask {
                               columnMetadata.getStartPos()
                                   + columnMetadata.getCompressedSize()
                                   - 1));
-                      LOG.info(
+                      LOG.debug(
                           "Column {} found in schema for {}, and rowGroupIndex {}, adding to prefetch list",
                           recentColumn,
                           this.s3Uri.getKey(),
@@ -258,7 +258,9 @@ public class ParquetPredictivePrefetchingTask {
             physicalIO.execute(dictionaryIoPlan);
 
             IOPlan columnIoPlan =
-                (columnRanges.isEmpty()) ? IOPlan.EMPTY_PLAN : new IOPlan(columnRanges);
+                (columnRanges.isEmpty())
+                    ? IOPlan.EMPTY_PLAN
+                    : new IOPlan(ParquetUtils.mergeRanges(columnRanges));
             return physicalIO.execute(columnIoPlan);
           } catch (Throwable t) {
             LOG.warn("Unable to prefetch columns for {}.", this.s3Uri.getKey(), t);

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -137,9 +137,12 @@ public class BlockManager implements Closeable {
     // effectiveEnd of the requested range
     long effectiveEnd = pos + Math.max(len, configuration.getReadAheadBytes()) - 1;
 
-    // Check sequential prefetching
+    // Check sequential prefetching. If read mode is ASYNC, that is the request is from the parquet
+    // prefetch path, then do not extend the request.
+    // TODO: Improve readModes, as tracked in
+    // https://github.com/awslabs/analytics-accelerator-s3/issues/195
     final long generation;
-    if (patternDetector.isSequentialRead(pos)) {
+    if (readMode != ReadMode.ASYNC && patternDetector.isSequentialRead(pos)) {
       generation = patternDetector.getGeneration(pos);
       effectiveEnd =
           Math.max(

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
@@ -16,6 +16,7 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.impl;
 
 import java.io.IOException;
+import java.util.Optional;
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Operation;
@@ -35,6 +36,7 @@ public class PhysicalIOImpl implements PhysicalIO {
   private final MetadataStore metadataStore;
   private final BlobStore blobStore;
   private final Telemetry telemetry;
+  private final Optional<ObjectMetadata> objectMetadata;
 
   private final long physicalIOBirth = System.nanoTime();
 
@@ -50,16 +52,19 @@ public class PhysicalIOImpl implements PhysicalIO {
    * @param metadataStore a metadata cache
    * @param blobStore a data cache
    * @param telemetry The {@link Telemetry} to use to report measurements.
+   * @param objectMetadata object metadata
    */
   public PhysicalIOImpl(
       @NonNull S3URI s3URI,
       @NonNull MetadataStore metadataStore,
       @NonNull BlobStore blobStore,
-      @NonNull Telemetry telemetry) {
+      @NonNull Telemetry telemetry,
+      @NonNull Optional<ObjectMetadata> objectMetadata) {
     this.s3URI = s3URI;
     this.metadataStore = metadataStore;
     this.blobStore = blobStore;
     this.telemetry = telemetry;
+    this.objectMetadata = objectMetadata;
   }
 
   /**
@@ -69,7 +74,7 @@ public class PhysicalIOImpl implements PhysicalIO {
    */
   @Override
   public ObjectMetadata metadata() {
-    return metadataStore.get(s3URI);
+    return objectMetadata.orElseGet(() -> metadataStore.get(s3URI));
   }
 
   /**

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.DefaultLogicalIOImpl;
@@ -107,17 +108,21 @@ public class S3SeekableInputStreamFactoryTest {
         new S3SeekableInputStreamFactory(mock(ObjectClient.class), configuration);
 
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(S3URI.of("bucket", "key.parquet"))
+        s3SeekableInputStreamFactory.createLogicalIO(
+                S3URI.of("bucket", "key.parquet"), Optional.empty())
             instanceof ParquetLogicalIOImpl);
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(S3URI.of("bucket", "key.par"))
+        s3SeekableInputStreamFactory.createLogicalIO(
+                S3URI.of("bucket", "key.par"), Optional.empty())
             instanceof ParquetLogicalIOImpl);
 
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(S3URI.of("bucket", "key.java"))
+        s3SeekableInputStreamFactory.createLogicalIO(
+                S3URI.of("bucket", "key.java"), Optional.empty())
             instanceof DefaultLogicalIOImpl);
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(S3URI.of("bucket", "key.txt"))
+        s3SeekableInputStreamFactory.createLogicalIO(
+                S3URI.of("bucket", "key.txt"), Optional.empty())
             instanceof DefaultLogicalIOImpl);
   }
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
@@ -72,6 +72,20 @@ public class S3SeekableInputStreamFactoryTest {
   }
 
   @Test
+  void testCreateStreamWithContentLength() {
+    S3SeekableInputStreamFactory s3SeekableInputStreamFactory =
+        new S3SeekableInputStreamFactory(
+            mock(ObjectClient.class),
+            S3SeekableInputStreamConfiguration.builder()
+                .logicalIOConfiguration(
+                    LogicalIOConfiguration.builder().prefetchFooterEnabled(false).build())
+                .build());
+    S3SeekableInputStream inputStream =
+        s3SeekableInputStreamFactory.createStream(S3URI.of("bucket", "key"), 500);
+    assertNotNull(inputStream);
+  }
+
+  @Test
   void testCreateIndependentStream() {
     S3SeekableInputStreamConfiguration configuration =
         S3SeekableInputStreamConfiguration.builder()

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.utils.IoUtils;
@@ -370,7 +371,8 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
               () -> {
                 try {
                   PhysicalIO physicalIO =
-                      new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+                      new PhysicalIOImpl(
+                          s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
                   LogicalIO logicalIO =
                       new ParquetLogicalIOImpl(
                           TEST_OBJECT,
@@ -424,7 +426,8 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
         TEST_URI,
         new ParquetLogicalIOImpl(
             TEST_OBJECT,
-            new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
+            new PhysicalIOImpl(
+                TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty()),
             TestTelemetry.DEFAULT,
             LogicalIOConfiguration.DEFAULT,
             new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)),

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
@@ -15,6 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator;
 
+import java.util.Optional;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIO;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.ParquetColumnPrefetchStore;
@@ -43,7 +44,8 @@ public class S3SeekableInputStreamTestBase {
   protected final LogicalIO fakeLogicalIO =
       new ParquetLogicalIOImpl(
           TEST_OBJECT,
-          new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
+          new PhysicalIOImpl(
+              TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty()),
           TestTelemetry.DEFAULT,
           logicalIOConfiguration,
           new ParquetColumnPrefetchStore(logicalIOConfiguration));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -130,7 +131,8 @@ public class ParquetLogicalIOImplTest {
         new BlobStore(
             metadataStore, mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(
@@ -154,7 +156,8 @@ public class ParquetLogicalIOImplTest {
         new BlobStore(
             metadataStore, mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTaskTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTaskTest.java
@@ -367,24 +367,24 @@ public class ParquetPredictivePrefetchingTaskTest {
     HashMap<Long, ColumnMetadata> offsetIndexToColumnMap = new HashMap<>();
 
     List<ColumnMetadata> sk_testColumnMetadataList = new ArrayList<>();
-    ColumnMetadata sk_test1 = new ColumnMetadata(0, "test", 100, 200, 100, 500, schemaHash);
+    ColumnMetadata sk_test1 = new ColumnMetadata(0, "test", 200, 100, 100, 500, schemaHash);
     sk_testColumnMetadataList.add(sk_test1);
     offsetIndexToColumnMap.put(100L, sk_test1);
 
     // Should not be prefetched as it does not belong to the first row group.
     ColumnMetadata sk_test1_row_group_1 =
-        new ColumnMetadata(1, "test", 1800, 1900, 1800, 500, schemaHash);
+        new ColumnMetadata(1, "test", 1900, 1800, 1800, 500, schemaHash);
     sk_testColumnMetadataList.add(sk_test1_row_group_1);
     offsetIndexToColumnMap.put(1800L, sk_test1_row_group_1);
 
     List<ColumnMetadata> sk_test_2ColumnMetadataList = new ArrayList<>();
-    ColumnMetadata sk_test2 = new ColumnMetadata(0, "sk_test_2", 600, 700, 600, 500, schemaHash);
+    ColumnMetadata sk_test2 = new ColumnMetadata(0, "sk_test_2", 700, 600, 600, 500, schemaHash);
     sk_test_2ColumnMetadataList.add(sk_test2);
     offsetIndexToColumnMap.put(600L, sk_test2);
 
     List<ColumnMetadata> sk_test_3ColumnMetadataList = new ArrayList<>();
     ColumnMetadata sk_test3 =
-        new ColumnMetadata(0, "sk_test_3", 1100, 1200, 1100, 500, getHashCode(columnNames));
+        new ColumnMetadata(0, "sk_test_3", 1400, 1300, 1300, 500, getHashCode(columnNames));
     sk_test_3ColumnMetadataList.add(sk_test3);
     offsetIndexToColumnMap.put(1100L, sk_test3);
 
@@ -419,9 +419,9 @@ public class ParquetPredictivePrefetchingTaskTest {
     IOPlan ioPlan = ioPlanArgumentCaptor.getValue();
     List<Range> expectedRanges = new ArrayList<>();
 
-    expectedRanges.add(new Range(100, 599));
-    expectedRanges.add(new Range(600, 1099));
-    expectedRanges.add(new Range(1100, 1599));
+    // first two columns are consecutive, and so get merged
+    expectedRanges.add(new Range(100, 1099));
+    expectedRanges.add(new Range(1300, 1799));
     assertTrue(ioPlan.getPrefetchRanges().containsAll(expectedRanges));
   }
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTaskTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPredictivePrefetchingTaskTest.java
@@ -182,7 +182,7 @@ public class ParquetPredictivePrefetchingTaskTest {
     // Then: physical IO gets the correct plan. Only recent columns from the current row
     // group are prefetched.
     ArgumentCaptor<IOPlan> ioPlanArgumentCaptor = ArgumentCaptor.forClass(IOPlan.class);
-    verify(physicalIO).execute(ioPlanArgumentCaptor.capture());
+    verify(physicalIO, times(2)).execute(ioPlanArgumentCaptor.capture());
 
     IOPlan ioPlan = ioPlanArgumentCaptor.getValue();
     List<Range> expectedRanges = new ArrayList<>();
@@ -235,9 +235,9 @@ public class ParquetPredictivePrefetchingTaskTest {
     // Then: physical IO gets the correct plan. Only recent columns from the current row
     // group are prefetched.
     ArgumentCaptor<IOPlan> ioPlanArgumentCaptor = ArgumentCaptor.forClass(IOPlan.class);
-    verify(physicalIO).execute(ioPlanArgumentCaptor.capture());
+    verify(physicalIO, times(2)).execute(ioPlanArgumentCaptor.capture());
 
-    IOPlan ioPlan = ioPlanArgumentCaptor.getValue();
+    IOPlan ioPlan = ioPlanArgumentCaptor.getAllValues().get(0);
     List<Range> expectedRanges = new ArrayList<>();
 
     expectedRanges.add(new Range(100, 199));
@@ -414,7 +414,7 @@ public class ParquetPredictivePrefetchingTaskTest {
 
     // Then: physical IO gets the correct plan
     ArgumentCaptor<IOPlan> ioPlanArgumentCaptor = ArgumentCaptor.forClass(IOPlan.class);
-    verify(physicalIO).execute(ioPlanArgumentCaptor.capture());
+    verify(physicalIO, times(2)).execute(ioPlanArgumentCaptor.capture());
 
     IOPlan ioPlan = ioPlanArgumentCaptor.getValue();
     List<Range> expectedRanges = new ArrayList<>();

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchRemainingColumnTaskTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchRemainingColumnTaskTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.ParquetColumnPrefetchStore;
@@ -117,7 +118,7 @@ public class ParquetPrefetchRemainingColumnTaskTest {
 
     ParquetPrefetchRemainingColumnTask parquetPrefetchRemainingColumnTask =
         new ParquetPrefetchRemainingColumnTask(
-            TEST_URI, Telemetry.NOOP, mockedPhysicalIO, mockedParquetColumnPrefetchStore);
+            TEST_URI, TestTelemetry.DEFAULT, mockedPhysicalIO, mockedParquetColumnPrefetchStore);
     parquetPrefetchRemainingColumnTask.prefetchRemainingColumnChunk(200, 5 * ONE_MB);
 
     verify(mockedPhysicalIO).execute(any(IOPlan.class));
@@ -140,7 +141,7 @@ public class ParquetPrefetchRemainingColumnTaskTest {
         .thenReturn(new ColumnMappers(offsetIndexToColumnMap, new HashMap<>()));
     ParquetPrefetchRemainingColumnTask parquetPrefetchRemainingColumnTask =
         new ParquetPrefetchRemainingColumnTask(
-            TEST_URI, Telemetry.NOOP, mockedPhysicalIO, mockedParquetColumnPrefetchStore);
+            TEST_URI, TestTelemetry.DEFAULT, mockedPhysicalIO, mockedParquetColumnPrefetchStore);
 
     doThrow(new IOException("Error in prefetch")).when(mockedPhysicalIO).execute(any(IOPlan.class));
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetUtilsTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetUtilsTest.java
@@ -16,9 +16,11 @@
 package software.amazon.s3.analyticsaccelerator.io.logical.parquet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_GB;
 import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration;
@@ -115,5 +117,32 @@ public class ParquetUtilsTest {
 
     assertEquals(range.getStart(), 0);
     assertEquals(range.getEnd(), 4);
+  }
+
+  @Test
+  void testMergeRanges() {
+
+    List<Range> ranges = new ArrayList<>();
+    ranges.add(new Range(8577000, 8578000));
+    ranges.add(new Range(8578001, 8579000));
+    ranges.add(new Range(4862808, 4966522));
+    ranges.add(new Range(4966523, 5414203));
+    ranges.add(new Range(447784, 899884));
+    ranges.add(new Range(4302424, 4862807));
+    ranges.add(new Range(5414204, 8572063));
+    ranges.add(new Range(8572073, 8574000));
+    ranges.add(new Range(8579001, 8579050));
+    ranges.add(new Range(8579060, 8579080));
+
+    List<Range> expectedRanges = new ArrayList<>();
+    expectedRanges.add(new Range(447784, 899884));
+    // Merge [4302424 - 4862807, 4862808  - 4966522, 4966523 - 5414203, 5414204, 8572063]
+    expectedRanges.add(new Range(4302424, 8572063));
+    expectedRanges.add(new Range(8572073, 8574000));
+    // Merge [8577000 - 8578000, 8578001 - 8579000,8579001 - 8579050]
+    expectedRanges.add(new Range(8577000, 8579050));
+    expectedRanges.add(new Range(8579060, 8579080));
+
+    assertTrue(expectedRanges.containsAll(ParquetUtils.mergeRanges(ranges)));
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
@@ -18,6 +18,7 @@ package software.amazon.s3.analyticsaccelerator.io.physical.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
@@ -44,7 +45,8 @@ public class PhysicalIOImplTest {
             TestTelemetry.DEFAULT,
             PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
 
     // When: we read
     // Then: returned data is correct
@@ -67,7 +69,8 @@ public class PhysicalIOImplTest {
             TestTelemetry.DEFAULT,
             PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
 
     // When: we read
     // Then: returned data is correct


### PR DESCRIPTION
## Description of change

This PR makes a few small changes:

1/ Allows for passing in content length if it is already known by the reader. This avoids an extra HEAD call.

2/ Merges consecutive ranges before passing it to physicalIO. When prefetching consecutive columns, we can end up with multiple small requests. In such cases, it is more efficient to merge these ranges into a single GET.

3/ Don't apply to sequential prefetch logic to LogicalIO plans that come from the parquet prefetcher. Here, since we already know the ranges we want for specific columns, we don't need to extend requests. When prefetching consecutive columns eg: [100-200, 201-300], sequential prefetching can cause some over reading. This is currently done by just checking if the Read is ASYNC, as the only place ASYNC reads happen currently are from the parquet prefetcher. This logic should be improved, see https://github.com/awslabs/analytics-accelerator-s3/issues/195 for more details.

#### Relevant issues

N/A

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?

No

#### Does this contribution introduce any new public APIs or behaviors?

Yes, a new createStream() method that allows the passing of a contentLength. 

#### How was the contribution tested?

Ran unit tests, and local benchmarks.

#### Does this contribution need a changelog entry?
- [ X] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).