### PR TITLE
Improve the unit and integration tests

### DIFF
--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
@@ -33,38 +33,57 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
   @ParameterizedTest
   @MethodSource("sequentialReads")
   void testSequentialReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
     testDATReadConcurrency(
-        s3Object, streamReadPattern, configuration, CONCURRENCY_LEVEL, CONCURRENCY_ITERATIONS);
+        s3ClientKind,
+        s3Object,
+        streamReadPattern,
+        configuration,
+        CONCURRENCY_LEVEL,
+        CONCURRENCY_ITERATIONS);
   }
 
   @ParameterizedTest
   @MethodSource("skippingReads")
   void testSkippingReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
     testDATReadConcurrency(
-        s3Object, streamReadPattern, configuration, CONCURRENCY_LEVEL, CONCURRENCY_ITERATIONS);
+        s3ClientKind,
+        s3Object,
+        streamReadPattern,
+        configuration,
+        CONCURRENCY_LEVEL,
+        CONCURRENCY_ITERATIONS);
   }
 
   @ParameterizedTest
   @MethodSource("parquetReads")
   void testQuasiParquetReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
     testDATReadConcurrency(
-        s3Object, streamReadPattern, configuration, CONCURRENCY_LEVEL, CONCURRENCY_ITERATIONS);
+        s3ClientKind,
+        s3Object,
+        streamReadPattern,
+        configuration,
+        CONCURRENCY_LEVEL,
+        CONCURRENCY_ITERATIONS);
   }
 
   static Stream<Arguments> sequentialReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         sequentialPatterns(),
         getS3SeekableInputStreamConfigurations());
@@ -72,6 +91,7 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
 
   static Stream<Arguments> skippingReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         skippingPatterns(),
         getS3SeekableInputStreamConfigurations());
@@ -79,6 +99,7 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
 
   static Stream<Arguments> parquetReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         parquetPatterns(),
         getS3SeekableInputStreamConfigurations());

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ExceptionCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ExceptionCorrectnessTest.java
@@ -77,7 +77,7 @@ public class ExceptionCorrectnessTest extends IntegrationTestBase {
   }
 
   private static Stream<Arguments> provideTestParameters() {
-    return Stream.of(S3ClientKind.SDK_V2_CRT_ASYNC, S3ClientKind.SDK_V2_JAVA_ASYNC)
+    return getS3ClientKinds().stream()
         .flatMap(
             clientKind ->
                 Stream.of(ReadMethod.values())

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ReadCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ReadCorrectnessTest.java
@@ -26,35 +26,39 @@ public class ReadCorrectnessTest extends IntegrationTestBase {
   @ParameterizedTest
   @MethodSource("sequentialReads")
   void testSequentialReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
   }
 
   @ParameterizedTest
   @MethodSource("skippingReads")
   void testSkippingReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
   }
 
   @ParameterizedTest
   @MethodSource("parquetReads")
   void testQuasiParquetReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
   }
 
   static Stream<Arguments> sequentialReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         sequentialPatterns(),
         getS3SeekableInputStreamConfigurations());
@@ -62,6 +66,7 @@ public class ReadCorrectnessTest extends IntegrationTestBase {
 
   static Stream<Arguments> skippingReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         skippingPatterns(),
         getS3SeekableInputStreamConfigurations());
