### PR TITLE
Stores known contentLen to Metadata cache

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStore.java
@@ -109,6 +109,17 @@ public class MetadataStore implements Closeable {
   }
 
   /**
+   * Allows storing of objectMetadata to cache. Useful when content length is already known, so can
+   * skip the HEAD request.
+   *
+   * @param s3URI the object to store metadata for
+   * @param objectMetadata Object metadata
+   */
+  public synchronized void storeObjectMetadata(S3URI s3URI, ObjectMetadata objectMetadata) {
+    this.cache.put(s3URI, CompletableFuture.completedFuture(objectMetadata));
+  }
+
+  /**
    * Utility method that cancels a {@link CompletableFuture} ignoring any exceptions.
    *
    * @param future an instance of {@link CompletableFuture} to cancel

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
@@ -16,7 +16,6 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.impl;
 
 import java.io.IOException;
-import java.util.Optional;
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Operation;
@@ -36,7 +35,6 @@ public class PhysicalIOImpl implements PhysicalIO {
   private final MetadataStore metadataStore;
   private final BlobStore blobStore;
   private final Telemetry telemetry;
-  private final Optional<ObjectMetadata> objectMetadata;
 
   private final long physicalIOBirth = System.nanoTime();
 
@@ -52,19 +50,16 @@ public class PhysicalIOImpl implements PhysicalIO {
    * @param metadataStore a metadata cache
    * @param blobStore a data cache
    * @param telemetry The {@link Telemetry} to use to report measurements.
-   * @param objectMetadata object metadata
    */
   public PhysicalIOImpl(
       @NonNull S3URI s3URI,
       @NonNull MetadataStore metadataStore,
       @NonNull BlobStore blobStore,
-      @NonNull Telemetry telemetry,
-      @NonNull Optional<ObjectMetadata> objectMetadata) {
+      @NonNull Telemetry telemetry) {
     this.s3URI = s3URI;
     this.metadataStore = metadataStore;
     this.blobStore = blobStore;
     this.telemetry = telemetry;
-    this.objectMetadata = objectMetadata;
   }
 
   /**
@@ -74,7 +69,7 @@ public class PhysicalIOImpl implements PhysicalIO {
    */
   @Override
   public ObjectMetadata metadata() {
-    return objectMetadata.orElseGet(() -> metadataStore.get(s3URI));
+    return metadataStore.get(s3URI);
   }
 
   /**

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.DefaultLogicalIOImpl;
@@ -122,21 +121,17 @@ public class S3SeekableInputStreamFactoryTest {
         new S3SeekableInputStreamFactory(mock(ObjectClient.class), configuration);
 
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(
-                S3URI.of("bucket", "key.parquet"), Optional.empty())
+        s3SeekableInputStreamFactory.createLogicalIO(S3URI.of("bucket", "key.parquet"))
             instanceof ParquetLogicalIOImpl);
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(
-                S3URI.of("bucket", "key.par"), Optional.empty())
+        s3SeekableInputStreamFactory.createLogicalIO(S3URI.of("bucket", "key.par"))
             instanceof ParquetLogicalIOImpl);
 
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(
-                S3URI.of("bucket", "key.java"), Optional.empty())
+        s3SeekableInputStreamFactory.createLogicalIO(S3URI.of("bucket", "key.java"))
             instanceof DefaultLogicalIOImpl);
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(
-                S3URI.of("bucket", "key.txt"), Optional.empty())
+        s3SeekableInputStreamFactory.createLogicalIO(S3URI.of("bucket", "key.txt"))
             instanceof DefaultLogicalIOImpl);
   }
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.utils.IoUtils;
@@ -371,8 +370,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
               () -> {
                 try {
                   PhysicalIO physicalIO =
-                      new PhysicalIOImpl(
-                          s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
+                      new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
                   LogicalIO logicalIO =
                       new ParquetLogicalIOImpl(
                           TEST_OBJECT,
@@ -426,8 +424,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
         TEST_URI,
         new ParquetLogicalIOImpl(
             TEST_OBJECT,
-            new PhysicalIOImpl(
-                TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty()),
+            new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
             TestTelemetry.DEFAULT,
             LogicalIOConfiguration.DEFAULT,
             new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)),

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
@@ -15,7 +15,6 @@
  */
 package software.amazon.s3.analyticsaccelerator;
 
-import java.util.Optional;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIO;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.ParquetColumnPrefetchStore;
@@ -44,8 +43,7 @@ public class S3SeekableInputStreamTestBase {
   protected final LogicalIO fakeLogicalIO =
       new ParquetLogicalIOImpl(
           TEST_OBJECT,
-          new PhysicalIOImpl(
-              TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty()),
+          new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
           TestTelemetry.DEFAULT,
           logicalIOConfiguration,
           new ParquetColumnPrefetchStore(logicalIOConfiguration));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -131,8 +130,7 @@ public class ParquetLogicalIOImplTest {
         new BlobStore(
             metadataStore, mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(
-            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(
@@ -156,8 +154,7 @@ public class ParquetLogicalIOImplTest {
         new BlobStore(
             metadataStore, mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(
-            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
@@ -18,7 +18,6 @@ package software.amazon.s3.analyticsaccelerator.io.physical.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
@@ -45,8 +44,7 @@ public class PhysicalIOImplTest {
             TestTelemetry.DEFAULT,
             PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(
-            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -69,8 +67,7 @@ public class PhysicalIOImplTest {
             TestTelemetry.DEFAULT,
             PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(
-            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, Optional.empty());
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
 
     // When: we read
     // Then: returned data is correct


### PR DESCRIPTION
## Description of change

Previour PR: https://github.com/awslabs/analytics-accelerator-s3/pull/194, got this wrong. This PR corrects it. 

The known contentLen must be stored in the metadatastore to prevent the extra HEAD request when contentLen is known. 

#### Relevant issues

N/A

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?

No

#### Does this contribution introduce any new public APIs or behaviors?

No

#### How was the contribution tested?

Unit tests + local spark in proc testing

#### Does this contribution need a changelog entry?
- [ X] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).