### PR TITLE
Fix Len = 0 and Insufficient Buffer behaviours for positioned reads

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/SeekableInputStream.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/SeekableInputStream.java
@@ -17,6 +17,7 @@ package software.amazon.s3.analyticsaccelerator;
 
 import java.io.IOException;
 import java.io.InputStream;
+import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 
 /**
  * A SeekableInputStream is like a conventional InputStream but equipped with two additional
@@ -57,4 +58,38 @@ public abstract class SeekableInputStream extends InputStream {
    * @throws IOException if an error occurs while reading the file
    */
   public abstract int readTail(byte[] buf, int off, int n) throws IOException;
+
+  /**
+   * Validates the arguments for a read operation. This method is available to use in all subclasses
+   * to ensure consistency.
+   *
+   * @param position the position to read from
+   * @param buffer the buffer to read into
+   * @param offset the offset in the buffer to start writing at
+   * @param length the number of bytes to read
+   * @throws IllegalArgumentException if the position, offset or length is negative
+   * @throws NullPointerException if the buffer is null
+   * @throws IndexOutOfBoundsException if the offset or length are invalid for the given buffer
+   */
+  protected void validatePositionedReadArgs(long position, byte[] buffer, int offset, int length) {
+    Preconditions.checkArgument(offset >= 0, "Offset is negative");
+    Preconditions.checkArgument(length >= 0, "Length is negative");
+
+    // TODO: S3A throws an EOFException here, S3FileIO does IllegalArgumentException
+    // TODO: https://github.com/awslabs/analytics-accelerator-s3/issues/84
+    Preconditions.checkArgument(position >= 0, "Position is negative");
+
+    if (buffer == null) {
+      throw new NullPointerException("Null destination buffer");
+    } else if (length > buffer.length - offset) {
+      throw new IndexOutOfBoundsException(
+          "Too many bytes for destination buffer "
+              + ": request length="
+              + length
+              + ", with offset ="
+              + offset
+              + "; buffer capacity ="
+              + (buffer.length - offset));
+    }
+  }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/SeekableInputStream.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/SeekableInputStream.java
@@ -72,24 +72,22 @@ public abstract class SeekableInputStream extends InputStream {
    * @throws IndexOutOfBoundsException if the offset or length are invalid for the given buffer
    */
   protected void validatePositionedReadArgs(long position, byte[] buffer, int offset, int length) {
-    Preconditions.checkArgument(offset >= 0, "Offset is negative");
+    Preconditions.checkNotNull(buffer, "Null destination buffer");
     Preconditions.checkArgument(length >= 0, "Length is negative");
+    Preconditions.checkArgument(offset >= 0, "Offset is negative");
 
     // TODO: S3A throws an EOFException here, S3FileIO does IllegalArgumentException
     // TODO: https://github.com/awslabs/analytics-accelerator-s3/issues/84
     Preconditions.checkArgument(position >= 0, "Position is negative");
-
-    if (buffer == null) {
-      throw new NullPointerException("Null destination buffer");
-    } else if (length > buffer.length - offset) {
-      throw new IndexOutOfBoundsException(
-          "Too many bytes for destination buffer "
-              + ": request length="
-              + length
-              + ", with offset ="
-              + offset
-              + "; buffer capacity ="
-              + (buffer.length - offset));
-    }
+    Preconditions.checkPositionIndex(
+        length,
+        buffer.length - offset,
+        "Too many bytes for destination buffer "
+            + ": request length="
+            + length
+            + ", with offset ="
+            + offset
+            + "; buffer capacity ="
+            + (buffer.length - offset));
   }
 }


### PR DESCRIPTION
## Description of change

According to InputStream documentation Len = 0 should return 0

`If len is zero, then no bytes are read and 0 is returned;` 

Following the InputStream implementation, this commit is adding argument checks to Positioned Reads. This validation is implemented in the SeekableInputStream to ensure all subclasses behave the same way in the unhappy path.

Checks are done in the same order with InputStream implementation. 

#### Relevant issues

https://github.com/awslabs/analytics-accelerator-s3/issues/201

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?

Yes. For a 0-length read to a 0-sized object read will now return 0 instead of -1.
Insufficient Buffer Capacity will now throw IndexOutOfBoundsException instead of IllegalArgumentException. 


#### Does this contribution introduce any new public APIs or behaviors?
No, it changes existing public API behaviour. 


#### How was the contribution tested?
Added new unit tests. 

#### Does this contribution need a changelog entry?
- [N/A] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).