@@ -69,6 +74,7 @@ public class ReadCorrectnessTest extends IntegrationTestBase {
 
   static Stream<Arguments> parquetReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         parquetPatterns(),
         getS3SeekableInputStreamConfigurations());

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/BenchmarkBase.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/BenchmarkBase.java
@@ -88,6 +88,13 @@ public abstract class BenchmarkBase extends ExecutionBase {
   protected abstract StreamReadPatternKind getReadPatternKind();
 
   /**
+   * Returns current client kind
+   *
+   * @return {@link S3ClientKind}
+   */
+  protected abstract S3ClientKind getClientKind();
+
+  /**
    * Benchmarks can override this to return the {@link DATInputStreamConfigurationKind}
    *
    * @return {@link DATInputStreamConfigurationKind}
@@ -116,6 +123,7 @@ public abstract class BenchmarkBase extends ExecutionBase {
   protected void executeReadPatternOnDAT() throws IOException {
     S3Object s3Object = this.getObject();
     executeReadPatternOnDAT(
+        this.getClientKind(),
         s3Object,
         this.getReadPatternKind().getStreamReadPattern(s3Object),
         // Use default configuration
@@ -131,6 +139,9 @@ public abstract class BenchmarkBase extends ExecutionBase {
   protected void executeReadPatternDirectly() throws IOException {
     S3Object s3Object = this.getObject();
     executeReadPatternDirectly(
-        s3Object, this.getReadPatternKind().getStreamReadPattern(s3Object), Optional.empty());
+        this.getClientKind(),
+        s3Object,
+        this.getReadPatternKind().getStreamReadPattern(s3Object),
+        Optional.empty());
   }
 }

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/ExecutionBase.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/ExecutionBase.java
@@ -34,13 +34,6 @@ public abstract class ExecutionBase {
   protected abstract S3ExecutionContext getS3ExecutionContext();
 
   /**
-   * Returns current client kind
-   *
-   * @return {@link S3ClientKind}
-   */
-  protected abstract S3ClientKind getClientKind();
-
-  /**
    * Creates an instance of {@link S3AsyncClientStreamReader} that uses {@link
    * software.amazon.awssdk.services.s3.S3AsyncClient} to read from S3
    *
@@ -75,16 +68,20 @@ public abstract class ExecutionBase {
   /**
    * Executes a pattern directly on an S3 Client.
    *
+   * @param s3ClientKind S3 client kind to use
    * @param s3Object {@link } S3 Object to run the pattern on
    * @param streamReadPattern the read pattern
    * @param checksum checksum to update, if specified
    * @throws IOException IO error, if thrown
    */
   protected void executeReadPatternDirectly(
-      S3Object s3Object, StreamReadPattern streamReadPattern, Optional<Crc32CChecksum> checksum)
+      S3ClientKind s3ClientKind,
+      S3Object s3Object,
+      StreamReadPattern streamReadPattern,
+      Optional<Crc32CChecksum> checksum)
       throws IOException {
     try (S3AsyncClientStreamReader s3AsyncClientStreamReader =
-        this.createS3AsyncClientStreamReader(getClientKind())) {
+        this.createS3AsyncClientStreamReader(s3ClientKind)) {
       s3AsyncClientStreamReader.readPattern(s3Object, streamReadPattern, checksum);
     }
   }
@@ -92,6 +89,7 @@ public abstract class ExecutionBase {
   /**
    * Executes a pattern on DAT
    *
+   * @param s3ClientKind S3 client kind to use
    * @param s3Object {@link S3Object} S3 Object to run the pattern on
    * @param DATInputStreamConfigurationKind DAT configuration
    * @param streamReadPattern the read pattern
@@ -99,13 +97,14 @@ public abstract class ExecutionBase {
    * @throws IOException IO error, if thrown
    */
   protected void executeReadPatternOnDAT(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPattern streamReadPattern,
       DATInputStreamConfigurationKind DATInputStreamConfigurationKind,
       Optional<Crc32CChecksum> checksum)
       throws IOException {
     try (S3DATClientStreamReader s3DATClientStreamReader =
-        this.createS3DATClientStreamReader(getClientKind(), DATInputStreamConfigurationKind)) {
+        this.createS3DATClientStreamReader(s3ClientKind, DATInputStreamConfigurationKind)) {
       executeReadPatternOnDAT(s3Object, s3DATClientStreamReader, streamReadPattern, checksum);
     }
   }

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/exceptions/ExceptionHandler.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/exceptions/ExceptionHandler.java
@@ -75,6 +75,21 @@ public enum ExceptionHandler {
         .orElseGet(() -> createIOException("Error accessing %s", uri, cause));
   }
 
+  /**
+   * Provides sample exceptions for all the exception types handled
+   *
+   * @return An array of exceptions
+   */
+  public static Exception[] getSampleExceptions() {
+    return new Exception[] {
+      NoSuchKeyException.builder().build(),
+      InvalidObjectStateException.builder().build(),
+      SdkClientException.builder().build(),
+      S3Exception.builder().build(),
+      SdkException.builder().build()
+    };
+  }
+
   private static IOException createIOException(String message, S3URI uri, Throwable cause) {
     return new IOException(String.format(message, uri), cause);
   }


### PR DESCRIPTION
## Description of change
- Ensure integration tests run for both S3 Client Kinds
- Add more unit tests for ObjectClient and S3SeekableInputStreamFactory

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors? 
NO

#### Does this contribution introduce any new public APIs or behaviors? 
NO

#### How was the contribution tested?
Unit and Integration tests

#### Does this contribution need a changelog entry?
NO

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).