### PR TITLE
Revert "Explicitly close input stream."

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamUtils.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamUtils.java
@@ -43,8 +43,6 @@ public class StreamUtils {
       while ((numBytesRead = inStream.read(buffer, 0, buffer.length)) != -1) {
         outStream.write(buffer, 0, numBytesRead);
       }
-
-      inStream.close();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Reverts awslabs/analytics-accelerator-s3#216

Integration tests fails when we close input stream explicitly. We need to dive deeper here before we can merge this change.