### PR TITLE
add gray failure tests and FaultyS3Client

### DIFF
--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
@@ -36,9 +36,9 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
       S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
-      DATInputStreamConfigurationKind configuration)
+      AALInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
-    testDATReadConcurrency(
+    testAALReadConcurrency(
         s3ClientKind,
         s3Object,
         streamReadPattern,
@@ -53,9 +53,9 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
       S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
-      DATInputStreamConfigurationKind configuration)
+      AALInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
-    testDATReadConcurrency(
+    testAALReadConcurrency(
         s3ClientKind,
         s3Object,
         streamReadPattern,
@@ -70,9 +70,9 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
       S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
-      DATInputStreamConfigurationKind configuration)
+      AALInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
-    testDATReadConcurrency(
+    testAALReadConcurrency(
         s3ClientKind,
         s3Object,
         streamReadPattern,
@@ -87,7 +87,7 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
       S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
-      DATInputStreamConfigurationKind configuration)
+      AALInputStreamConfigurationKind configuration)
       throws IOException {
     testChangingEtagMidStream(s3ClientKind, s3Object, streamReadPattern, configuration);
   }
@@ -98,7 +98,7 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
       S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
-      DATInputStreamConfigurationKind configuration)
+      AALInputStreamConfigurationKind configuration)
       throws IOException {
     testChangingEtagAfterStreamPassesAndReturnsCachedObject(s3ClientKind, s3Object, configuration);
   }

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/GrayFailureTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/GrayFailureTest.java
@@ -17,65 +17,67 @@ package software.amazon.s3.analyticsaccelerator.access;
 
 import java.io.IOException;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/** Tests read correctness on multiple sizes and read patterns */
