### PR TITLE
Add JMH JAR generation to CICD

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build with Gradle
         run: |
           ./gradlew -PsnapshotBuild=true build
+          ./gradlew jmhJar
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Description of change

This commit makes sure that we always generate the JMH JAR that is used for running the microbenchmarks.  Previously, this was an unexercised workflow, which meant that we could break it without detecting it.

Including in CICD is essentially ensuring that we have our loops closed on this and should never break microbenchmark builds.

#### Relevant issues
N/A

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Locally

#### Does this contribution need a changelog entry?
- [x] I have updated the CHANGELOG or README if appropriate

---

> By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).