### PR TITLE
fix: fixing jmh local build

### DIFF
--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -213,6 +213,7 @@ tasks.named<SpotBugsTask>("spotbugsTestFixtures") {
 }
 
 tasks.build {dependsOn(shadowJar)}
+
 tasks.jar {dependsOn(shadowJar)}
 
 tasks.jar {
@@ -240,6 +241,23 @@ jmhReport {
 
 tasks.jmh {
     finalizedBy(tasks.jmhReport)
+}
+
+tasks.named("jmhRunBytecodeGenerator") {
+    dependsOn(tasks.named("copyAndRename"))
+}
+
+tasks.register<Copy>("copyAndRename") {
+    dependsOn(shadowJar)
+    inputs.file("${project.layout.buildDirectory.get().asFile}/libs/analyticsaccelerator-s3-$currentVersion.jar")
+    outputs.file("${project.layout.buildDirectory.get().asFile}/libs/input-stream.jar")
+
+    from("${project.layout.buildDirectory.get().asFile}/libs/analyticsaccelerator-s3-$currentVersion.jar")
+    into("${project.layout.buildDirectory.get().asFile}/libs/")
+
+    //Use include to overwrite existing file we made.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    rename("analyticsaccelerator-s3-$currentVersion.jar", "input-stream.jar")
 }
 
 tasks.named<Test>("test") {


### PR DESCRIPTION
## Description of change
We are currently getting:
```
* What went wrong:
Execution failed for task ':input-stream:jmhJar'.
> Cannot expand ZIP '/Volumes/workplace/dats/analytics-accelerator-s3/input-stream/build/libs/input-stream.jar' as it does not exist.
```
This is because jmh expects a certain pattern for files and we don't match that pattern. Ideally we would be able to update that pattern and tell it which jar to use but I couldn't find a way, so instead I just created it. This is hacky and obviously changing the pattern would be best, if you know how please let me know otherwise this works.

I'm simply creating the jar it expects based off of the latest source. We could remove that dummy jar if we want but I didn't want to add more complexity to an already complex gradle setup.

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
with `gradle clean jmhJar` I also used this jar to upload all the data I needed and it looked to be correct

#### Does this contribution need a changelog entry?
- [x ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).