### PR TITLE
feat: adding etag checking for stream reads

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/GetRequest.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/GetRequest.java
@@ -32,5 +32,5 @@ public class GetRequest {
   @NonNull S3URI s3Uri;
   @NonNull Range range;
   @NonNull Referrer referrer;
-  String etag;
+  @NonNull String etag;
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/GetRequest.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/GetRequest.java
@@ -30,4 +30,5 @@ public class GetRequest {
   @NonNull S3URI s3Uri;
   @NonNull Range range;
   @NonNull Referrer referrer;
+  String etag;
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectContent.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectContent.java
@@ -24,4 +24,5 @@ import lombok.Data;
 @Builder
 public class ObjectContent {
   InputStream stream;
+  String etag;
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
@@ -23,4 +23,5 @@ import lombok.Data;
 @Builder
 public class ObjectMetadata {
   long contentLength;
+  String etag;
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
@@ -24,5 +24,6 @@ import lombok.Data;
 @Builder
 public class ObjectMetadata {
   long contentLength;
-  Optional<String> etag;
+
+  @Builder.Default Optional<String> etag = Optional.empty();
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
@@ -15,6 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator.request;
 
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
 
@@ -23,5 +24,5 @@ import lombok.Data;
 @Builder
 public class ObjectMetadata {
   long contentLength;
-  String etag;
+  Optional<String> etag;
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
@@ -15,9 +15,9 @@
  */
 package software.amazon.s3.analyticsaccelerator.request;
 
-import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NonNull;
 
 /** Wrapper class around HeadObjectResponse abstracting away from S3-specific details */
 @Data
@@ -25,5 +25,5 @@ import lombok.Data;
 public class ObjectMetadata {
   long contentLength;
 
-  @Builder.Default Optional<String> etag = Optional.empty();
+  @NonNull String etag;
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectKey.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectKey.java
@@ -15,7 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator.util;
 
-import java.util.Objects;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,7 +27,8 @@ import lombok.NonNull;
 @Builder
 public class ObjectKey {
   @NonNull S3URI s3URI;
-  @NonNull String etag;
+
+  Optional<String> etag;
 
   @Override
   public boolean equals(Object o) {
@@ -40,6 +41,13 @@ public class ObjectKey {
 
   @Override
   public int hashCode() {
-    return Objects.hash(s3URI, etag);
+    int result = s3URI.hashCode();
+
+    // Include etag in hash only if present
+    if (etag.isPresent()) {
+      result = result + etag.hashCode();
+    }
+
+    return result;
   }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectKey.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectKey.java
@@ -13,24 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package software.amazon.s3.analyticsaccelerator.request;
+package software.amazon.s3.analyticsaccelerator.util;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NonNull;
-import lombok.Value;
-import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
-/**
- * Object representing arguments to a GetObject call. This class helps us abstract away from S3 SDK
- * constructs.
- */
-@Value
+/** Container used to represent an S3 object for a specific version/etag */
+@Getter
+@AllArgsConstructor
 @Builder
-@SuppressFBWarnings(value = "NM_CONFUSING", justification = "Sharing Getter names is not confusing")
-public class GetRequest {
-  @NonNull S3URI s3Uri;
-  @NonNull Range range;
-  @NonNull Referrer referrer;
-  String etag;
+public class ObjectKey {
+  @NonNull S3URI s3URI;
+  @NonNull String etag;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ObjectKey objectKey = (ObjectKey) o;
+    return s3URI.equals(objectKey.s3URI) && etag.equals(objectKey.etag);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(s3URI, etag);
+  }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectKey.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectKey.java
@@ -15,7 +15,6 @@
  */
 package software.amazon.s3.analyticsaccelerator.util;
 
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,8 +26,7 @@ import lombok.NonNull;
 @Builder
 public class ObjectKey {
   @NonNull S3URI s3URI;
-
-  @Builder.Default Optional<String> etag = Optional.empty();
+  @NonNull String etag;
 
   @Override
   public boolean equals(Object o) {
@@ -41,13 +39,6 @@ public class ObjectKey {
 
   @Override
   public int hashCode() {
-    int result = s3URI.hashCode();
-
-    // Include etag in hash only if present
-    if (etag.isPresent()) {
-      result = result + etag.hashCode();
-    }
-
-    return result;
+    return s3URI.hashCode() + etag.hashCode();
   }
 }

--- a/common/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectKeyTest.java
+++ b/common/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectKeyTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 @SuppressFBWarnings(
@@ -35,10 +34,10 @@ public class ObjectKeyTest {
     S3URI s3uri2 = S3URI.of("bucket", "key");
     S3URI s3uri3 = S3URI.of("bucket", "key2");
 
-    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag(Optional.of("etag1")).build();
-    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag(Optional.of("etag1")).build();
-    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag(Optional.of("etag2")).build();
-    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag(Optional.of("etag1")).build();
+    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag("etag1").build();
+    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag("etag1").build();
+    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag("etag2").build();
+    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag("etag1").build();
 
     Map<ObjectKey, String> map = new HashMap<>();
 
@@ -68,10 +67,10 @@ public class ObjectKeyTest {
     S3URI s3uri2 = S3URI.of("bucket", "key");
     S3URI s3uri3 = S3URI.of("bucket", "key2");
 
-    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag(Optional.of("etag1")).build();
-    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag(Optional.of("etag1")).build();
-    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag(Optional.of("etag2")).build();
-    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag(Optional.of("etag1")).build();
+    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag("etag1").build();
+    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag("etag1").build();
+    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag("etag2").build();
+    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag("etag1").build();
 
     // Test equals
     assertEquals(key1, key1); // Same object
@@ -95,20 +94,21 @@ public class ObjectKeyTest {
     assertThrows(
         NullPointerException.class,
         () -> {
-          ObjectKey.builder().s3URI(null).etag(Optional.of("etag1")).build();
+          ObjectKey.builder().s3URI(null).etag("etag1").build();
         });
 
     // Test null etag
-    assertDoesNotThrow(
+    assertThrows(
+        NullPointerException.class,
         () -> {
-          ObjectKey.builder().s3URI(s3uri).etag(Optional.empty()).build();
+          ObjectKey.builder().s3URI(s3uri).etag(null).build();
         });
 
     // Test constructor with null values
     assertThrows(
         NullPointerException.class,
         () -> {
-          new ObjectKey(null, Optional.of("etag1"));
+          new ObjectKey(null, null);
         });
   }
 }

--- a/common/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectKeyTest.java
+++ b/common/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectKeyTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@SuppressFBWarnings(
+    value = "NP_NONNULL_PARAM_VIOLATION",
+    justification = "We mean to pass nulls to checks")
+public class ObjectKeyTest {
+
+  @Test
+  void testMapOperations() {
+    // Create test objects
+    S3URI s3uri1 = S3URI.of("bucket", "key");
+    S3URI s3uri2 = S3URI.of("bucket", "key");
+    S3URI s3uri3 = S3URI.of("bucket", "key2");
+
+    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag("etag1").build();
+
+    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag("etag1").build();
+
+    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag("etag2").build();
+
+    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag("etag1").build();
+
+    Map<ObjectKey, String> map = new HashMap<>();
+
+    // Test putting and retrieving
+    map.put(key1, "value1");
+    assertEquals("value1", map.get(key1));
+
+    // Test same s3URI and etag should be treated as same key
+    map.put(key2, "value2");
+    assertEquals("value2", map.get(key1));
+    assertEquals(1, map.size());
+
+    // Test different etag should be treated as different key
+    map.put(key3, "value3");
+    assertEquals("value3", map.get(key3));
+    assertEquals(2, map.size());
+
+    // Test different s3URI should be treated as different key
+    map.put(key4, "value4");
+    assertEquals("value4", map.get(key4));
+    assertEquals(3, map.size());
+  }
+
+  @Test
+  void testEqualsAndHashCodeObjectKey() {
+    S3URI s3uri1 = S3URI.of("bucket", "key");
+    S3URI s3uri2 = S3URI.of("bucket", "key");
+    S3URI s3uri3 = S3URI.of("bucket", "key2");
+
+    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag("etag1").build();
+
+    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag("etag1").build();
+
+    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag("etag2").build();
+
+    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag("etag1").build();
+
+    // Test equals
+    assertEquals(key1, key1); // Same object
+    assertEquals(key1, key2); // Same values
+    assertNotEquals(key1, key3); // Different etag
+    assertNotEquals(key1, key4); // Different s3URI
+    assertNotEquals(key1, null); // Null comparison
+    assertNotEquals(key1, "not an ObjectKey"); // Different type
+
+    // Test hashCode
+    assertEquals(key1.hashCode(), key2.hashCode()); // Same values should have same hash
+    assertNotEquals(key1.hashCode(), key3.hashCode()); // Different etag should have different hash
+    assertNotEquals(key1.hashCode(), key4.hashCode()); // Different s3URI should have different hash
+  }
+
+  @Test
+  void testNullValidation() {
+    S3URI s3uri = S3URI.of("bucket", "key");
+
+    // Test null s3URI
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          ObjectKey.builder().s3URI(null).etag("etag1").build();
+        });
+
+    // Test null etag
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          ObjectKey.builder().s3URI(s3uri).etag(null).build();
+        });
+
+    // Test constructor with null values
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new ObjectKey(null, "etag1");
+        });
+
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new ObjectKey(s3uri, null);
+        });
+  }
+}

--- a/common/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectKeyTest.java
+++ b/common/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectKeyTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 @SuppressFBWarnings(
@@ -34,13 +35,10 @@ public class ObjectKeyTest {
     S3URI s3uri2 = S3URI.of("bucket", "key");
     S3URI s3uri3 = S3URI.of("bucket", "key2");
 
-    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag("etag1").build();
-
-    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag("etag1").build();
-
-    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag("etag2").build();
-
-    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag("etag1").build();
+    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag(Optional.of("etag1")).build();
+    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag(Optional.of("etag1")).build();
+    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag(Optional.of("etag2")).build();
+    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag(Optional.of("etag1")).build();
 
     Map<ObjectKey, String> map = new HashMap<>();
 
@@ -70,13 +68,10 @@ public class ObjectKeyTest {
     S3URI s3uri2 = S3URI.of("bucket", "key");
     S3URI s3uri3 = S3URI.of("bucket", "key2");
 
-    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag("etag1").build();
-
-    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag("etag1").build();
-
-    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag("etag2").build();
-
-    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag("etag1").build();
+    ObjectKey key1 = ObjectKey.builder().s3URI(s3uri1).etag(Optional.of("etag1")).build();
+    ObjectKey key2 = ObjectKey.builder().s3URI(s3uri2).etag(Optional.of("etag1")).build();
+    ObjectKey key3 = ObjectKey.builder().s3URI(s3uri1).etag(Optional.of("etag2")).build();
+    ObjectKey key4 = ObjectKey.builder().s3URI(s3uri3).etag(Optional.of("etag1")).build();
 
     // Test equals
     assertEquals(key1, key1); // Same object
@@ -100,27 +95,20 @@ public class ObjectKeyTest {
     assertThrows(
         NullPointerException.class,
         () -> {
-          ObjectKey.builder().s3URI(null).etag("etag1").build();
+          ObjectKey.builder().s3URI(null).etag(Optional.of("etag1")).build();
         });
 
     // Test null etag
-    assertThrows(
-        NullPointerException.class,
+    assertDoesNotThrow(
         () -> {
-          ObjectKey.builder().s3URI(s3uri).etag(null).build();
+          ObjectKey.builder().s3URI(s3uri).etag(Optional.empty()).build();
         });
 
     // Test constructor with null values
     assertThrows(
         NullPointerException.class,
         () -> {
-          new ObjectKey(null, "etag1");
-        });
-
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new ObjectKey(s3uri, null);
+          new ObjectKey(null, Optional.of("etag1"));
         });
   }
 }

--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -23,6 +23,7 @@ To generate data and run benchmarks, you first need to configure your environmen
 
 ### Data Generation
 After your environment is configured, you can generate data to run benchmarks against.
+* If you haven't already done so create a new S3 Bucket and add the bucket name(`S3_TEST_BUCKET`) and prefix(`S3_TEST_PREFIX`) as env vars
 * Build the `jmhJar` : `./gradlew jmhJar`
 * Run the generator: `java -cp input-stream/build/libs/input-stream-jmh.jar software.amazon.s3.analyticsaccelerator.benchmarks.data.generation.BenchmarkDataGeneratorDriver`
 

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -67,7 +67,6 @@ dependencies {
     api(project(":object-client"))
 
     implementation(project(":common"))
-    implementation(libs.s3);
     implementation(libs.parquet.format)
     implementation(libs.slf4j.api)
 

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
@@ -103,13 +103,6 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
     testChangingEtagAfterStreamPassesAndReturnsCachedObject(s3ClientKind, s3Object, configuration);
   }
 
-  @ParameterizedTest
-  @MethodSource("etagTests")
-  void testTurningEtagCheckOffIsRespected(S3ClientKind s3ClientKind, S3Object s3Object)
-      throws IOException {
-    testTurningEtagCheckOffIsHandledCorrectly(s3ClientKind, s3Object);
-  }
-
   static Stream<Arguments> sequentialReads() {
     return argumentsFor(
         getS3ClientKinds(),

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
@@ -63,6 +63,26 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
         s3Object, streamReadPattern, configuration, CONCURRENCY_LEVEL, CONCURRENCY_ITERATIONS);
   }
 
+  @ParameterizedTest
+  @MethodSource("etagTests")
+  void testChangingEtagFailsStream(
+      S3Object s3Object,
+      StreamReadPatternKind streamReadPattern,
+      DATInputStreamConfigurationKind configuration)
+      throws IOException {
+    testChangingEtagMidStream(s3Object, configuration);
+  }
+
+  @ParameterizedTest
+  @MethodSource("etagTests")
+  void testChangingEtagReturnsCachedObject(
+      S3Object s3Object,
+      StreamReadPatternKind streamReadPattern,
+      DATInputStreamConfigurationKind configuration)
+      throws IOException {
+    testChangingEtagAfterStreamPassesAndReturnsCachedObject(s3Object, configuration);
+  }
+
   static Stream<Arguments> sequentialReads() {
     return argumentsFor(
         S3Object.smallAndMediumObjects(),
@@ -82,5 +102,10 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
         S3Object.smallAndMediumObjects(),
         parquetPatterns(),
         getS3SeekableInputStreamConfigurations());
+  }
+
+  static Stream<Arguments> etagTests() {
+    return argumentsFor(
+        S3Object.smallObjects(), parquetPatterns(), getS3SeekableInputStreamConfigurations());
   }
 }

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
@@ -70,7 +70,7 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException {
-    testChangingEtagMidStream(s3Object, configuration);
+    testChangingEtagMidStream(s3Object, streamReadPattern, configuration);
   }
 
   @ParameterizedTest

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/IntegrationTestBase.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/IntegrationTestBase.java
@@ -15,10 +15,15 @@
  */
 package software.amazon.s3.analyticsaccelerator.access;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static software.amazon.s3.analyticsaccelerator.access.ChecksumAssertions.assertChecksums;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -27,12 +32,18 @@ import lombok.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.provider.Arguments;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.checksums.Crc32CChecksum;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
+import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 /** Base class for the integration tests */
 public abstract class IntegrationTestBase extends ExecutionBase {
   @NonNull private final AtomicReference<S3ExecutionContext> s3ExecutionContext = new AtomicReference<>();
+
+  SecureRandom random = new SecureRandom();
 
   @BeforeEach
   void setUp() {
@@ -90,6 +101,143 @@ public abstract class IntegrationTestBase extends ExecutionBase {
 
     // Assert checksums
     assertChecksums(directChecksum, datChecksum);
+  }
+
+  /**
+   * Checks to make sure we throw an error and fail the stream while reading a stream and the etag
+   * changes during the read.
+   *
+   * @param s3Object S3 object to read
+   * @param DATInputStreamConfigurationKind configuration kind
+   */
+  protected void testChangingEtagMidStream(
+      @NonNull S3Object s3Object,
+      @NonNull DATInputStreamConfigurationKind DATInputStreamConfigurationKind)
+      throws IOException {
+    int bufferSize = (int) s3Object.getSize();
+    byte[] buffer = new byte[bufferSize];
+
+    // Create the s3DATClientStreamReader - that creates the shared state
+    try (S3DATClientStreamReader s3DATClientStreamReader =
+        this.createS3DATClientStreamReader(getClientKind(), DATInputStreamConfigurationKind)) {
+
+      S3URI s3URI =
+          s3Object.getObjectUri(this.getS3ExecutionContext().getConfiguration().getBaseUri());
+      S3AsyncClient s3Client = this.getS3ExecutionContext().getS3Client();
+      S3SeekableInputStream stream = s3DATClientStreamReader.createReadStream(s3Object);
+
+      int readAheadBytes =
+          (int)
+              DATInputStreamConfigurationKind.getValue()
+                  .getPhysicalIOConfiguration()
+                  .getReadAheadBytes();
+
+      // Read first 100 bytes
+      readAndAssert(stream, buffer, 0, 100);
+
+      // Read next 100 bytes
+      readAndAssert(stream, buffer, 100, 100);
+
+      // Change the file
+      s3Client
+          .putObject(
+              x -> x.bucket(s3URI.getBucket()).key(s3URI.getKey()),
+              AsyncRequestBody.fromBytes(generateRandomBytes(bufferSize)))
+          .join();
+
+      // read the next bytes and fail.
+      Exception ex =
+          assertThrows(Exception.class, () -> readAndAssert(stream, buffer, 200, readAheadBytes));
+      S3Exception s3Exception =
+          assertInstanceOf(S3Exception.class, ex.getCause(), "Cause should be S3Exception");
+      assertEquals(412, s3Exception.statusCode(), "Expected Precondition Failed (412) status code");
+    }
+  }
+
+  /**
+   * Used to read and assert helps when we want to run it in a lambda.
+   *
+   * @param stream input stream
+   * @param buffer buffer to populate
+   * @param offset start pos
+   * @param len how much to read
+   * @throws IOException
+   */
+  private void readAndAssert(InputStream stream, byte[] buffer, int offset, int len)
+      throws IOException {
+    int readBytes = stream.read(buffer, offset, len);
+    assertEquals(readBytes, len);
+  }
+
+  /**
+   * Tests to make sure if we have read our whole object we pass and return our cached data even if
+   * the etag has changed after the read is complete
+   *
+   * @param s3Object S3 object to read
+   * @param DATInputStreamConfigurationKind configuration kind
+   * @throws IOException
+   */
+  protected void testChangingEtagAfterStreamPassesAndReturnsCachedObject(
+      @NonNull S3Object s3Object,
+      @NonNull DATInputStreamConfigurationKind DATInputStreamConfigurationKind)
+      throws IOException {
+    int bufferSize = (int) s3Object.getSize();
+    // Create the s3DATClientStreamReader - that creates the shared state
+    try (S3DATClientStreamReader s3DATClientStreamReader =
+        this.createS3DATClientStreamReader(getClientKind(), DATInputStreamConfigurationKind)) {
+      S3SeekableInputStream stream = s3DATClientStreamReader.createReadStream(s3Object);
+      Crc32CChecksum datChecksum = calculateCRC32C(stream, bufferSize);
+
+      S3URI s3URI =
+          s3Object.getObjectUri(this.getS3ExecutionContext().getConfiguration().getBaseUri());
+      S3AsyncClient s3Client = this.getS3ExecutionContext().getS3Client();
+
+      // Change the file
+      s3Client
+          .putObject(
+              x -> x.bucket(s3URI.getBucket()).key(s3URI.getKey()),
+              AsyncRequestBody.fromBytes(generateRandomBytes(bufferSize)))
+          .join();
+
+      S3SeekableInputStream cacheStream = s3DATClientStreamReader.createReadStream(s3Object);
+      Crc32CChecksum cachedChecksum = calculateCRC32C(cacheStream, bufferSize);
+
+      // Assert checksums
+      assertChecksums(datChecksum, cachedChecksum);
+    }
+  }
+
+  /**
+   * Generates a byte array filled with random bytes.
+   *
+   * @param bufferSize how big our byte array needs to be
+   * @return a populated byte array
+   */
+  protected byte[] generateRandomBytes(int bufferSize) {
+    byte[] data = new byte[bufferSize];
+    random.nextBytes(data);
+    return data;
+  }
+
+  /**
+   * Used to calculate a checksum based off our input stream
+   *
+   * @param input the input stream to generate the checksum for
+   * @param bufferSize how big the input stream is
+   * @return the calculated Crc32CChecksum
+   * @throws IOException
+   */
+  protected static Crc32CChecksum calculateCRC32C(InputStream input, int bufferSize)
+      throws IOException {
+    Crc32CChecksum checksum = new Crc32CChecksum();
+    byte[] buffer = new byte[bufferSize];
+    int bytesRead;
+
+    while ((bytesRead = input.read(buffer)) != -1) {
+      checksum.update(buffer, 0, bytesRead);
+    }
+
+    return checksum;
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStream.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStream.java
@@ -147,6 +147,7 @@ public class S3SeekableInputStream extends SeekableInputStream {
             Operation.builder()
                 .name(OPERATION_READ)
                 .attribute(StreamAttributes.uri(this.s3URI))
+                .attribute(StreamAttributes.etag(this.logicalIO.metadata().getEtag()))
                 .attribute(StreamAttributes.range(position, position + length - 1))
                 .build(),
         () -> {
@@ -211,6 +212,7 @@ public class S3SeekableInputStream extends SeekableInputStream {
                 .name(OPERATION_READ)
                 .attribute(StreamAttributes.variant(FLAVOR_TAIL))
                 .attribute(StreamAttributes.uri(this.s3URI))
+                .attribute(StreamAttributes.etag(this.logicalIO.metadata().getEtag()))
                 .attribute(
                     StreamAttributes.range(getContentLength() - length, getContentLength() - 1))
                 .build(),

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -74,11 +74,7 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
         new MetadataStore(objectClient, telemetry, configuration.getPhysicalIOConfiguration());
     this.objectFormatSelector = new ObjectFormatSelector(configuration.getLogicalIOConfiguration());
     this.objectBlobStore =
-        new BlobStore(
-            objectMetadataStore,
-            objectClient,
-            telemetry,
-            configuration.getPhysicalIOConfiguration());
+        new BlobStore(objectClient, telemetry, configuration.getPhysicalIOConfiguration());
   }
 
   /**
@@ -96,13 +92,14 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
    *
    * @param s3URI the object's S3 URI
    * @param contentLength content length
+   * @param etag etag for content
    * @return An instance of the input stream.
    */
-  public S3SeekableInputStream createStream(@NonNull S3URI s3URI, long contentLength) {
+  public S3SeekableInputStream createStream(@NonNull S3URI s3URI, long contentLength, String etag) {
     Preconditions.checkArgument(contentLength >= 0, "`len` must be non-negative");
 
     objectMetadataStore.storeObjectMetadata(
-        s3URI, ObjectMetadata.builder().contentLength(contentLength).build());
+        s3URI, ObjectMetadata.builder().contentLength(contentLength).etag(etag).build());
 
     return new S3SeekableInputStream(s3URI, createLogicalIO(s3URI), telemetry);
   }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -125,12 +125,7 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
         return new ParquetLogicalIOImpl(
             s3URI,
             new PhysicalIOImpl(
-                s3URI,
-                objectMetadataStore,
-                objectBlobStore,
-                configuration.getPhysicalIOConfiguration(),
-                telemetry,
-                streamContext),
+                s3URI, objectMetadataStore, objectBlobStore, telemetry, streamContext),
             telemetry,
             configuration.getLogicalIOConfiguration(),
             parquetColumnPrefetchStore);
@@ -139,12 +134,7 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
         return new DefaultLogicalIOImpl(
             s3URI,
             new PhysicalIOImpl(
-                s3URI,
-                objectMetadataStore,
-                objectBlobStore,
-                configuration.getPhysicalIOConfiguration(),
-                telemetry,
-                streamContext),
+                s3URI, objectMetadataStore, objectBlobStore, telemetry, streamContext),
             telemetry);
     }
   }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -33,7 +33,6 @@ public class PhysicalIOConfiguration {
   private static final int DEFAULT_CAPACITY_BLOB_STORE = 50;
   private static final int DEFAULT_CAPACITY_METADATA_STORE = 50;
   private static final boolean DEFAULT_USE_SINGLE_CACHE = true;
-  private static final boolean DEFAULT_CHANGE_DETECTION_MODE = true;
   private static final long DEFAULT_BLOCK_SIZE_BYTES = 8 * ONE_MB;
   private static final long DEFAULT_READ_AHEAD_BYTES = 64 * ONE_KB;
   private static final long DEFAULT_MAX_RANGE_SIZE = 8 * ONE_MB;
@@ -94,14 +93,6 @@ public class PhysicalIOConfiguration {
 
   private static final String SEQUENTIAL_PREFETCH_SPEED_KEY = "sequentialprefetch.speed";
 
-  /**
-   * Whether to check etags for object. {@link
-   * PhysicalIOConfiguration#DEFAULT_CHANGE_DETECTION_MODE} by default.
-   */
-  @Builder.Default private boolean detectionMode = DEFAULT_CHANGE_DETECTION_MODE;
-
-  private static final String DETECTION_MODE_KEY = "change.detection";
-
   /** Default set of settings for {@link PhysicalIO} */
   public static final PhysicalIOConfiguration DEFAULT = PhysicalIOConfiguration.builder().build();
 
@@ -120,7 +111,6 @@ public class PhysicalIOConfiguration {
         .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
         .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
         .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
-        .detectionMode(configuration.getBoolean(DETECTION_MODE_KEY, DEFAULT_CHANGE_DETECTION_MODE))
         .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
         .sequentialPrefetchBase(
             configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
@@ -143,7 +133,6 @@ public class PhysicalIOConfiguration {
    *     physical blocks. Example: A constant of 2.0 means doubling the block sizes.
    * @param sequentialPrefetchSpeed Constant controlling the rate of growth of sequentially
    *     prefetched physical blocks.
-   * @param detectionMode used to determine if the stream should check for changing object versions
    */
   @Builder
   private PhysicalIOConfiguration(
@@ -154,8 +143,7 @@ public class PhysicalIOConfiguration {
       long maxRangeSizeBytes,
       long partSizeBytes,
       double sequentialPrefetchBase,
-      double sequentialPrefetchSpeed,
-      boolean detectionMode) {
+      double sequentialPrefetchSpeed) {
     Preconditions.checkArgument(blobStoreCapacity > 0, "`blobStoreCapacity` must be positive");
     Preconditions.checkArgument(
         metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
@@ -176,7 +164,6 @@ public class PhysicalIOConfiguration {
     this.partSizeBytes = partSizeBytes;
     this.sequentialPrefetchBase = sequentialPrefetchBase;
     this.sequentialPrefetchSpeed = sequentialPrefetchSpeed;
-    this.detectionMode = detectionMode;
   }
 
   @Override
@@ -192,7 +179,6 @@ public class PhysicalIOConfiguration {
     builder.append("\tpartSizeBytes: " + partSizeBytes + "\n");
     builder.append("\tsequentialPrefetchBase: " + sequentialPrefetchBase + "\n");
     builder.append("\tsequentialPrefetchSpeed: " + sequentialPrefetchSpeed + "\n");
-    builder.append("\tdetectionMode: " + detectionMode + "\n");
 
     return builder.toString();
   }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -33,6 +33,7 @@ public class PhysicalIOConfiguration {
   private static final int DEFAULT_CAPACITY_BLOB_STORE = 50;
   private static final int DEFAULT_CAPACITY_METADATA_STORE = 50;
   private static final boolean DEFAULT_USE_SINGLE_CACHE = true;
+  private static final boolean DEFAULT_DETECTION_MODE_ON = true;
   private static final long DEFAULT_BLOCK_SIZE_BYTES = 8 * ONE_MB;
   private static final long DEFAULT_READ_AHEAD_BYTES = 64 * ONE_KB;
   private static final long DEFAULT_MAX_RANGE_SIZE = 8 * ONE_MB;
@@ -93,6 +94,14 @@ public class PhysicalIOConfiguration {
 
   private static final String SEQUENTIAL_PREFETCH_SPEED_KEY = "sequentialprefetch.speed";
 
+  /**
+   * Whether to check etags for object. {@link PhysicalIOConfiguration#DEFAULT_DETECTION_MODE_ON} by
+   * default.
+   */
+  @Builder.Default private boolean detectionModeOn = DEFAULT_DETECTION_MODE_ON;
+
+  private static final String DETECTION_MODE_ON = "detectionmodeon";
+
   /** Default set of settings for {@link PhysicalIO} */
   public static final PhysicalIOConfiguration DEFAULT = PhysicalIOConfiguration.builder().build();
 
@@ -111,6 +120,7 @@ public class PhysicalIOConfiguration {
         .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
         .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
         .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
+        .detectionModeOn(configuration.getBoolean(DETECTION_MODE_ON, DEFAULT_DETECTION_MODE_ON))
         .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
         .sequentialPrefetchBase(
             configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
@@ -133,6 +143,8 @@ public class PhysicalIOConfiguration {
    *     physical blocks. Example: A constant of 2.0 means doubling the block sizes.
    * @param sequentialPrefetchSpeed Constant controlling the rate of growth of sequentially
    *     prefetched physical blocks.
+   * @param detectionModeOn used to determine if the stream should check for changing object
+   *     versions
    */
   @Builder
   private PhysicalIOConfiguration(
@@ -143,7 +155,8 @@ public class PhysicalIOConfiguration {
       long maxRangeSizeBytes,
       long partSizeBytes,
       double sequentialPrefetchBase,
-      double sequentialPrefetchSpeed) {
+      double sequentialPrefetchSpeed,
+      boolean detectionModeOn) {
     Preconditions.checkArgument(blobStoreCapacity > 0, "`blobStoreCapacity` must be positive");
     Preconditions.checkArgument(
         metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
@@ -164,6 +177,7 @@ public class PhysicalIOConfiguration {
     this.partSizeBytes = partSizeBytes;
     this.sequentialPrefetchBase = sequentialPrefetchBase;
     this.sequentialPrefetchSpeed = sequentialPrefetchSpeed;
+    this.detectionModeOn = detectionModeOn;
   }
 
   @Override
@@ -179,6 +193,7 @@ public class PhysicalIOConfiguration {
     builder.append("\tpartSizeBytes: " + partSizeBytes + "\n");
     builder.append("\tsequentialPrefetchBase: " + sequentialPrefetchBase + "\n");
     builder.append("\tsequentialPrefetchSpeed: " + sequentialPrefetchSpeed + "\n");
+    builder.append("\tdetectionModeOn: " + detectionModeOn + "\n");
 
     return builder.toString();
   }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Blob.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Blob.java
@@ -35,7 +35,7 @@ public class Blob implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(Blob.class);
   private static final String OPERATION_EXECUTE = "blob.execute";
 
-  private final ObjectKey s3URI;
+  private final ObjectKey objectKey;
   private final BlockManager blockManager;
   private final ObjectMetadata metadata;
   private final Telemetry telemetry;
@@ -54,7 +54,7 @@ public class Blob implements Closeable {
       @NonNull BlockManager blockManager,
       @NonNull Telemetry telemetry) {
 
-    this.s3URI = objectKey;
+    this.objectKey = objectKey;
     this.metadata = metadata;
     this.blockManager = blockManager;
     this.telemetry = telemetry;
@@ -129,8 +129,8 @@ public class Blob implements Closeable {
         () ->
             Operation.builder()
                 .name(OPERATION_EXECUTE)
-                .attribute(StreamAttributes.uri(this.s3URI.getS3URI()))
-                .attribute(StreamAttributes.etag(this.s3URI.getEtag()))
+                .attribute(StreamAttributes.uri(this.objectKey.getS3URI()))
+                .attribute(StreamAttributes.etag(this.objectKey.getEtag()))
                 .attribute(StreamAttributes.ioPlan(plan))
                 .build(),
         () -> {

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
@@ -24,8 +24,9 @@ import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
+import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.StreamContext;
-import software.amazon.s3.analyticsaccelerator.util.S3URI;
+import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 
 /** A BlobStore is a container for Blobs and functions as a data cache. */
 @SuppressFBWarnings(
@@ -33,8 +34,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification =
         "Inner class is created very infrequently, and fluency justifies the extra pointer")
 public class BlobStore implements Closeable {
-  private final Map<S3URI, Blob> blobMap;
-  private final MetadataStore metadataStore;
+  private final Map<ObjectKey, Blob> blobMap;
   private final ObjectClient objectClient;
   private final Telemetry telemetry;
   private final PhysicalIOConfiguration configuration;
@@ -42,24 +42,21 @@ public class BlobStore implements Closeable {
   /**
    * Construct an instance of BlobStore.
    *
-   * @param metadataStore the MetadataStore storing object metadata information
    * @param objectClient object client capable of interacting with the underlying object store
    * @param telemetry an instance of {@link Telemetry} to use
    * @param configuration the PhysicalIO configuration
    */
   public BlobStore(
-      @NonNull MetadataStore metadataStore,
       @NonNull ObjectClient objectClient,
       @NonNull Telemetry telemetry,
       @NonNull PhysicalIOConfiguration configuration) {
-    this.metadataStore = metadataStore;
     this.objectClient = objectClient;
     this.telemetry = telemetry;
     this.blobMap =
         Collections.synchronizedMap(
-            new LinkedHashMap<S3URI, Blob>() {
+            new LinkedHashMap<ObjectKey, Blob>() {
               @Override
-              protected boolean removeEldestEntry(final Map.Entry<S3URI, Blob> eldest) {
+              protected boolean removeEldestEntry(final Map.Entry<ObjectKey, Blob> eldest) {
                 return this.size() > configuration.getBlobStoreCapacity();
               }
             });
@@ -69,20 +66,40 @@ public class BlobStore implements Closeable {
   /**
    * Opens a new blob if one does not exist or returns the handle to one that exists already.
    *
-   * @param s3URI the S3 URI of the object
+   * @param objectKey the etag and S3 URI of the object
+   * @param metadata the metadata for the object we are computing
    * @param streamContext contains audit headers to be attached in the request header
    * @return the blob representing the object from the BlobStore
    */
-  public Blob get(S3URI s3URI, StreamContext streamContext) {
+  public Blob get(ObjectKey objectKey, ObjectMetadata metadata, StreamContext streamContext) {
     return blobMap.computeIfAbsent(
-        s3URI,
+        objectKey,
         uri ->
             new Blob(
                 uri,
-                metadataStore,
+                metadata,
                 new BlockManager(
-                    uri, objectClient, metadataStore, telemetry, configuration, streamContext),
+                    uri, objectClient, metadata, telemetry, configuration, streamContext),
                 telemetry));
+  }
+
+  /**
+   * Evicts the specified key from the cache
+   *
+   * @param objectKey the etag and S3 URI of the object
+   * @return a boolean stating if the object existed or not
+   */
+  public boolean evictKey(ObjectKey objectKey) {
+    return this.blobMap.remove(objectKey) != null;
+  }
+
+  /**
+   * Returns the amount of objects currently cached in the blobstore.
+   *
+   * @return an int containing the total amount of cached blobs
+   */
+  public int blobCount() {
+    return this.blobMap.size();
   }
 
   /** Closes the {@link BlobStore} and frees up all resources it holds. */

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
@@ -94,7 +94,7 @@ public class BlobStore implements Closeable {
   }
 
   /**
-   * Returns the amount of objects currently cached in the blobstore.
+   * Returns the number of objects currently cached in the blobstore.
    *
    * @return an int containing the total amount of cached blobs
    */

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -115,11 +115,9 @@ public class Block implements Closeable {
         GetRequest.builder()
             .s3Uri(this.objectKey.getS3URI())
             .range(this.range)
+            .etag(this.objectKey.getEtag())
             .referrer(new Referrer(range.toHttpString(), readMode));
 
-    if (this.objectKey.getEtag().isPresent()) {
-      getRequestBuilder.etag(this.objectKey.getEtag().get());
-    }
     GetRequest getRequest = getRequestBuilder.build();
 
     this.source =

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -183,7 +183,7 @@ public class BlockManager implements Closeable {
             Operation.builder()
                 .name(OPERATION_MAKE_RANGE_AVAILABLE)
                 .attribute(StreamAttributes.uri(this.objectKey.getS3URI()))
-                .attribute(StreamAttributes.etag(this.metadata.getEtag()))
+                .attribute(StreamAttributes.etag(this.objectKey.getEtag()))
                 .attribute(StreamAttributes.range(pos, pos + len - 1))
                 .attribute(StreamAttributes.effectiveRange(pos, effectiveEndFinal))
                 .attribute(StreamAttributes.generation(generation))

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -177,6 +177,9 @@ public class BlockManager implements Closeable {
 
     // Fix "effectiveEnd", so we can pass it into the lambda
     final long effectiveEndFinal = effectiveEnd;
+
+    String etag = this.metadataStore.get(s3URI).getEtag();
+
     this.telemetry.measureStandard(
         () ->
             Operation.builder()
@@ -202,7 +205,8 @@ public class BlockManager implements Closeable {
                         r.getEnd(),
                         generation,
                         readMode,
-                        streamContext);
+                        streamContext,
+                        etag);
                 blockStore.add(block);
               });
         });

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStore.java
@@ -44,7 +44,7 @@ public class BlockStore implements Closeable {
    */
   public BlockStore(ObjectKey objectKey, ObjectMetadata metadata) {
     Preconditions.checkNotNull(objectKey, "`objectKey` must not be null");
-    Preconditions.checkNotNull(metadata, "`metadataStore` must not be null");
+    Preconditions.checkNotNull(metadata, "`metadata` must not be null");
 
     this.s3URI = objectKey;
     this.metadata = metadata;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStore.java
@@ -23,29 +23,30 @@ import java.util.OptionalLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.s3.analyticsaccelerator.common.Preconditions;
-import software.amazon.s3.analyticsaccelerator.util.S3URI;
+import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
+import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 
 /** A BlockStore, which is a collection of Blocks. */
 public class BlockStore implements Closeable {
 
   private static final Logger LOG = LoggerFactory.getLogger(BlockStore.class);
 
-  private final S3URI s3URI;
-  private final MetadataStore metadataStore;
+  private final ObjectKey s3URI;
+  private final ObjectMetadata metadata;
   private final List<Block> blocks;
 
   /**
    * Constructs a new instance of a BlockStore.
    *
-   * @param s3URI the object's S3 URI
-   * @param metadataStore the metadata cache
+   * @param objectKey the etag and S3 URI of the object
+   * @param metadata the metadata for the object
    */
-  public BlockStore(S3URI s3URI, MetadataStore metadataStore) {
-    Preconditions.checkNotNull(s3URI, "`s3URI` must not be null");
-    Preconditions.checkNotNull(metadataStore, "`metadataStore` must not be null");
+  public BlockStore(ObjectKey objectKey, ObjectMetadata metadata) {
+    Preconditions.checkNotNull(objectKey, "`objectKey` must not be null");
+    Preconditions.checkNotNull(metadata, "`metadataStore` must not be null");
 
-    this.s3URI = s3URI;
-    this.metadataStore = metadataStore;
+    this.s3URI = objectKey;
+    this.metadata = metadata;
     this.blocks = new LinkedList<>();
   }
 
@@ -114,7 +115,7 @@ public class BlockStore implements Closeable {
   }
 
   private long getLastObjectByte() {
-    return this.metadataStore.get(s3URI).getContentLength() - 1;
+    return this.metadata.getContentLength() - 1;
   }
 
   private void safeClose(Block block) {

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStore.java
@@ -89,6 +89,16 @@ public class MetadataStore implements Closeable {
   }
 
   /**
+   * Evicts the specified key from the cache
+   *
+   * @param s3URI the s3 uri of the object to evict
+   * @return a boolean stating if the object existed or not
+   */
+  public boolean evictKey(S3URI s3URI) {
+    return this.cache.remove(s3URI) != null;
+  }
+
+  /**
    * Get the metadata for an object asynchronously (either from cache or the underlying object
    * store).
    *

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
@@ -27,16 +27,18 @@ import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlan;
 import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlanExecution;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.StreamContext;
+import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 import software.amazon.s3.analyticsaccelerator.util.StreamAttributes;
 
 /** A PhysicalIO frontend */
 public class PhysicalIOImpl implements PhysicalIO {
-  private final S3URI s3URI;
-  private final MetadataStore metadataStore;
-  private final BlobStore blobStore;
+  private MetadataStore metadataStore;
+  private BlobStore blobStore;
   private final Telemetry telemetry;
   private final StreamContext streamContext;
+  private ObjectKey objectKey;
+  private final ObjectMetadata metadata;
 
   private final long physicalIOBirth = System.nanoTime();
 
@@ -76,11 +78,13 @@ public class PhysicalIOImpl implements PhysicalIO {
       @NonNull BlobStore blobStore,
       @NonNull Telemetry telemetry,
       StreamContext streamContext) {
-    this.s3URI = s3URI;
     this.metadataStore = metadataStore;
     this.blobStore = blobStore;
     this.telemetry = telemetry;
     this.streamContext = streamContext;
+
+    this.metadata = this.metadataStore.get(s3URI);
+    this.objectKey = ObjectKey.builder().etag(metadata.getEtag()).s3URI(s3URI).build();
   }
 
   /**
@@ -90,7 +94,7 @@ public class PhysicalIOImpl implements PhysicalIO {
    */
   @Override
   public ObjectMetadata metadata() {
-    return metadataStore.get(s3URI);
+    return metadata;
   }
 
   /**
@@ -103,19 +107,24 @@ public class PhysicalIOImpl implements PhysicalIO {
   public int read(long pos) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
     Preconditions.checkArgument(pos < contentLength(), "`pos` must be less than content length");
-
-    return this.telemetry.measureVerbose(
-        () ->
-            Operation.builder()
-                .name(OPERATION_READ)
-                .attribute(StreamAttributes.variant(FLAVOR_BYTE))
-                .attribute(StreamAttributes.uri(this.s3URI))
-                .attribute(StreamAttributes.range(pos, pos))
-                .attribute(
-                    StreamAttributes.physicalIORelativeTimestamp(
-                        System.nanoTime() - physicalIOBirth))
-                .build(),
-        () -> blobStore.get(s3URI, streamContext).read(pos));
+    try {
+      return this.telemetry.measureVerbose(
+          () ->
+              Operation.builder()
+                  .name(OPERATION_READ)
+                  .attribute(StreamAttributes.variant(FLAVOR_BYTE))
+                  .attribute(StreamAttributes.uri(this.objectKey.getS3URI()))
+                  .attribute(StreamAttributes.etag(this.objectKey.getEtag()))
+                  .attribute(StreamAttributes.range(pos, pos))
+                  .attribute(
+                      StreamAttributes.physicalIORelativeTimestamp(
+                          System.nanoTime() - physicalIOBirth))
+                  .build(),
+          () -> blobStore.get(this.objectKey, this.metadata, streamContext).read(pos));
+    } catch (Exception e) {
+      handleOperationExceptions(e);
+      throw e;
+    }
   }
 
   /**
@@ -135,17 +144,23 @@ public class PhysicalIOImpl implements PhysicalIO {
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
     Preconditions.checkArgument(off < buf.length, "`off` must be less than size of buffer");
 
-    return this.telemetry.measureVerbose(
-        () ->
-            Operation.builder()
-                .name(OPERATION_READ)
-                .attribute(StreamAttributes.uri(this.s3URI))
-                .attribute(StreamAttributes.range(pos, pos + len - 1))
-                .attribute(
-                    StreamAttributes.physicalIORelativeTimestamp(
-                        System.nanoTime() - physicalIOBirth))
-                .build(),
-        () -> blobStore.get(s3URI, streamContext).read(buf, off, len, pos));
+    try {
+      return this.telemetry.measureVerbose(
+          () ->
+              Operation.builder()
+                  .name(OPERATION_READ)
+                  .attribute(StreamAttributes.uri(this.objectKey.getS3URI()))
+                  .attribute(StreamAttributes.etag(this.objectKey.getEtag()))
+                  .attribute(StreamAttributes.range(pos, pos + len - 1))
+                  .attribute(
+                      StreamAttributes.physicalIORelativeTimestamp(
+                          System.nanoTime() - physicalIOBirth))
+                  .build(),
+          () -> blobStore.get(objectKey, this.metadata, streamContext).read(buf, off, len, pos));
+    } catch (Exception e) {
+      handleOperationExceptions(e);
+      throw e;
+    }
   }
 
   /**
@@ -161,18 +176,27 @@ public class PhysicalIOImpl implements PhysicalIO {
   public int readTail(byte[] buf, int off, int len) throws IOException {
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
     long contentLength = contentLength();
-    return telemetry.measureVerbose(
-        () ->
-            Operation.builder()
-                .name(OPERATION_READ)
-                .attribute(StreamAttributes.variant(FLAVOR_TAIL))
-                .attribute(StreamAttributes.uri(this.s3URI))
-                .attribute(StreamAttributes.range(contentLength - len, contentLength - 1))
-                .attribute(
-                    StreamAttributes.physicalIORelativeTimestamp(
-                        System.nanoTime() - physicalIOBirth))
-                .build(),
-        () -> blobStore.get(s3URI, streamContext).read(buf, off, len, contentLength - len));
+    try {
+      return telemetry.measureVerbose(
+          () ->
+              Operation.builder()
+                  .name(OPERATION_READ)
+                  .attribute(StreamAttributes.variant(FLAVOR_TAIL))
+                  .attribute(StreamAttributes.uri(objectKey.getS3URI()))
+                  .attribute(StreamAttributes.etag(objectKey.getEtag()))
+                  .attribute(StreamAttributes.range(contentLength - len, contentLength - 1))
+                  .attribute(
+                      StreamAttributes.physicalIORelativeTimestamp(
+                          System.nanoTime() - physicalIOBirth))
+                  .build(),
+          () ->
+              blobStore
+                  .get(objectKey, this.metadata, streamContext)
+                  .read(buf, off, len, contentLength - len));
+    } catch (Exception e) {
+      handleOperationExceptions(e);
+      throw e;
+    }
   }
 
   /**
@@ -183,17 +207,29 @@ public class PhysicalIOImpl implements PhysicalIO {
    */
   @Override
   public IOPlanExecution execute(IOPlan ioPlan) {
-    return telemetry.measureVerbose(
-        () ->
-            Operation.builder()
-                .name(OPERATION_EXECUTE)
-                .attribute(StreamAttributes.uri(this.s3URI))
-                .attribute(StreamAttributes.ioPlan(ioPlan))
-                .attribute(
-                    StreamAttributes.physicalIORelativeTimestamp(
-                        System.nanoTime() - physicalIOBirth))
-                .build(),
-        () -> blobStore.get(s3URI, streamContext).execute(ioPlan));
+    try {
+      return telemetry.measureVerbose(
+          () ->
+              Operation.builder()
+                  .name(OPERATION_EXECUTE)
+                  .attribute(StreamAttributes.uri(objectKey.getS3URI()))
+                  .attribute(StreamAttributes.etag(this.objectKey.getEtag()))
+                  .attribute(StreamAttributes.ioPlan(ioPlan))
+                  .attribute(
+                      StreamAttributes.physicalIORelativeTimestamp(
+                          System.nanoTime() - physicalIOBirth))
+                  .build(),
+          () -> blobStore.get(objectKey, this.metadata, streamContext).execute(ioPlan));
+    } catch (Exception e) {
+      handleOperationExceptions(e);
+      throw e;
+    }
+  }
+
+  private void handleOperationExceptions(Exception e) {
+    System.out.println("Exception here: evicting bad key" + e);
+    metadataStore.evictKey(this.objectKey.getS3URI());
+    blobStore.evictKey(this.objectKey);
   }
 
   private long contentLength() {

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
@@ -247,7 +247,7 @@ public class PhysicalIOImpl implements PhysicalIO {
     }
   }
 
-  private long contentLength() throws IOException {
+  private long contentLength() {
     return metadata().getContentLength();
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamAttributes.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamAttributes.java
@@ -15,7 +15,6 @@
  */
 package software.amazon.s3.analyticsaccelerator.util;
 
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Attribute;
@@ -58,12 +57,8 @@ public enum StreamAttributes {
    * @param etag the etag to create the attribute from.
    * @return The new instance of the {@link Attribute}.
    */
-  public static Attribute etag(Optional<String> etag) {
-    if (etag.isPresent()) {
-      return Attribute.of(StreamAttributes.ETAG.getName(), etag);
-    } else {
-      return Attribute.of(StreamAttributes.ETAG.getName(), "NO_ETAG");
-    }
+  public static Attribute etag(String etag) {
+    return Attribute.of(StreamAttributes.ETAG.getName(), etag);
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamAttributes.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamAttributes.java
@@ -15,6 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator.util;
 
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Attribute;
@@ -57,8 +58,12 @@ public enum StreamAttributes {
    * @param etag the etag to create the attribute from.
    * @return The new instance of the {@link Attribute}.
    */
-  public static Attribute etag(String etag) {
-    return Attribute.of(StreamAttributes.ETAG.getName(), etag);
+  public static Attribute etag(Optional<String> etag) {
+    if (etag.isPresent()) {
+      return Attribute.of(StreamAttributes.ETAG.getName(), etag);
+    } else {
+      return Attribute.of(StreamAttributes.ETAG.getName(), "NO_ETAG");
+    }
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamAttributes.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamAttributes.java
@@ -26,6 +26,7 @@ import software.amazon.s3.analyticsaccelerator.request.Range;
 @AllArgsConstructor
 public enum StreamAttributes {
   URI("uri"),
+  ETAG("etag"),
   RANGE("range"),
   VARIANT("variant"),
   EFFECTIVE_RANGE("range.effective"),
@@ -48,6 +49,16 @@ public enum StreamAttributes {
    */
   public static Attribute uri(S3URI s3URI) {
     return Attribute.of(StreamAttributes.URI.getName(), s3URI.toString());
+  }
+
+  /**
+   * Creates an {@link Attribute} for a etag.
+   *
+   * @param etag the etag to create the attribute from.
+   * @return The new instance of the {@link Attribute}.
+   */
+  public static Attribute etag(String etag) {
+    return Attribute.of(StreamAttributes.ETAG.getName(), etag);
   }
 
   /**

--- a/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/InMemoryS3SeekableInputStream.java
+++ b/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/InMemoryS3SeekableInputStream.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
@@ -65,7 +64,7 @@ public class InMemoryS3SeekableInputStream extends SeekableInputStream {
     @Override
     public CompletableFuture<ObjectMetadata> headObject(HeadRequest headRequest) {
       return CompletableFuture.completedFuture(
-          ObjectMetadata.builder().contentLength(size).etag(Optional.of(etag)).build());
+          ObjectMetadata.builder().contentLength(size).etag(etag).build());
     }
 
     @Override

--- a/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/InMemoryS3SeekableInputStream.java
+++ b/input-stream/src/referenceTest/java/software/amazon/s3/analyticsaccelerator/property/InMemoryS3SeekableInputStream.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
@@ -49,7 +50,7 @@ public class InMemoryS3SeekableInputStream extends SeekableInputStream {
   }
 
   private static class InMemoryObjectClient implements ObjectClient {
-
+    private static final String etag = "Random";
     private final int size;
     private byte[] content;
 
@@ -64,7 +65,7 @@ public class InMemoryS3SeekableInputStream extends SeekableInputStream {
     @Override
     public CompletableFuture<ObjectMetadata> headObject(HeadRequest headRequest) {
       return CompletableFuture.completedFuture(
-          ObjectMetadata.builder().contentLength(size).build());
+          ObjectMetadata.builder().contentLength(size).etag(Optional.of(etag)).build());
     }
 
     @Override

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
@@ -38,7 +38,6 @@ import software.amazon.s3.analyticsaccelerator.exceptions.ExceptionHandler;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.DefaultLogicalIOImpl;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.ParquetLogicalIOImpl;
-import software.amazon.s3.analyticsaccelerator.request.*;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.StreamContext;
@@ -51,7 +50,7 @@ public class S3SeekableInputStreamFactoryTest {
   private static S3URI s3URI = S3URI.of("bucket", "key");
   private static int CONTENT_LENGTH = 500;
   private static final ObjectMetadata objectMetadata =
-      ObjectMetadata.builder().contentLength(CONTENT_LENGTH).etag(Optional.of("ETAG")).build();
+      ObjectMetadata.builder().contentLength(CONTENT_LENGTH).etag("ETAG").build();
 
   private static final S3URI TEST_URI = S3URI.of("test-bucket", "test-key");
 
@@ -120,29 +119,8 @@ public class S3SeekableInputStreamFactoryTest {
         CONTENT_LENGTH,
         s3SeekableInputStreamFactory.getObjectMetadataStore().get(s3URI).getContentLength());
     assertEquals(
-        objectMetadata.getEtag().get(),
-        s3SeekableInputStreamFactory.getObjectMetadataStore().get(s3URI).getEtag().get());
-  }
-
-  @Test
-  void testCreateStreamWithJustContentLength() throws IOException {
-    S3SeekableInputStreamFactory s3SeekableInputStreamFactory =
-        new S3SeekableInputStreamFactory(
-            mock(ObjectClient.class),
-            S3SeekableInputStreamConfiguration.builder()
-                .logicalIOConfiguration(
-                    LogicalIOConfiguration.builder().prefetchFooterEnabled(false).build())
-                .build());
-    S3SeekableInputStream inputStream =
-        s3SeekableInputStreamFactory.createStream(
-            s3URI,
-            ObjectMetadata.builder().contentLength(CONTENT_LENGTH).etag(Optional.empty()).build());
-    assertNotNull(inputStream);
-    assertEquals(
-        CONTENT_LENGTH,
-        s3SeekableInputStreamFactory.getObjectMetadataStore().get(s3URI).getContentLength());
-    assertFalse(
-        s3SeekableInputStreamFactory.getObjectMetadataStore().get(s3URI).getEtag().isPresent());
+        objectMetadata.getEtag(),
+        s3SeekableInputStreamFactory.getObjectMetadataStore().get(s3URI).getEtag());
   }
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.utils.IoUtils;
@@ -323,7 +324,8 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     // Given: seekable stream
     LogicalIO mockLogicalIO = mock(LogicalIO.class);
     when(mockLogicalIO.metadata())
-        .thenReturn(ObjectMetadata.builder().contentLength(200).etag("random").build());
+        .thenReturn(
+            ObjectMetadata.builder().contentLength(200).etag(Optional.of("RANDOM")).build());
     try (S3SeekableInputStream stream =
         new S3SeekableInputStream(TEST_URI, mockLogicalIO, TestTelemetry.DEFAULT)) {
 
@@ -363,7 +365,12 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
               () -> {
                 try {
                   PhysicalIO physicalIO =
-                      new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+                      new PhysicalIOImpl(
+                          s3URI,
+                          metadataStore,
+                          blobStore,
+                          PhysicalIOConfiguration.DEFAULT,
+                          TestTelemetry.DEFAULT);
                   LogicalIO logicalIO =
                       new ParquetLogicalIOImpl(
                           TEST_OBJECT,
@@ -453,7 +460,12 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
         s3URI,
         new ParquetLogicalIOImpl(
             s3URI,
-            new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT),
+            new PhysicalIOImpl(
+                s3URI,
+                metadataStore,
+                blobStore,
+                PhysicalIOConfiguration.DEFAULT,
+                TestTelemetry.DEFAULT),
             TestTelemetry.DEFAULT,
             LogicalIOConfiguration.DEFAULT,
             new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)),

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -25,7 +25,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.utils.IoUtils;
@@ -324,8 +323,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     // Given: seekable stream
     LogicalIO mockLogicalIO = mock(LogicalIO.class);
     when(mockLogicalIO.metadata())
-        .thenReturn(
-            ObjectMetadata.builder().contentLength(200).etag(Optional.of("RANDOM")).build());
+        .thenReturn(ObjectMetadata.builder().contentLength(200).etag("RANDOM").build());
     try (S3SeekableInputStream stream =
         new S3SeekableInputStream(TEST_URI, mockLogicalIO, TestTelemetry.DEFAULT)) {
 
@@ -365,12 +363,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
               () -> {
                 try {
                   PhysicalIO physicalIO =
-                      new PhysicalIOImpl(
-                          s3URI,
-                          metadataStore,
-                          blobStore,
-                          PhysicalIOConfiguration.DEFAULT,
-                          TestTelemetry.DEFAULT);
+                      new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
                   LogicalIO logicalIO =
                       new ParquetLogicalIOImpl(
                           TEST_OBJECT,
@@ -461,12 +454,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
         s3URI,
         new ParquetLogicalIOImpl(
             s3URI,
-            new PhysicalIOImpl(
-                s3URI,
-                metadataStore,
-                blobStore,
-                PhysicalIOConfiguration.DEFAULT,
-                TestTelemetry.DEFAULT),
+            new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT),
             TestTelemetry.DEFAULT,
             LogicalIOConfiguration.DEFAULT,
             new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)),

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -322,7 +322,8 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
   void testMinusOneIsHandledProperly() throws IOException {
     // Given: seekable stream
     LogicalIO mockLogicalIO = mock(LogicalIO.class);
-    when(mockLogicalIO.metadata()).thenReturn(ObjectMetadata.builder().contentLength(200).build());
+    when(mockLogicalIO.metadata())
+        .thenReturn(ObjectMetadata.builder().contentLength(200).etag("random").build());
     try (S3SeekableInputStream stream =
         new S3SeekableInputStream(TEST_URI, mockLogicalIO, TestTelemetry.DEFAULT)) {
 
@@ -350,11 +351,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     MetadataStore metadataStore =
         new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
-        new BlobStore(
-            metadataStore,
-            fakeObjectClient,
-            TestTelemetry.DEFAULT,
-            PhysicalIOConfiguration.DEFAULT);
+        new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
 
     AtomicReference<Throwable> thrown = new AtomicReference<>();
 
@@ -450,11 +447,7 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
     MetadataStore metadataStore =
         new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
-        new BlobStore(
-            metadataStore,
-            fakeObjectClient,
-            TestTelemetry.DEFAULT,
-            PhysicalIOConfiguration.DEFAULT);
+        new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
 
     return new S3SeekableInputStream(
         s3URI,

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
@@ -36,8 +36,7 @@ public class S3SeekableInputStreamTestBase {
   protected final MetadataStore metadataStore =
       new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
   protected final BlobStore blobStore =
-      new BlobStore(
-          metadataStore, fakeObjectClient, TestTelemetry.DEFAULT, physicalIOConfiguration);
+      new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, physicalIOConfiguration);
   protected final LogicalIOConfiguration logicalIOConfiguration = LogicalIOConfiguration.DEFAULT;
 
   protected final LogicalIO fakeLogicalIO =

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
@@ -42,7 +42,12 @@ public class S3SeekableInputStreamTestBase {
   protected final LogicalIO fakeLogicalIO =
       new ParquetLogicalIOImpl(
           TEST_OBJECT,
-          new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
+          new PhysicalIOImpl(
+              TEST_OBJECT,
+              metadataStore,
+              blobStore,
+              PhysicalIOConfiguration.DEFAULT,
+              TestTelemetry.DEFAULT),
           TestTelemetry.DEFAULT,
           logicalIOConfiguration,
           new ParquetColumnPrefetchStore(logicalIOConfiguration));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
@@ -47,12 +47,7 @@ public class S3SeekableInputStreamTestBase {
       fakeLogicalIO =
           new ParquetLogicalIOImpl(
               TEST_OBJECT,
-              new PhysicalIOImpl(
-                  TEST_OBJECT,
-                  metadataStore,
-                  blobStore,
-                  PhysicalIOConfiguration.DEFAULT,
-                  TestTelemetry.DEFAULT),
+              new PhysicalIOImpl(TEST_OBJECT, metadataStore, blobStore, TestTelemetry.DEFAULT),
               TestTelemetry.DEFAULT,
               logicalIOConfiguration,
               new ParquetColumnPrefetchStore(logicalIOConfiguration));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/DefaultLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/DefaultLogicalIOImplTest.java
@@ -91,7 +91,8 @@ public class DefaultLogicalIOImplTest {
   @Test
   void testReadTail() throws IOException {
     PhysicalIO physicalIO = mock(PhysicalIO.class);
-    when(physicalIO.metadata()).thenReturn(ObjectMetadata.builder().contentLength(123).build());
+    when(physicalIO.metadata())
+        .thenReturn(ObjectMetadata.builder().contentLength(123).etag("random").build());
     DefaultLogicalIOImpl logicalIO = new DefaultLogicalIOImpl(TEST_URI, physicalIO, Telemetry.NOOP);
     byte[] buffer = new byte[5];
     logicalIO.readTail(buffer, 0, 5);

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -158,6 +158,34 @@ public class ParquetLogicalIOImplTest {
   }
 
   @Test
+  void testMetadataWithMissingEtag() throws IOException {
+    ObjectClient mockClient = mock(ObjectClient.class);
+    when(mockClient.headObject(any(HeadRequest.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(ObjectMetadata.builder().contentLength(0).build()));
+    S3URI s3URI = S3URI.of("test", "test");
+    MetadataStore metadataStore =
+        new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
+    BlobStore blobStore =
+        new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
+    PhysicalIOImpl physicalIO =
+        new PhysicalIOImpl(
+            s3URI,
+            metadataStore,
+            blobStore,
+            PhysicalIOConfiguration.DEFAULT,
+            TestTelemetry.DEFAULT);
+    assertDoesNotThrow(
+        () ->
+            new ParquetLogicalIOImpl(
+                TEST_URI,
+                physicalIO,
+                TestTelemetry.DEFAULT,
+                LogicalIOConfiguration.DEFAULT,
+                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
+  }
+
+  @Test
   void testMetadataWithNegativeContentLength() throws IOException {
     ObjectClient mockClient = mock(ObjectClient.class);
     when(mockClient.headObject(any(HeadRequest.class)))

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -122,13 +122,13 @@ public class ParquetLogicalIOImplTest {
     ObjectClient mockClient = mock(ObjectClient.class);
     when(mockClient.headObject(any(HeadRequest.class)))
         .thenReturn(
-            CompletableFuture.completedFuture(ObjectMetadata.builder().contentLength(0).build()));
+            CompletableFuture.completedFuture(
+                ObjectMetadata.builder().contentLength(0).etag("random").build()));
     S3URI s3URI = S3URI.of("test", "test");
     MetadataStore metadataStore =
         new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
-        new BlobStore(
-            metadataStore, mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
+        new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
         new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     assertDoesNotThrow(
@@ -146,13 +146,13 @@ public class ParquetLogicalIOImplTest {
     ObjectClient mockClient = mock(ObjectClient.class);
     when(mockClient.headObject(any(HeadRequest.class)))
         .thenReturn(
-            CompletableFuture.completedFuture(ObjectMetadata.builder().contentLength(-1).build()));
+            CompletableFuture.completedFuture(
+                ObjectMetadata.builder().contentLength(-1).etag("random").build()));
     S3URI s3URI = S3URI.of("test", "test");
     MetadataStore metadataStore =
         new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
-        new BlobStore(
-            metadataStore, mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
+        new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
         new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     assertDoesNotThrow(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -134,47 +133,14 @@ public class ParquetLogicalIOImplTest {
     when(mockClient.headObject(any(HeadRequest.class)))
         .thenReturn(
             CompletableFuture.completedFuture(
-                ObjectMetadata.builder().contentLength(0).etag(Optional.of("random")).build()));
+                ObjectMetadata.builder().contentLength(0).etag("random").build()));
     S3URI s3URI = S3URI.of("test", "test");
     MetadataStore metadataStore =
         new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(
-            s3URI,
-            metadataStore,
-            blobStore,
-            PhysicalIOConfiguration.DEFAULT,
-            TestTelemetry.DEFAULT);
-    assertDoesNotThrow(
-        () ->
-            new ParquetLogicalIOImpl(
-                TEST_URI,
-                physicalIO,
-                TestTelemetry.DEFAULT,
-                LogicalIOConfiguration.DEFAULT,
-                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
-  }
-
-  @Test
-  void testMetadataWithMissingEtag() throws IOException {
-    ObjectClient mockClient = mock(ObjectClient.class);
-    when(mockClient.headObject(any(HeadRequest.class)))
-        .thenReturn(
-            CompletableFuture.completedFuture(ObjectMetadata.builder().contentLength(0).build()));
-    S3URI s3URI = S3URI.of("test", "test");
-    MetadataStore metadataStore =
-        new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
-    BlobStore blobStore =
-        new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
-    PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(
-            s3URI,
-            metadataStore,
-            blobStore,
-            PhysicalIOConfiguration.DEFAULT,
-            TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(
@@ -191,19 +157,14 @@ public class ParquetLogicalIOImplTest {
     when(mockClient.headObject(any(HeadRequest.class)))
         .thenReturn(
             CompletableFuture.completedFuture(
-                ObjectMetadata.builder().contentLength(-1).etag(Optional.of("random")).build()));
+                ObjectMetadata.builder().contentLength(-1).etag("random").build()));
     S3URI s3URI = S3URI.of("test", "test");
     MetadataStore metadataStore =
         new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(
-            s3URI,
-            metadataStore,
-            blobStore,
-            PhysicalIOConfiguration.DEFAULT,
-            TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -90,6 +91,16 @@ public class ParquetLogicalIOImplTest {
                 TestTelemetry.DEFAULT,
                 mock(LogicalIOConfiguration.class),
                 null));
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new ParquetLogicalIOImpl(
+                null,
+                mock(PhysicalIO.class),
+                TestTelemetry.DEFAULT,
+                mock(LogicalIOConfiguration.class),
+                mock(ParquetColumnPrefetchStore.class)));
   }
 
   @Test
@@ -123,14 +134,19 @@ public class ParquetLogicalIOImplTest {
     when(mockClient.headObject(any(HeadRequest.class)))
         .thenReturn(
             CompletableFuture.completedFuture(
-                ObjectMetadata.builder().contentLength(0).etag("random").build()));
+                ObjectMetadata.builder().contentLength(0).etag(Optional.of("random")).build()));
     S3URI s3URI = S3URI.of("test", "test");
     MetadataStore metadataStore =
         new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI,
+            metadataStore,
+            blobStore,
+            PhysicalIOConfiguration.DEFAULT,
+            TestTelemetry.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(
@@ -147,14 +163,19 @@ public class ParquetLogicalIOImplTest {
     when(mockClient.headObject(any(HeadRequest.class)))
         .thenReturn(
             CompletableFuture.completedFuture(
-                ObjectMetadata.builder().contentLength(-1).etag("random").build()));
+                ObjectMetadata.builder().contentLength(-1).etag(Optional.of("random")).build()));
     S3URI s3URI = S3URI.of("test", "test");
     MetadataStore metadataStore =
         new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlobStore blobStore =
         new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI,
+            metadataStore,
+            blobStore,
+            PhysicalIOConfiguration.DEFAULT,
+            TestTelemetry.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTaskTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTaskTest.java
@@ -93,7 +93,10 @@ public class ParquetPrefetchTailTaskTest {
     for (Map.Entry<Long, List<Range>> contentLengthToRangeList : contentSizeToRanges.entrySet()) {
       PhysicalIOImpl mockedPhysicalIO = mock(PhysicalIOImpl.class);
       ObjectMetadata metadata =
-          ObjectMetadata.builder().contentLength(contentLengthToRangeList.getKey()).build();
+          ObjectMetadata.builder()
+              .contentLength(contentLengthToRangeList.getKey())
+              .etag("random")
+              .build();
       when(mockedPhysicalIO.metadata()).thenReturn(metadata);
 
       ParquetPrefetchTailTask parquetPrefetchTailTask =
@@ -117,7 +120,7 @@ public class ParquetPrefetchTailTaskTest {
             TEST_URI, Telemetry.NOOP, LogicalIOConfiguration.DEFAULT, mockedPhysicalIO);
 
     // When: task executes but PhysicalIO throws
-    ObjectMetadata metadata = ObjectMetadata.builder().contentLength(600).build();
+    ObjectMetadata metadata = ObjectMetadata.builder().contentLength(600).etag("random").build();
     when(mockedPhysicalIO.metadata()).thenReturn(metadata);
     doThrow(new IOException("Error in prefetch")).when(mockedPhysicalIO).execute(any(IOPlan.class));
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetReadTailTaskTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetReadTailTaskTest.java
@@ -75,7 +75,7 @@ public class ParquetReadTailTaskTest {
     // Given: read tail task
     PhysicalIO mockedPhysicalIO = mock(PhysicalIO.class);
     when(mockedPhysicalIO.metadata())
-        .thenReturn(ObjectMetadata.builder().contentLength(800).build());
+        .thenReturn(ObjectMetadata.builder().etag("random").contentLength(800).build());
     ParquetReadTailTask parquetReadTailTask =
         new ParquetReadTailTask(
             TEST_URI, Telemetry.NOOP, LogicalIOConfiguration.DEFAULT, mockedPhysicalIO);
@@ -95,7 +95,7 @@ public class ParquetReadTailTaskTest {
     // Given: read tail task with a throwing physicalIO under the hood
     PhysicalIO mockedPhysicalIO = mock(PhysicalIO.class);
     when(mockedPhysicalIO.metadata())
-        .thenReturn(ObjectMetadata.builder().contentLength(800).build());
+        .thenReturn(ObjectMetadata.builder().contentLength(800).etag("random").build());
     when(mockedPhysicalIO.readTail(any(), anyInt(), anyInt()))
         .thenThrow(new IOException("Something went horribly wrong."));
     ParquetReadTailTask parquetReadTailTask =

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
@@ -71,7 +71,6 @@ public class PhysicalIOConfigurationTest {
             + "\tmaxRangeSizeBytes: 8388608\n"
             + "\tpartSizeBytes: 20\n"
             + "\tsequentialPrefetchBase: 2.0\n"
-            + "\tsequentialPrefetchSpeed: 1.0\n"
-            + "\tdetectionMode: true\n");
+            + "\tsequentialPrefetchSpeed: 1.0\n");
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
@@ -71,6 +71,7 @@ public class PhysicalIOConfigurationTest {
             + "\tmaxRangeSizeBytes: 8388608\n"
             + "\tpartSizeBytes: 20\n"
             + "\tsequentialPrefetchBase: 2.0\n"
-            + "\tsequentialPrefetchSpeed: 1.0\n");
+            + "\tsequentialPrefetchSpeed: 1.0\n"
+            + "\tdetectionModeOn: true\n");
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -41,7 +40,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class BlobStoreTest {
   private static final String TEST_DATA = "test-data";
-  private static final Optional<String> ETAG = Optional.of("random");
+  private static final String ETAG = "random";
   private static final ObjectMetadata objectMetadata =
       ObjectMetadata.builder().contentLength(TEST_DATA.length()).etag(ETAG).build();
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -39,7 +40,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class BlobStoreTest {
   private static final String TEST_DATA = "test-data";
-  private static final String ETAG = "random";
+  private static final Optional<String> ETAG = Optional.of("random");
   private static final ObjectMetadata objectMetadata =
       ObjectMetadata.builder().contentLength(TEST_DATA.length()).etag(ETAG).build();
 
@@ -53,8 +54,7 @@ public class BlobStoreTest {
     ObjectClient objectClient = new FakeObjectClient("test-data");
     MetadataStore metadataStore = mock(MetadataStore.class);
     when(metadataStore.get(any()))
-        .thenReturn(
-            ObjectMetadata.builder().contentLength(TEST_DATA.length()).etag("random").build());
+        .thenReturn(ObjectMetadata.builder().contentLength(TEST_DATA.length()).etag(ETAG).build());
     blobStore = new BlobStore(objectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
   }
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
@@ -30,63 +31,81 @@ import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.StreamContext;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
+import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 @SuppressFBWarnings(
     value = "NP_NONNULL_PARAM_VIOLATION",
     justification = "We mean to pass nulls to checks")
 public class BlobStoreTest {
+  private static final String TEST_DATA = "test-data";
+  private static final String ETAG = "random";
+  private static final ObjectMetadata objectMetadata =
+      ObjectMetadata.builder().contentLength(TEST_DATA.length()).etag(ETAG).build();
+
+  private static final ObjectKey objectKey =
+      ObjectKey.builder().s3URI(S3URI.of("test", "test")).etag(ETAG).build();
+
+  private BlobStore blobStore;
+
+  @BeforeEach
+  void setUp() {
+    ObjectClient objectClient = new FakeObjectClient("test-data");
+    MetadataStore metadataStore = mock(MetadataStore.class);
+    when(metadataStore.get(any()))
+        .thenReturn(
+            ObjectMetadata.builder().contentLength(TEST_DATA.length()).etag("random").build());
+    blobStore = new BlobStore(objectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
+  }
+
   @Test
   void testCreateBoundaries() {
     assertThrows(
         NullPointerException.class,
-        () ->
-            new BlobStore(
-                null,
-                mock(ObjectClient.class),
-                mock(Telemetry.class),
-                mock(PhysicalIOConfiguration.class)));
+        () -> new BlobStore(null, mock(Telemetry.class), mock(PhysicalIOConfiguration.class)));
     assertThrows(
         NullPointerException.class,
-        () ->
-            new BlobStore(
-                mock(MetadataStore.class),
-                null,
-                mock(Telemetry.class),
-                mock(PhysicalIOConfiguration.class)));
+        () -> new BlobStore(null, mock(Telemetry.class), mock(PhysicalIOConfiguration.class)));
     assertThrows(
         NullPointerException.class,
-        () ->
-            new BlobStore(
-                mock(MetadataStore.class),
-                mock(ObjectClient.class),
-                null,
-                mock(PhysicalIOConfiguration.class)));
+        () -> new BlobStore(mock(ObjectClient.class), null, mock(PhysicalIOConfiguration.class)));
     assertThrows(
         NullPointerException.class,
-        () ->
-            new BlobStore(
-                mock(MetadataStore.class), mock(ObjectClient.class), mock(Telemetry.class), null));
+        () -> new BlobStore(mock(ObjectClient.class), mock(Telemetry.class), null));
   }
 
   @Test
   public void testGetReturnsReadableBlob() {
-    // Given: a BlobStore with an underlying metadata store and object client
-    final String TEST_DATA = "test-data";
-    ObjectClient objectClient = new FakeObjectClient("test-data");
-    MetadataStore metadataStore = mock(MetadataStore.class);
-    when(metadataStore.get(any()))
-        .thenReturn(ObjectMetadata.builder().contentLength(TEST_DATA.length()).build());
-    BlobStore blobStore =
-        new BlobStore(
-            metadataStore, objectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
-
     // When: a Blob is asked for
-    Blob blob = blobStore.get(S3URI.of("test", "test"), mock(StreamContext.class));
+    Blob blob = blobStore.get(objectKey, objectMetadata, mock(StreamContext.class));
 
     // Then:
     byte[] b = new byte[TEST_DATA.length()];
     blob.read(b, 0, b.length, 0);
     assertEquals(TEST_DATA, new String(b, StandardCharsets.UTF_8));
+    assertEquals(1, blobStore.blobCount());
+  }
+
+  @Test
+  void testEvictKey_ExistingKey() {
+    // Setup
+    blobStore.get(objectKey, objectMetadata, mock(StreamContext.class));
+
+    // Test
+    boolean result = blobStore.evictKey(objectKey);
+
+    // Verify
+    assertTrue(result, "Evicting existing key should return true");
+    assertEquals(0, blobStore.blobCount(), "Cache should be empty after eviction");
+  }
+
+  @Test
+  void testEvictKey_NonExistingKey() {
+    // Test
+    boolean result = blobStore.evictKey(objectKey);
+
+    // Verify
+    assertFalse(result, "Evicting non-existing key should return false");
+    assertEquals(0, blobStore.blobCount(), "Cache should remain empty");
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
@@ -44,7 +43,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class BlobTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
-  private static final Optional<String> ETAG = Optional.of("RandomString");
+  private static final String ETAG = "RandomString";
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
   private static final String TEST_DATA = "test-data-0123456789";
   private static final int OBJECT_SIZE = 100;

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
@@ -25,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
@@ -42,7 +43,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class BlobTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
-  private static final String ETAG = "random";
+  private static final Optional<String> ETAG = Optional.of("RandomString");
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
   private static final String TEST_DATA = "test-data-0123456789";
   private static final int OBJECT_SIZE = 100;

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
@@ -30,9 +30,11 @@ import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlan;
 import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlanExecution;
+import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.Range;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
+import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 @SuppressFBWarnings(
@@ -40,25 +42,30 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class BlobTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
+  private static final String ETAG = "random";
+  private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
   private static final String TEST_DATA = "test-data-0123456789";
+  private static final int OBJECT_SIZE = 100;
+  ObjectMetadata mockMetadataStore =
+      ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
 
   @Test
   void testCreateBoundaries() {
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
     assertThrows(
         NullPointerException.class,
-        () ->
-            new Blob(
-                null, mock(MetadataStore.class), mock(BlockManager.class), TestTelemetry.DEFAULT));
+        () -> new Blob(null, mockMetadataStore, mock(BlockManager.class), TestTelemetry.DEFAULT));
     assertThrows(
         NullPointerException.class,
-        () -> new Blob(TEST_URI, null, mock(BlockManager.class), TestTelemetry.DEFAULT));
+        () -> new Blob(objectKey, null, mock(BlockManager.class), TestTelemetry.DEFAULT));
 
     assertThrows(
         NullPointerException.class,
-        () -> new Blob(TEST_URI, mock(MetadataStore.class), null, TestTelemetry.DEFAULT));
+        () -> new Blob(objectKey, mockMetadataStore, null, TestTelemetry.DEFAULT));
     assertThrows(
         NullPointerException.class,
-        () -> new Blob(TEST_URI, mock(MetadataStore.class), mock(BlockManager.class), null));
+        () -> new Blob(objectKey, mockMetadataStore, mock(BlockManager.class), null));
   }
 
   @Test
@@ -118,7 +125,6 @@ public class BlobTest {
 
     // When & Then: read is called with illegal arguments, IllegalArgumentException is thrown
     byte[] b = new byte[4];
-
     assertThrows(IllegalArgumentException.class, () -> blob.read(-100));
     assertThrows(IllegalArgumentException.class, () -> blob.read(b, 0, b.length, -100));
     assertThrows(IllegalArgumentException.class, () -> blob.read(b, 0, b.length, b.length + 1));
@@ -130,9 +136,8 @@ public class BlobTest {
   @Test
   public void testExecuteSubmitsCorrectRanges() {
     // Given: test blob and an IOPlan
-    MetadataStore metadataStore = mock(MetadataStore.class);
     BlockManager blockManager = mock(BlockManager.class);
-    Blob blob = new Blob(TEST_URI, metadataStore, blockManager, TestTelemetry.DEFAULT);
+    Blob blob = new Blob(objectKey, mockMetadataStore, blockManager, TestTelemetry.DEFAULT);
     List<Range> ranges = new LinkedList<>();
     ranges.add(new Range(0, 100));
     ranges.add(new Range(999, 1000));
@@ -150,9 +155,8 @@ public class BlobTest {
   @Test
   public void testCloseClosesBlockManager() {
     // Given: test blob
-    MetadataStore metadataStore = mock(MetadataStore.class);
     BlockManager blockManager = mock(BlockManager.class);
-    Blob blob = new Blob(TEST_URI, metadataStore, blockManager, TestTelemetry.DEFAULT);
+    Blob blob = new Blob(objectKey, mockMetadataStore, blockManager, TestTelemetry.DEFAULT);
 
     // When: blob is closed
     blob.close();
@@ -162,17 +166,17 @@ public class BlobTest {
   }
 
   private Blob getTestBlob(String data) {
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(data.length()).etag(ETAG).build();
     FakeObjectClient fakeObjectClient = new FakeObjectClient(data);
-    MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     BlockManager blockManager =
         new BlockManager(
-            TEST_URI,
+            objectKey,
             fakeObjectClient,
-            metadataStore,
+            mockMetadataStore,
             TestTelemetry.DEFAULT,
             PhysicalIOConfiguration.DEFAULT);
 
-    return new Blob(TEST_URI, metadataStore, blockManager, TestTelemetry.DEFAULT);
+    return new Blob(objectKey, mockMetadataStore, blockManager, TestTelemetry.DEFAULT);
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
@@ -27,6 +27,7 @@ import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -42,7 +43,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     value = "NP_NONNULL_PARAM_VIOLATION",
     justification = "We mean to pass nulls to checks")
 public class BlockManagerTest {
-  private static String ETAG = "random";
+  private static final Optional<String> ETAG = Optional.of("RandomString");
   private ObjectMetadata metadataStore;
   static S3URI testUri = S3URI.of("foo", "bar");
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(testUri).etag(ETAG).build();
@@ -197,7 +198,7 @@ public class BlockManagerTest {
                     return false;
                   }
                   // Check if the If-Match header matches expected ETag
-                  return request.getEtag() != null && request.getEtag().equals(ETAG);
+                  return request.getEtag() != null && request.getEtag().equals(ETAG.get());
                 }),
             any()))
         .thenThrow(S3Exception.builder().message("PreconditionFailed").statusCode(412).build());
@@ -260,7 +261,7 @@ public class BlockManagerTest {
                     return false;
                   }
                   // Check if the If-Match header matches expected ETag
-                  return request.getEtag() == null || request.getEtag().equals(ETAG);
+                  return request.getEtag() == null || request.getEtag().equals(ETAG.get());
                 }),
             any()))
         .thenReturn(
@@ -277,7 +278,7 @@ public class BlockManagerTest {
                     return false;
                   }
                   // Check if the If-Match header matches expected ETag
-                  return request.getEtag() != null && !request.getEtag().equals(ETAG);
+                  return request.getEtag() != null && !request.getEtag().equals(ETAG.get());
                 }),
             any()))
         .thenThrow(S3Exception.builder().message("PreconditionFailed").statusCode(412).build());

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
@@ -28,7 +28,6 @@ import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -44,7 +43,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     value = "NP_NONNULL_PARAM_VIOLATION",
     justification = "We mean to pass nulls to checks")
 public class BlockManagerTest {
-  private static final Optional<String> ETAG = Optional.of("RandomString");
+  private static final String ETAG = "RandomString";
   private ObjectMetadata metadataStore;
   static S3URI testUri = S3URI.of("foo", "bar");
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(testUri).etag(ETAG).build();
@@ -199,7 +198,7 @@ public class BlockManagerTest {
                     return false;
                   }
                   // Check if the If-Match header matches expected ETag
-                  return request.getEtag() != null && request.getEtag().equals(ETAG.get());
+                  return request.getEtag() != null && request.getEtag().equals(ETAG);
                 }),
             any()))
         .thenThrow(S3Exception.builder().message("PreconditionFailed").statusCode(412).build());
@@ -262,7 +261,7 @@ public class BlockManagerTest {
                     return false;
                   }
                   // Check if the If-Match header matches expected ETag
-                  return request.getEtag() == null || request.getEtag().equals(ETAG.get());
+                  return request.getEtag() == null || request.getEtag().equals(ETAG);
                 }),
             any()))
         .thenReturn(
@@ -279,7 +278,7 @@ public class BlockManagerTest {
                     return false;
                   }
                   // Check if the If-Match header matches expected ETag
-                  return request.getEtag() != null && !request.getEtag().equals(ETAG.get());
+                  return request.getEtag() != null && !request.getEtag().equals(ETAG);
                 }),
             any()))
         .thenThrow(S3Exception.builder().message("PreconditionFailed").statusCode(412).build());

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
@@ -34,6 +34,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 public class BlockStoreTest {
 
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
+  private static final String ETAG = "RandomString";
 
   @Test
   public void test__blockStore__getBlockAfterAddBlock() {
@@ -45,7 +46,7 @@ public class BlockStoreTest {
 
     // When: a new block is added
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 3, 5, 0, ReadMode.SYNC));
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 3, 5, 0, ReadMode.SYNC, ETAG));
 
     // Then: getBlock can retrieve the same block
     Optional<Block> b = blockStore.getBlock(4);
@@ -66,11 +67,13 @@ public class BlockStoreTest {
     BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
 
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC));
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC, ETAG));
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC));
+        new Block(
+            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC, ETAG));
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC));
+        new Block(
+            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC, ETAG));
 
     // When & Then: we query for the next missing byte, the result is correct
     assertEquals(OptionalLong.of(0), blockStore.findNextMissingByte(0));
@@ -93,11 +96,13 @@ public class BlockStoreTest {
     BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
 
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC));
+        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC, ETAG));
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC));
+        new Block(
+            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC, ETAG));
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC));
+        new Block(
+            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC, ETAG));
 
     // When & Then: we query for the next available byte, the result is correct
     assertEquals(OptionalLong.of(2), blockStore.findNextLoadedByte(0));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
@@ -22,31 +22,35 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
-import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
+import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
+import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 public class BlockStoreTest {
 
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
   private static final String ETAG = "RandomString";
+  private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
+  private static final int OBJECT_SIZE = 100;
 
   @Test
   public void test__blockStore__getBlockAfterAddBlock() {
     // Given: empty BlockStore
     FakeObjectClient fakeObjectClient = new FakeObjectClient("test-data");
-    MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
-    BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
 
     // When: a new block is added
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 3, 5, 0, ReadMode.SYNC, ETAG));
+        new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 3, 5, 0, ReadMode.SYNC));
 
     // Then: getBlock can retrieve the same block
     Optional<Block> b = blockStore.getBlock(4);
@@ -62,18 +66,17 @@ public class BlockStoreTest {
     // Given: BlockStore with blocks (2,3), (5,10), (12,15)
     final String X_TIMES_16 = "xxxxxxxxxxxxxxxx";
     FakeObjectClient fakeObjectClient = new FakeObjectClient(X_TIMES_16);
-    MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
-    BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
+    int size = X_TIMES_16.getBytes(StandardCharsets.UTF_8).length;
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(size).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
 
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC, ETAG));
+        new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC));
     blockStore.add(
-        new Block(
-            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC, ETAG));
+        new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC));
     blockStore.add(
-        new Block(
-            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC, ETAG));
+        new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC));
 
     // When & Then: we query for the next missing byte, the result is correct
     assertEquals(OptionalLong.of(0), blockStore.findNextMissingByte(0));
@@ -91,18 +94,16 @@ public class BlockStoreTest {
     // Given: BlockStore with blocks (2,3), (5,10), (12,15)
     final String X_TIMES_16 = "xxxxxxxxxxxxxxxx";
     FakeObjectClient fakeObjectClient = new FakeObjectClient(X_TIMES_16);
-    MetadataStore metadataStore =
-        new MetadataStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
-    BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
 
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC, ETAG));
+        new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 2, 3, 0, ReadMode.SYNC));
     blockStore.add(
-        new Block(
-            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC, ETAG));
+        new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 5, 10, 0, ReadMode.SYNC));
     blockStore.add(
-        new Block(
-            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC, ETAG));
+        new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 12, 15, 0, ReadMode.SYNC));
 
     // When & Then: we query for the next available byte, the result is correct
     assertEquals(OptionalLong.of(2), blockStore.findNextLoadedByte(0));
@@ -118,7 +119,9 @@ public class BlockStoreTest {
   @Test
   public void test__blockStore__closesBlocks() {
     // Given: BlockStore with a block
-    BlockStore blockStore = new BlockStore(TEST_URI, mock(MetadataStore.class));
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
     Block block = mock(Block.class);
     blockStore.add(block);
 
@@ -132,7 +135,9 @@ public class BlockStoreTest {
   @Test
   public void test__blockStore__closeWorksWithExceptions() {
     // Given: BlockStore with two blocks
-    BlockStore blockStore = new BlockStore(TEST_URI, mock(MetadataStore.class));
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
     Block b1 = mock(Block.class);
     Block b2 = mock(Block.class);
     blockStore.add(b1);

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
@@ -37,7 +37,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 public class BlockStoreTest {
 
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
-  private static final Optional<String> ETAG = Optional.of("RandomString");
+  private static final String ETAG = "RandomString";
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
   private static final int OBJECT_SIZE = 100;
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
@@ -36,7 +36,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 public class BlockStoreTest {
 
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
-  private static final String ETAG = "RandomString";
+  private static final Optional<String> ETAG = Optional.of("RandomString");
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
   private static final int OBJECT_SIZE = 100;
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -24,6 +24,7 @@ import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
+import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 @SuppressFBWarnings(
@@ -32,6 +33,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 public class BlockTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
   private static final String ETAG = "RandomString";
+  private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
 
   @Test
   public void testSingleByteReadReturnsCorrectByte() {
@@ -40,14 +42,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI,
+            objectKey,
             fakeObjectClient,
             TestTelemetry.DEFAULT,
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC,
-            ETAG);
+            ReadMode.SYNC);
 
     // When: bytes are requested from the block
     int r1 = block.read(0);
@@ -67,14 +68,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI,
+            objectKey,
             fakeObjectClient,
             TestTelemetry.DEFAULT,
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC,
-            ETAG);
+            ReadMode.SYNC);
 
     // When: bytes are requested from the block
     byte[] b1 = new byte[4];
@@ -110,7 +110,7 @@ public class BlockTest {
         NullPointerException.class,
         () ->
             new Block(
-                TEST_URI,
+                objectKey,
                 null,
                 TestTelemetry.DEFAULT,
                 0,
@@ -122,12 +122,12 @@ public class BlockTest {
         NullPointerException.class,
         () ->
             new Block(
-                TEST_URI, fakeObjectClient, null, 0, TEST_DATA.length(), 0, ReadMode.SYNC, null));
+                objectKey, fakeObjectClient, null, 0, TEST_DATA.length(), 0, ReadMode.SYNC, null));
     assertThrows(
         NullPointerException.class,
         () ->
             new Block(
-                TEST_URI,
+                objectKey,
                 fakeObjectClient,
                 TestTelemetry.DEFAULT,
                 0,
@@ -145,7 +145,7 @@ public class BlockTest {
         IllegalArgumentException.class,
         () ->
             new Block(
-                TEST_URI,
+                objectKey,
                 fakeObjectClient,
                 TestTelemetry.DEFAULT,
                 -1,
@@ -157,22 +157,20 @@ public class BlockTest {
         IllegalArgumentException.class,
         () ->
             new Block(
-                TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, -5, 0, ReadMode.SYNC, null));
+                objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 0, -5, 0, ReadMode.SYNC, null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 20, 1, 0, ReadMode.SYNC));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 0, 5, -1, ReadMode.SYNC));
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new Block(
-                TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 20, 1, 0, ReadMode.SYNC, ETAG));
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new Block(
-                TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, 5, -1, ReadMode.SYNC, ETAG));
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new Block(
-                TEST_URI,
+                objectKey,
                 fakeObjectClient,
                 TestTelemetry.DEFAULT,
                 -5,
@@ -189,14 +187,13 @@ public class BlockTest {
     byte[] b = new byte[4];
     Block block =
         new Block(
-            TEST_URI,
+            objectKey,
             fakeObjectClient,
             TestTelemetry.DEFAULT,
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC,
-            ETAG);
+            ReadMode.SYNC);
     assertThrows(IllegalArgumentException.class, () -> block.read(-10));
     assertThrows(NullPointerException.class, () -> block.read(null, 0, 3, 1));
     assertThrows(IllegalArgumentException.class, () -> block.read(b, -5, 3, 1));
@@ -210,14 +207,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI,
+            objectKey,
             fakeObjectClient,
             TestTelemetry.DEFAULT,
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC,
-            ETAG);
+            ReadMode.SYNC);
     assertTrue(block.contains(0));
     assertFalse(block.contains(TEST_DATA.length() + 1));
   }
@@ -228,14 +224,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI,
+            objectKey,
             fakeObjectClient,
             TestTelemetry.DEFAULT,
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC,
-            ETAG);
+            ReadMode.SYNC);
     assertThrows(IllegalArgumentException.class, () -> block.contains(-1));
   }
 
@@ -245,14 +240,13 @@ public class BlockTest {
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
     Block block =
         new Block(
-            TEST_URI,
+            objectKey,
             fakeObjectClient,
             TestTelemetry.DEFAULT,
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC,
-            ETAG);
+            ReadMode.SYNC);
     block.close();
     block.close();
   }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
@@ -34,7 +33,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class BlockTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
-  private static final Optional<String> ETAG = Optional.of("RandomString");
+  private static final String ETAG = "RandomString";
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -31,6 +31,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class BlockTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
+  private static final String ETAG = "RandomString";
 
   @Test
   public void testSingleByteReadReturnsCorrectByte() {
@@ -45,7 +46,8 @@ public class BlockTest {
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC);
+            ReadMode.SYNC,
+            ETAG);
 
     // When: bytes are requested from the block
     int r1 = block.read(0);
@@ -71,7 +73,8 @@ public class BlockTest {
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC);
+            ReadMode.SYNC,
+            ETAG);
 
     // When: bytes are requested from the block
     byte[] b1 = new byte[4];
@@ -101,20 +104,37 @@ public class BlockTest {
                 0,
                 TEST_DATA.length(),
                 0,
-                ReadMode.SYNC));
+                ReadMode.SYNC,
+                null));
     assertThrows(
         NullPointerException.class,
         () ->
             new Block(
-                TEST_URI, null, TestTelemetry.DEFAULT, 0, TEST_DATA.length(), 0, ReadMode.SYNC));
-    assertThrows(
-        NullPointerException.class,
-        () -> new Block(TEST_URI, fakeObjectClient, null, 0, TEST_DATA.length(), 0, ReadMode.SYNC));
+                TEST_URI,
+                null,
+                TestTelemetry.DEFAULT,
+                0,
+                TEST_DATA.length(),
+                0,
+                ReadMode.SYNC,
+                null));
     assertThrows(
         NullPointerException.class,
         () ->
             new Block(
-                TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, TEST_DATA.length(), 0, null));
+                TEST_URI, fakeObjectClient, null, 0, TEST_DATA.length(), 0, ReadMode.SYNC, null));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new Block(
+                TEST_URI,
+                fakeObjectClient,
+                TestTelemetry.DEFAULT,
+                0,
+                TEST_DATA.length(),
+                0,
+                null,
+                null));
   }
 
   @Test
@@ -131,19 +151,23 @@ public class BlockTest {
                 -1,
                 TEST_DATA.length(),
                 0,
-                ReadMode.SYNC));
+                ReadMode.SYNC,
+                null));
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, -5, 0, ReadMode.SYNC));
+            new Block(
+                TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, -5, 0, ReadMode.SYNC, null));
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 20, 1, 0, ReadMode.SYNC));
+            new Block(
+                TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 20, 1, 0, ReadMode.SYNC, ETAG));
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, 5, -1, ReadMode.SYNC));
+            new Block(
+                TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 0, 5, -1, ReadMode.SYNC, ETAG));
     assertThrows(
         IllegalArgumentException.class,
         () ->
@@ -154,7 +178,8 @@ public class BlockTest {
                 -5,
                 0,
                 TEST_DATA.length(),
-                ReadMode.SYNC));
+                ReadMode.SYNC,
+                null));
   }
 
   @Test
@@ -170,7 +195,8 @@ public class BlockTest {
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC);
+            ReadMode.SYNC,
+            ETAG);
     assertThrows(IllegalArgumentException.class, () -> block.read(-10));
     assertThrows(NullPointerException.class, () -> block.read(null, 0, 3, 1));
     assertThrows(IllegalArgumentException.class, () -> block.read(b, -5, 3, 1));
@@ -190,7 +216,8 @@ public class BlockTest {
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC);
+            ReadMode.SYNC,
+            ETAG);
     assertTrue(block.contains(0));
     assertFalse(block.contains(TEST_DATA.length() + 1));
   }
@@ -207,7 +234,8 @@ public class BlockTest {
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC);
+            ReadMode.SYNC,
+            ETAG);
     assertThrows(IllegalArgumentException.class, () -> block.contains(-1));
   }
 
@@ -223,7 +251,8 @@ public class BlockTest {
             0,
             TEST_DATA.length(),
             0,
-            ReadMode.SYNC);
+            ReadMode.SYNC,
+            ETAG);
     block.close();
     block.close();
   }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
@@ -32,7 +33,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class BlockTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
-  private static final String ETAG = "RandomString";
+  private static final Optional<String> ETAG = Optional.of("RandomString");
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
@@ -37,7 +36,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class IOPlannerTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
-  private static final Optional<String> ETAG = Optional.of("RandomString");
+  private static final String ETAG = "RandomString";
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
@@ -16,9 +16,6 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
@@ -30,6 +27,7 @@ import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.Range;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
+import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 @SuppressFBWarnings(
@@ -38,6 +36,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 public class IOPlannerTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
   private static final String ETAG = "RandomString";
+  private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
 
   @Test
   void testCreateBoundaries() {
@@ -48,10 +47,9 @@ public class IOPlannerTest {
   void testPlanReadBoundaries() {
     // Given: an empty BlockStore
     final int OBJECT_SIZE = 10_000;
-    MetadataStore mockMetadataStore = mock(MetadataStore.class);
-    when(mockMetadataStore.get(any()))
-        .thenReturn(ObjectMetadata.builder().contentLength(OBJECT_SIZE).build());
-    BlockStore blockStore = new BlockStore(TEST_URI, mockMetadataStore);
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(-5, 10, 100));
@@ -63,10 +61,9 @@ public class IOPlannerTest {
   public void testPlanReadNoopWhenBlockStoreEmpty() {
     // Given: an empty BlockStore
     final int OBJECT_SIZE = 10_000;
-    MetadataStore mockMetadataStore = mock(MetadataStore.class);
-    when(mockMetadataStore.get(any()))
-        .thenReturn(ObjectMetadata.builder().contentLength(OBJECT_SIZE).build());
-    BlockStore blockStore = new BlockStore(TEST_URI, mockMetadataStore);
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     // When: a read plan is requested for a range
@@ -84,13 +81,13 @@ public class IOPlannerTest {
     // Given: a BlockStore with a (100,200) block in it
     final int OBJECT_SIZE = 10_000;
     byte[] content = new byte[OBJECT_SIZE];
-    MetadataStore metadataStore = getTestMetadataStoreWithContentLength(OBJECT_SIZE);
-    BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
     FakeObjectClient fakeObjectClient =
         new FakeObjectClient(new String(content, StandardCharsets.UTF_8));
     blockStore.add(
-        new Block(
-            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 100, 200, 0, ReadMode.SYNC, ETAG));
+        new Block(objectKey, fakeObjectClient, TestTelemetry.DEFAULT, 100, 200, 0, ReadMode.SYNC));
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     // When: a read plan is requested for a range (0, 400)
@@ -108,8 +105,9 @@ public class IOPlannerTest {
   public void testPlanReadRegressionSingleByteObject() {
     // Given: a single byte object and an empty block store
     final int OBJECT_SIZE = 1;
-    MetadataStore metadataStore = getTestMetadataStoreWithContentLength(OBJECT_SIZE);
-    BlockStore blockStore = new BlockStore(TEST_URI, metadataStore);
+    ObjectMetadata mockMetadataStore =
+        ObjectMetadata.builder().contentLength(OBJECT_SIZE).etag(ETAG).build();
+    BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     // When: a read plan is requested for a range (0, 400)
@@ -120,13 +118,5 @@ public class IOPlannerTest {
     expected.add(new Range(0, 0));
 
     assertEquals(expected, missingRanges);
-  }
-
-  private MetadataStore getTestMetadataStoreWithContentLength(long contentLength) {
-    MetadataStore mockMetadataStore = mock(MetadataStore.class);
-    when(mockMetadataStore.get(any()))
-        .thenReturn(ObjectMetadata.builder().contentLength(contentLength).build());
-
-    return mockMetadataStore;
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
@@ -37,6 +37,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class IOPlannerTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
+  private static final String ETAG = "RandomString";
 
   @Test
   void testCreateBoundaries() {
@@ -88,7 +89,8 @@ public class IOPlannerTest {
     FakeObjectClient fakeObjectClient =
         new FakeObjectClient(new String(content, StandardCharsets.UTF_8));
     blockStore.add(
-        new Block(TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 100, 200, 0, ReadMode.SYNC));
+        new Block(
+            TEST_URI, fakeObjectClient, TestTelemetry.DEFAULT, 100, 200, 0, ReadMode.SYNC, ETAG));
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     // When: a read plan is requested for a range (0, 400)

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
@@ -21,6 +21,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
@@ -35,7 +36,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
     justification = "We mean to pass nulls to checks")
 public class IOPlannerTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
-  private static final String ETAG = "RandomString";
+  private static final Optional<String> ETAG = Optional.of("RandomString");
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -39,7 +40,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 public class PhysicalIOImplTest {
 
   private static final S3URI s3URI = S3URI.of("foo", "bar");
-  private static final String etag = "random";
+  private static final Optional<String> etag = Optional.of("random");
 
   @Test
   void testConstructorThrowsOnNullArgument() {
@@ -47,7 +48,12 @@ public class PhysicalIOImplTest {
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
-              s3URI, null, mock(BlobStore.class), TestTelemetry.DEFAULT, mock(StreamContext.class));
+              s3URI,
+              null,
+              mock(BlobStore.class),
+              mock(PhysicalIOConfiguration.class),
+              TestTelemetry.DEFAULT,
+              mock(StreamContext.class));
         });
 
     assertThrows(
@@ -57,6 +63,7 @@ public class PhysicalIOImplTest {
               s3URI,
               mock(MetadataStore.class),
               null,
+              mock(PhysicalIOConfiguration.class),
               TestTelemetry.DEFAULT,
               mock(StreamContext.class));
         });
@@ -65,36 +72,71 @@ public class PhysicalIOImplTest {
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
-              null, mock(MetadataStore.class), mock(BlobStore.class), TestTelemetry.DEFAULT);
+              null,
+              mock(MetadataStore.class),
+              mock(BlobStore.class),
+              mock(PhysicalIOConfiguration.class),
+              TestTelemetry.DEFAULT);
         });
 
     assertThrows(
         NullPointerException.class,
         () -> {
-          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), mock(BlobStore.class), null);
-        });
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(s3URI, null, mock(BlobStore.class), TestTelemetry.DEFAULT);
-        });
-
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), null, TestTelemetry.DEFAULT);
+          new PhysicalIOImpl(
+              s3URI,
+              mock(MetadataStore.class),
+              mock(BlobStore.class),
+              mock(PhysicalIOConfiguration.class),
+              null);
         });
     assertThrows(
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
-              null, mock(MetadataStore.class), mock(BlobStore.class), TestTelemetry.DEFAULT);
+              s3URI,
+              null,
+              mock(BlobStore.class),
+              mock(PhysicalIOConfiguration.class),
+              TestTelemetry.DEFAULT);
         });
 
     assertThrows(
         NullPointerException.class,
         () -> {
-          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), mock(BlobStore.class), null);
+          new PhysicalIOImpl(
+              s3URI,
+              mock(MetadataStore.class),
+              null,
+              mock(PhysicalIOConfiguration.class),
+              TestTelemetry.DEFAULT);
+        });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(
+              null,
+              mock(MetadataStore.class),
+              mock(BlobStore.class),
+              mock(PhysicalIOConfiguration.class),
+              TestTelemetry.DEFAULT);
+        });
+
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(
+              s3URI,
+              mock(MetadataStore.class),
+              mock(BlobStore.class),
+              mock(PhysicalIOConfiguration.class),
+              null);
+        });
+
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(
+              s3URI, mock(MetadataStore.class), mock(BlobStore.class), null, TestTelemetry.DEFAULT);
         });
   }
 
@@ -108,7 +150,12 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI,
+            metadataStore,
+            blobStore,
+            PhysicalIOConfiguration.DEFAULT,
+            TestTelemetry.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -127,7 +174,12 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI,
+            metadataStore,
+            blobStore,
+            PhysicalIOConfiguration.DEFAULT,
+            TestTelemetry.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -143,7 +195,12 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI,
+            metadataStore,
+            blobStore,
+            PhysicalIOConfiguration.DEFAULT,
+            TestTelemetry.DEFAULT);
 
     byte[] buffer = new byte[5];
     assertEquals(5, physicalIOImplV2.read(buffer, 0, 5, 5));
@@ -158,7 +215,12 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI,
+            metadataStore,
+            blobStore,
+            PhysicalIOConfiguration.DEFAULT,
+            TestTelemetry.DEFAULT);
     byte[] buffer = new byte[5];
     assertEquals(5, physicalIOImplV2.readTail(buffer, 0, 5));
     assertEquals(1, blobStore.blobCount());
@@ -178,7 +240,12 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(objectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI,
+            metadataStore,
+            blobStore,
+            PhysicalIOConfiguration.DEFAULT,
+            TestTelemetry.DEFAULT);
 
     assertThrows(S3Exception.class, () -> physicalIOImplV2.read(0));
     assertThrows(Exception.class, () -> metadataStore.get(s3URI));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
@@ -48,7 +47,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 public class PhysicalIOImplTest {
 
   private static final S3URI s3URI = S3URI.of("foo", "bar");
-  private static final Optional<String> etag = Optional.of("random");
+  private static final String etag = "random";
 
   @Test
   void testConstructorThrowsOnNullArgument() {
@@ -56,10 +55,16 @@ public class PhysicalIOImplTest {
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
+              s3URI, null, mock(BlobStore.class), TestTelemetry.DEFAULT, mock(StreamContext.class));
+        });
+
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(
               s3URI,
+              mock(MetadataStore.class),
               null,
-              mock(BlobStore.class),
-              mock(PhysicalIOConfiguration.class),
               TestTelemetry.DEFAULT,
               mock(StreamContext.class));
         });
@@ -68,83 +73,43 @@ public class PhysicalIOImplTest {
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
-              s3URI,
-              mock(MetadataStore.class),
-              null,
-              mock(PhysicalIOConfiguration.class),
-              TestTelemetry.DEFAULT,
-              mock(StreamContext.class));
+              null, mock(MetadataStore.class), mock(BlobStore.class), TestTelemetry.DEFAULT);
+        });
+
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), mock(BlobStore.class), null);
+        });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(s3URI, null, mock(BlobStore.class), TestTelemetry.DEFAULT);
+        });
+
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), null, TestTelemetry.DEFAULT);
+        });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(
+              null, mock(MetadataStore.class), mock(BlobStore.class), TestTelemetry.DEFAULT);
+        });
+
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), mock(BlobStore.class), null);
         });
 
     assertThrows(
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
-              null,
-              mock(MetadataStore.class),
-              mock(BlobStore.class),
-              mock(PhysicalIOConfiguration.class),
-              TestTelemetry.DEFAULT);
-        });
-
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(
-              s3URI,
-              mock(MetadataStore.class),
-              mock(BlobStore.class),
-              mock(PhysicalIOConfiguration.class),
-              null);
-        });
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(
-              s3URI,
-              null,
-              mock(BlobStore.class),
-              mock(PhysicalIOConfiguration.class),
-              TestTelemetry.DEFAULT);
-        });
-
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(
-              s3URI,
-              mock(MetadataStore.class),
-              null,
-              mock(PhysicalIOConfiguration.class),
-              TestTelemetry.DEFAULT);
-        });
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(
-              null,
-              mock(MetadataStore.class),
-              mock(BlobStore.class),
-              mock(PhysicalIOConfiguration.class),
-              TestTelemetry.DEFAULT);
-        });
-
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(
-              s3URI,
-              mock(MetadataStore.class),
-              mock(BlobStore.class),
-              mock(PhysicalIOConfiguration.class),
-              null);
-        });
-
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(
-              s3URI, mock(MetadataStore.class), mock(BlobStore.class), null, TestTelemetry.DEFAULT);
+              s3URI, mock(MetadataStore.class), mock(BlobStore.class), TestTelemetry.DEFAULT, null);
         });
   }
 
@@ -158,12 +123,7 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(
-            s3URI,
-            metadataStore,
-            blobStore,
-            PhysicalIOConfiguration.DEFAULT,
-            TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -182,12 +142,7 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(
-            s3URI,
-            metadataStore,
-            blobStore,
-            PhysicalIOConfiguration.DEFAULT,
-            TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -203,12 +158,7 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(
-            s3URI,
-            metadataStore,
-            blobStore,
-            PhysicalIOConfiguration.DEFAULT,
-            TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
 
     byte[] buffer = new byte[5];
     assertEquals(5, physicalIOImplV2.read(buffer, 0, 5, 5));
@@ -223,12 +173,7 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(
-            s3URI,
-            metadataStore,
-            blobStore,
-            PhysicalIOConfiguration.DEFAULT,
-            TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
     byte[] buffer = new byte[5];
     assertEquals(5, physicalIOImplV2.readTail(buffer, 0, 5));
     assertEquals(1, blobStore.blobCount());
@@ -239,7 +184,7 @@ public class PhysicalIOImplTest {
   public void test_FailureEvictsObjectsAsExpected() throws IOException {
     AwsServiceException s3Exception =
         S3Exception.builder()
-            .message("PreconditionFailed")
+            .message("At least one of the pre-conditions you specified did not hold")
             .statusCode(412)
             .awsErrorDetails(
                 AwsErrorDetails.builder()
@@ -248,11 +193,12 @@ public class PhysicalIOImplTest {
                     .serviceName("S3")
                     .build())
             .build();
+    IOException ioException = new IOException(s3Exception);
 
     S3AsyncClient mockS3AsyncClient = mock(S3AsyncClient.class);
     CompletableFuture<ResponseInputStream<GetObjectResponse>> failedFuture =
         new CompletableFuture<>();
-    failedFuture.completeExceptionally(s3Exception);
+    failedFuture.completeExceptionally(ioException);
     when(mockS3AsyncClient.getObject(
             any(GetObjectRequest.class), any(AsyncResponseTransformer.class)))
         .thenReturn(failedFuture);
@@ -265,12 +211,7 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(client, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(
-            s3URI,
-            metadataStore,
-            blobStore,
-            PhysicalIOConfiguration.DEFAULT,
-            TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
 
     assertThrows(IOException.class, () -> physicalIOImplV2.read(0));
     assertEquals(0, blobStore.blobCount());

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/util/FakeObjectClient.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/util/FakeObjectClient.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,7 +41,7 @@ public class FakeObjectClient implements ObjectClient {
   @Getter private AtomicInteger getRequestCount = new AtomicInteger();
   @Getter private ConcurrentLinkedDeque<Range> requestedRanges = new ConcurrentLinkedDeque<>();
   private byte[] contentBytes;
-  @Getter private String etag = "RANDOM";
+  @Getter private Optional<String> etag = Optional.of("RANDOM");
 
   /**
    * Instantiate a fake Object Client backed by some string as data.
@@ -63,7 +64,7 @@ public class FakeObjectClient implements ObjectClient {
 
   @Override
   public CompletableFuture<ObjectContent> getObject(GetRequest getRequest) {
-    if (!getRequest.getEtag().equals(this.etag)) {
+    if (!getRequest.getEtag().equals(this.etag.get())) {
       throw S3Exception.builder()
           .message("At least one of the pre-conditions you specified did not hold")
           .statusCode(412)

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/util/FakeObjectClient.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/util/FakeObjectClient.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,7 +40,7 @@ public class FakeObjectClient implements ObjectClient {
   @Getter private AtomicInteger getRequestCount = new AtomicInteger();
   @Getter private ConcurrentLinkedDeque<Range> requestedRanges = new ConcurrentLinkedDeque<>();
   private byte[] contentBytes;
-  @Getter private Optional<String> etag = Optional.of("RANDOM");
+  @Getter private String etag = "RANDOM";
 
   /**
    * Instantiate a fake Object Client backed by some string as data.
@@ -64,7 +63,7 @@ public class FakeObjectClient implements ObjectClient {
 
   @Override
   public CompletableFuture<ObjectContent> getObject(GetRequest getRequest) {
-    if (!getRequest.getEtag().equals(this.etag.get())) {
+    if (!getRequest.getEtag().equals(this.etag)) {
       throw S3Exception.builder()
           .message("At least one of the pre-conditions you specified did not hold")
           .statusCode(412)

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
@@ -134,6 +134,7 @@ public class S3SdkObjectClient implements ObjectClient {
                 headObjectResponse ->
                     ObjectMetadata.builder()
                         .contentLength(headObjectResponse.contentLength())
+                        .etag(headObjectResponse.eTag())
                         .build()));
   }
 
@@ -163,6 +164,10 @@ public class S3SdkObjectClient implements ObjectClient {
         GetObjectRequest.builder()
             .bucket(getRequest.getS3Uri().getBucket())
             .key(getRequest.getS3Uri().getKey());
+
+    if (getRequest.getEtag() != null) {
+      builder.ifMatch(getRequest.getEtag());
+    }
 
     final String range = getRequest.getRange().toHttpString();
     builder.range(range);

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
@@ -15,6 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.Getter;
 import lombok.NonNull;
@@ -134,7 +135,7 @@ public class S3SdkObjectClient implements ObjectClient {
                 headObjectResponse ->
                     ObjectMetadata.builder()
                         .contentLength(headObjectResponse.contentLength())
-                        .etag(headObjectResponse.eTag())
+                        .etag(Optional.of(headObjectResponse.eTag()))
                         .build()));
   }
 

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
@@ -168,7 +168,6 @@ public class S3SdkObjectClient implements ObjectClient {
     if (getRequest.getEtag() != null) {
       builder.ifMatch(getRequest.getEtag());
     }
-
     final String range = getRequest.getRange().toHttpString();
     builder.range(range);
 

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
@@ -142,7 +142,7 @@ public class S3SdkObjectClient implements ObjectClient {
                     headObjectResponse ->
                         ObjectMetadata.builder()
                             .contentLength(headObjectResponse.contentLength())
-                            .etag(Optional.of(headObjectResponse.eTag()))
+                            .etag(headObjectResponse.eTag())
                             .build()))
         .exceptionally(handleException(headRequest.getS3Uri()));
   }
@@ -172,11 +172,9 @@ public class S3SdkObjectClient implements ObjectClient {
     GetObjectRequest.Builder builder =
         GetObjectRequest.builder()
             .bucket(getRequest.getS3Uri().getBucket())
+            .ifMatch(getRequest.getEtag())
             .key(getRequest.getS3Uri().getKey());
 
-    if (getRequest.getEtag() != null) {
-      builder.ifMatch(getRequest.getEtag());
-    }
     final String range = getRequest.getRange().toHttpString();
     builder.range(range);
 

--- a/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
+++ b/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ public class S3SdkObjectClientTest {
 
   private static final String HEADER_REFERER = "Referer";
 
-  private static final String ETAG = "RandomString";
+  private static final Optional<String> ETAG = Optional.of("RandomString");
 
   @Test
   void testForNullsInConstructor() {
@@ -172,7 +173,7 @@ public class S3SdkObjectClientTest {
               GetRequest.builder()
                   .s3Uri(S3URI.of("bucket", "key"))
                   .range(new Range(0, 20))
-                  .etag(ETAG)
+                  .etag(ETAG.get())
                   .referrer(new Referrer("bytes=0-20", ReadMode.SYNC))
                   .build()));
       assertThrows(
@@ -200,7 +201,7 @@ public class S3SdkObjectClientTest {
               GetRequest.builder()
                   .s3Uri(S3URI.of("bucket", "key"))
                   .range(new Range(0, 20))
-                  .etag(ETAG)
+                  .etag(ETAG.get())
                   .referrer(new Referrer("bytes=0-20", ReadMode.SYNC))
                   .build()));
     }
@@ -288,7 +289,7 @@ public class S3SdkObjectClientTest {
     when(s3AsyncClient.headObject(any(HeadObjectRequest.class)))
         .thenReturn(
             CompletableFuture.completedFuture(
-                HeadObjectResponse.builder().contentLength(42L).eTag(ETAG).build()));
+                HeadObjectResponse.builder().contentLength(42L).eTag(ETAG.get()).build()));
 
     /*
      The argument matcher is used to check if our arguments match the values we want to mock a return for
@@ -304,7 +305,7 @@ public class S3SdkObjectClientTest {
                         return false;
                       }
                       // Check if the If-Match header matches expected ETag
-                      return request.ifMatch() == null || request.ifMatch().equals(ETAG);
+                      return request.ifMatch() == null || request.ifMatch().equals(ETAG.get());
                     }),
             (AsyncResponseTransformer<GetObjectResponse, Object>) any()))
         .thenReturn(
@@ -323,7 +324,7 @@ public class S3SdkObjectClientTest {
                       if (request == null) {
                         return false;
                       }
-                      return (request).ifMatch() != null && !(request).ifMatch().equals(ETAG);
+                      return (request).ifMatch() != null && !(request).ifMatch().equals(ETAG.get());
                     }),
             (AsyncResponseTransformer<GetObjectResponse, Object>) any()))
         .thenThrow(S3Exception.builder().message("PreconditionFailed").statusCode(412).build());

--- a/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
+++ b/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
@@ -163,22 +163,6 @@ public class S3SdkObjectClientTest {
   }
 
   @Test
-  void testGetObjectWithRange() {
-    try (S3AsyncClient s3AsyncClient = createMockClient()) {
-      S3SdkObjectClient client = new S3SdkObjectClient(s3AsyncClient);
-      assertInstanceOf(
-          CompletableFuture.class,
-          client.getObject(
-              GetRequest.builder()
-                  .s3Uri(S3URI.of("bucket", "key"))
-                  .range(new Range(0, 20))
-                  .etag(ETAG)
-                  .referrer(new Referrer("bytes=0-20", ReadMode.SYNC))
-                  .build()));
-    }
-  }
-
-  @Test
   void testGetObjectWithDifferentEtagsThrowsError() {
     try (S3AsyncClient s3AsyncClient = createMockClient()) {
       S3SdkObjectClient client = new S3SdkObjectClient(s3AsyncClient);
@@ -203,6 +187,22 @@ public class S3SdkObjectClientTest {
                           .referrer(new Referrer("bytes=0-20", ReadMode.SYNC))
                           .build())
                   .get());
+    }
+  }
+
+  @Test
+  void testGetObjectWithRange() {
+    try (S3AsyncClient s3AsyncClient = createMockClient()) {
+      S3SdkObjectClient client = new S3SdkObjectClient(s3AsyncClient);
+      assertInstanceOf(
+          CompletableFuture.class,
+          client.getObject(
+              GetRequest.builder()
+                  .s3Uri(S3URI.of("bucket", "key"))
+                  .range(new Range(0, 20))
+                  .etag(ETAG)
+                  .referrer(new Referrer("bytes=0-20", ReadMode.SYNC))
+                  .build()));
     }
   }
 


### PR DESCRIPTION
## Description of change
We want etags on our get requests to verify that object reads are for the same version of the object as it is a durability concern. To do this I'm adding etags to the metadata for an object and then making conditional get requests.

Additionally pinning an objects metadata to a point in time. To stop us getting the metadata at different time points during a read. This idea helps us keep metadata consistent for a whole stream.

Additionally now am clearing the metadata for an object on exception. This will change when I pull in https://github.com/awslabs/analytics-accelerator-s3/pull/210. But just to demonstrate the idea I made it on all exceptions at first. 


#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
Yes

#### Does this contribution introduce any new public APIs or behaviors?
Yes

#### How was the contribution tested?
* Unit tests:
For the unit tests: checking if we change the etag between blobs we get an error and used argument matcher for this
for this file [BlockTest.java](https://github.com/awslabs/analytics-accelerator-s3/compare/stubz151_etag?expand=1#diff-75cd3f62ba96f2b7d7e806e6b9c5572e63cbfb2e8eb1052ae02ca74ffa76cfb5) I just updated the values to include the etag don't think it's that important

* Integration tests:
For integration tests: added 2 one that verifies we fail when it changes mid read and a second that validates we pass and return the cached object if it's done reading.



#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate
TODO still, will update

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).