-public class ReadCorrectnessTest extends IntegrationTestBase {
+/** Tests read stream behaviour with untrusted S3ClientKinds on multiple sizes and read patterns */
+@Disabled("Disabled as AAL is not resilient to Faulty S3 Clients yet.")
+public class GrayFailureTest extends IntegrationTestBase {
   @ParameterizedTest
   @MethodSource("sequentialReads")
   void testSequentialReads(
-      S3ClientKind s3ClientKind,
+      S3ClientKind clientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       AALInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(clientKind, s3Object, streamReadPattern, configuration);
   }
 
   @ParameterizedTest
   @MethodSource("skippingReads")
   void testSkippingReads(
-      S3ClientKind s3ClientKind,
+      S3ClientKind clientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       AALInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(clientKind, s3Object, streamReadPattern, configuration);
   }
 
   @ParameterizedTest
   @MethodSource("parquetReads")
   void testQuasiParquetReads(
-      S3ClientKind s3ClientKind,
+      S3ClientKind clientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       AALInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(clientKind, s3Object, streamReadPattern, configuration);
   }
 
   static Stream<Arguments> sequentialReads() {
     return argumentsFor(
-        getS3ClientKinds(),
-        S3Object.smallAndMediumObjects(),
+        S3ClientKind.faultyClients(),
+        S3Object.smallObjects(),
         sequentialPatterns(),
         getS3SeekableInputStreamConfigurations());
   }
 
   static Stream<Arguments> skippingReads() {
     return argumentsFor(
-        getS3ClientKinds(),
-        S3Object.smallAndMediumObjects(),
+        S3ClientKind.faultyClients(),
+        S3Object.smallObjects(),
         skippingPatterns(),
         getS3SeekableInputStreamConfigurations());
   }
 
   static Stream<Arguments> parquetReads() {
     return argumentsFor(
-        getS3ClientKinds(),
-        S3Object.smallAndMediumObjects(),
+        S3ClientKind.faultyClients(),
+        S3Object.smallObjects(),
         parquetPatterns(),
         getS3SeekableInputStreamConfigurations());
   }

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/AALBenchmark.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/AALBenchmark.java
@@ -25,7 +25,7 @@ import software.amazon.s3.analyticsaccelerator.access.StreamReadPatternKind;
  * Benchmarks that measure performance of DAT via CRT by replaying all patterns against multiple
  * object sizes
  */
-public class DATBenchmark extends BenchmarkBase {
+public class AALBenchmark extends BenchmarkBase {
   // NOTE: all params here must come after "object", so they should start with any letter after "o".
   @Param public StreamReadPatternKind pattern;
 

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/BenchmarkBase.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/BenchmarkBase.java
@@ -95,12 +95,12 @@ public abstract class BenchmarkBase extends ExecutionBase {
   protected abstract S3ClientKind getClientKind();
 
   /**
-   * Benchmarks can override this to return the {@link DATInputStreamConfigurationKind}
+   * Benchmarks can override this to return the {@link AALInputStreamConfigurationKind}
    *
-   * @return {@link DATInputStreamConfigurationKind}
+   * @return {@link AALInputStreamConfigurationKind}
    */
-  protected DATInputStreamConfigurationKind getDATInputStreamConfigurationKind() {
-    return DATInputStreamConfigurationKind.DEFAULT;
+  protected AALInputStreamConfigurationKind getDATInputStreamConfigurationKind() {
+    return AALInputStreamConfigurationKind.DEFAULT;
   }
 
   @Benchmark
@@ -122,7 +122,7 @@ public abstract class BenchmarkBase extends ExecutionBase {
    */
   protected void executeReadPatternOnDAT() throws IOException {
     S3Object s3Object = this.getObject();
-    executeReadPatternOnDAT(
+    executeReadPatternOnAAL(
         this.getClientKind(),
         s3Object,
         this.getReadPatternKind().getStreamReadPattern(s3Object),

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/AALInputStreamConfigurationKind.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/AALInputStreamConfigurationKind.java
@@ -22,7 +22,7 @@ import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguratio
 /** Enum representing meaningful configuration samples for {@link S3ExecutionConfiguration} */
 @AllArgsConstructor
 @Getter
-public enum DATInputStreamConfigurationKind {
+public enum AALInputStreamConfigurationKind {
   DEFAULT("DEFAULT", S3SeekableInputStreamConfiguration.DEFAULT);
 
   private final String name;

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/ExecutionBase.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/ExecutionBase.java
@@ -49,33 +49,33 @@ public abstract class ExecutionBase {
   }
 
   /**
-   * Creates an instance of {@link S3DATClientStreamReader} that uses DAT to read from S3
+   * Creates an instance of {@link S3AALClientStreamReader} that uses AAL to read from S3
    *
    * @param s3ClientKind S3 Client kind
-   * @param DATInputStreamConfigurationKind {@link S3SeekableInputStreamConfiguration} kind
-   * @return an instance of {@link S3DATClientStreamReader}
+   * @param AALInputStreamConfigurationKind {@link S3SeekableInputStreamConfiguration} kind
+   * @return an instance of {@link S3AALClientStreamReader}
    */
-  protected S3DATClientStreamReader createS3DATClientStreamReader(
+  protected S3AALClientStreamReader createS3AALClientStreamReader(
       @NonNull S3ClientKind s3ClientKind,
-      @NonNull DATInputStreamConfigurationKind DATInputStreamConfigurationKind) {
-    return new S3DATClientStreamReader(
+      @NonNull AALInputStreamConfigurationKind AALInputStreamConfigurationKind) {
+    return new S3AALClientStreamReader(
         s3ClientKind.getS3Client(this.getS3ExecutionContext()),
-        DATInputStreamConfigurationKind.getValue(),
+        AALInputStreamConfigurationKind.getValue(),
         this.getS3ExecutionContext().getConfiguration().getBaseUri(),
         this.getS3ExecutionContext().getConfiguration().getBufferSizeBytes());
   }
 
   /**
-   * Creates an instance of {@link S3DATClientStreamReader} that uses DAT to read from S3
+   * Creates an instance of {@link S3AALClientStreamReader} that uses AAL to read from S3
    *
    * @param s3ClientKind S3 Client kind
    * @param s3SeekableInputStreamConfiguration {@link S3SeekableInputStreamConfiguration}
-   * @return an instance of {@link S3DATClientStreamReader}
+   * @return an instance of {@link S3AALClientStreamReader}
    */
-  protected S3DATClientStreamReader createS3DATClientStreamReader(
+  protected S3AALClientStreamReader createS3AALClientStreamReader(
       @NonNull S3ClientKind s3ClientKind,
       @NonNull S3SeekableInputStreamConfiguration s3SeekableInputStreamConfiguration) {
-    return new S3DATClientStreamReader(
+    return new S3AALClientStreamReader(
         s3ClientKind.getS3Client(this.getS3ExecutionContext()),
         s3SeekableInputStreamConfiguration,
         this.getS3ExecutionContext().getConfiguration().getBaseUri(),
@@ -97,6 +97,12 @@ public abstract class ExecutionBase {
       StreamReadPattern streamReadPattern,
       Optional<Crc32CChecksum> checksum)
       throws IOException {
+    // Direct Read Pattern execution shouldn't read using the faulty client but it should use a
+    // trusted client.
+    s3ClientKind =
+        s3ClientKind == S3ClientKind.FAULTY_S3_CLIENT
+            ? S3ClientKind.SDK_V2_JAVA_ASYNC
+            : s3ClientKind;
     try (S3AsyncClientStreamReader s3AsyncClientStreamReader =
         this.createS3AsyncClientStreamReader(s3ClientKind)) {
       s3AsyncClientStreamReader.readPattern(s3Object, streamReadPattern, checksum);
@@ -104,43 +110,43 @@ public abstract class ExecutionBase {
   }
 
   /**
-   * Executes a pattern on DAT
+   * Executes a pattern on AAL
    *
    * @param s3ClientKind S3 client kind to use
    * @param s3Object {@link S3Object} S3 Object to run the pattern on
-   * @param DATInputStreamConfigurationKind DAT configuration
+   * @param AALInputStreamConfigurationKind DAT configuration
    * @param streamReadPattern the read pattern
    * @param checksum checksum to update, if specified
    * @throws IOException IO error, if thrown
    */
-  protected void executeReadPatternOnDAT(
+  protected void executeReadPatternOnAAL(
       S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPattern streamReadPattern,
-      DATInputStreamConfigurationKind DATInputStreamConfigurationKind,
+      AALInputStreamConfigurationKind AALInputStreamConfigurationKind,
       Optional<Crc32CChecksum> checksum)
       throws IOException {
-    try (S3DATClientStreamReader s3DATClientStreamReader =
-        this.createS3DATClientStreamReader(s3ClientKind, DATInputStreamConfigurationKind)) {
-      executeReadPatternOnDAT(s3Object, s3DATClientStreamReader, streamReadPattern, checksum);
+    try (S3AALClientStreamReader s3AALClientStreamReader =
+        this.createS3AALClientStreamReader(s3ClientKind, AALInputStreamConfigurationKind)) {
+      executeReadPatternOnAAL(s3Object, s3AALClientStreamReader, streamReadPattern, checksum);
     }
   }
 
   /**
-   * Executes a pattern on DAT
+   * Executes a pattern on AAL
    *
    * @param s3Object {@link S3Object} S3 Object to run the pattern on
-   * @param s3DATClientStreamReader DAT stream reader
+   * @param s3AALClientStreamReader DAT stream reader
    * @param streamReadPattern the read pattern
    * @param checksum checksum to update, if specified
    * @throws IOException IO error, if thrown
    */
-  protected void executeReadPatternOnDAT(
+  protected void executeReadPatternOnAAL(
       S3Object s3Object,
-      S3DATClientStreamReader s3DATClientStreamReader,
+      S3AALClientStreamReader s3AALClientStreamReader,
       StreamReadPattern streamReadPattern,
       Optional<Crc32CChecksum> checksum)
       throws IOException {
-    s3DATClientStreamReader.readPattern(s3Object, streamReadPattern, checksum);
+    s3AALClientStreamReader.readPattern(s3Object, streamReadPattern, checksum);
   }
 }

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/FaultyS3AsyncClient.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/FaultyS3AsyncClient.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.access;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.DelegatingS3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+/**
+ * A faulty S3 Client implementation that injects failure to S3 calls. Current version only adds
+ * infinite waiting to Get calls. We should extend this in the future to except a FaultKind or a
+ * FaultConfiguration.
+ */
+public class FaultyS3AsyncClient extends DelegatingS3AsyncClient {
+
+  Set<String> stuckObjects;
+
+  /**
+   * Create an instance of a S3 client, for interaction with Amazon S3 compatible object stores.
+   * This takes ownership of the passed client and will close it on its own close().
+   *
+   * @param delegate Underlying client to be used for making requests to S3.
+   */
+  public FaultyS3AsyncClient(S3AsyncClient delegate) {
+    super(delegate);
+    this.stuckObjects = Collections.synchronizedSet(new HashSet<>());
+  }
+
+  /**
+   * A faulty override of getObject. First GET call to an object will wait forever. All requests to
+   * the same object will be delegated to regular S3AsyncClient.
+   *
+   * @param request request
+   * @param asyncResponseTransformer response transformer
+   * @return an instance of {@link S3AsyncClient}
+   */
+  @Override
+  public <T> CompletableFuture<T> getObject(
+      GetObjectRequest request,
+      AsyncResponseTransformer<GetObjectResponse, T> asyncResponseTransformer) {
+    if (!stuckObjects.contains(request.key())) {
+      stuckObjects.add(request.key());
+      return CompletableFuture.supplyAsync(
+          () -> {
+            try {
+              while (true) {
+                Thread.sleep(10000);
+              }
+            } catch (InterruptedException e) {
+              e.printStackTrace();
+            }
+            return null;
+          });
+    } else {
+      return super.getObject(request, asyncResponseTransformer);
+    }
+  }
+}

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3AALClientStreamReader.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3AALClientStreamReader.java
@@ -28,19 +28,19 @@ import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 /** Client stream reader based on DAT */
-public class S3DATClientStreamReader extends S3StreamReaderBase {
+public class S3AALClientStreamReader extends S3StreamReaderBase {
   @NonNull @Getter private final S3SdkObjectClient sdkObjectClient;
   @NonNull @Getter private final S3SeekableInputStreamFactory s3SeekableInputStreamFactory;
 
   /**
-   * Creates an instance of {@link S3DATClientStreamReader}
+   * Creates an instance of {@link S3AALClientStreamReader}
    *
    * @param s3AsyncClient an instance of {@link S3AsyncClient}
    * @param configuration {@link S3SeekableInputStreamConfiguration}
    * @param baseUri base URI for all objects
    * @param bufferSize buffer size
    */
-  public S3DATClientStreamReader(
+  public S3AALClientStreamReader(
       @NonNull S3AsyncClient s3AsyncClient,
       @NonNull S3SeekableInputStreamConfiguration configuration,
       @NonNull S3URI baseUri,

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3AsyncClientFactory.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3AsyncClientFactory.java
@@ -48,4 +48,16 @@ public class S3AsyncClientFactory {
         .targetThroughputInGbps((double) configuration.getCrtTargetThroughputGbps())
         .build();
   }
+
+  /**
+   * Builds a faulty async Java client
+   *
+   * @param configuration configuration
+   * @return an instance of {@link S3AsyncClient}
+   */
+  public static S3AsyncClient createFaultyS3Client(
+      @NonNull S3AsyncClientFactoryConfiguration configuration) {
+    S3AsyncClient delegate = createS3AsyncClient(configuration);
+    return new FaultyS3AsyncClient(delegate);
+  }
 }

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ClientKind.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ClientKind.java
@@ -15,6 +15,8 @@
  */
 package software.amazon.s3.analyticsaccelerator.access;
 
+import java.util.Arrays;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -25,7 +27,8 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 @Getter
 public enum S3ClientKind {
   SDK_V2_JAVA_ASYNC("ASYNC_JAVA"),
-  SDK_V2_CRT_ASYNC("ASYNC_CRT");
+  SDK_V2_CRT_ASYNC("ASYNC_CRT"),
+  FAULTY_S3_CLIENT("FAULTY_S3");
 
   private final String value;
   /**
@@ -41,8 +44,28 @@ public enum S3ClientKind {
         return s3ExecutionContext.getS3Client();
       case SDK_V2_CRT_ASYNC:
         return s3ExecutionContext.getS3CrtClient();
+      case FAULTY_S3_CLIENT:
+        return s3ExecutionContext.getFaultyS3Client();
       default:
         throw new IllegalArgumentException("Unsupported client kind: " + this);
     }
+  }
+
+  /**
+   * Trusted S3 Clients
+   *
+   * @return small objects
+   */
+  public static List<S3ClientKind> trustedClients() {
+    return Arrays.asList(SDK_V2_JAVA_ASYNC, SDK_V2_CRT_ASYNC);
+  }
+
+  /**
+   * Faulty S3 Clients
+   *
+   * @return small objects
+   */
+  public static List<S3ClientKind> faultyClients() {
+    return Arrays.asList(FAULTY_S3_CLIENT);
   }
 }

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ExecutionContext.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ExecutionContext.java
@@ -28,6 +28,7 @@ public class S3ExecutionContext implements Closeable {
   @NonNull private final S3ExecutionConfiguration configuration;
   @NonNull private final S3AsyncClient s3Client;
   @NonNull private final S3AsyncClient s3CrtClient;
+  @NonNull private final S3AsyncClient faultyS3Client;
 
   /**
    * Creates an instance of {@link S3ExecutionContext}
@@ -40,6 +41,8 @@ public class S3ExecutionContext implements Closeable {
         S3AsyncClientFactory.createS3AsyncClient(configuration.getClientFactoryConfiguration());
     this.s3CrtClient =
         S3AsyncClientFactory.createS3CrtAsyncClient(configuration.getClientFactoryConfiguration());
+    this.faultyS3Client =
+        S3AsyncClientFactory.createFaultyS3Client(configuration.getClientFactoryConfiguration());
 
     // test connections
     testConnection(this.s3Client, configuration);


### PR DESCRIPTION
## Description of change
This change adds a new S3Client to TestFixtures -- FaultyS3Client. 
The purpose of this client to inject failures to S3 Interactions and test for resiliency of the library.

#### Relevant issues
AWS Java SDK V2 has an issue of getting stuck time to time: https://github.com/aws/aws-sdk-java-v2/issues/5755 
With this PR we are reproducing a similar behaviour. In the follow-up PRs we will implement defense in depth mechanisms.

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No.

#### Does this contribution introduce any new public APIs or behaviors?
No.

#### How was the contribution tested?
This is a test contribution itself. New tests are disabled.
Confirmed `./gradlew integrationTest` are still passing with the 2 trusted SDK clients and not triggered with the faulty client. 


#### Does this contribution need a changelog entry?
No. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).