### PR TITLE
Reduce long to int type cast

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -166,11 +166,12 @@ public class Block implements Closeable {
     Preconditions.checkArgument(off < buf.length, "`off` must be less than size of buffer");
 
     byte[] content = this.getData();
-    int available = content.length - posToOffset(pos);
+    int contentOffset = posToOffset(pos);
+    int available = content.length - contentOffset;
     int bytesToCopy = Math.min(len, available);
 
     for (int i = 0; i < bytesToCopy; ++i) {
-      buf[off + i] = content[posToOffset(pos) + i];
+      buf[off + i] = content[contentOffset + i];
     }
 
     return bytesToCopy;


### PR DESCRIPTION
## Description of change
When copying bytes from block content to buf passed in parameter, we re-compute content offset for each byte.
This means doing a long -> int cast for every byte read from the stream. This conversation is not needed to be done multiple times as start of a block is final and pos is not changing inside the method. This PR removes unnecessary conversation. 

#### Relevant issues
<!-- Please add issue numbers. -->
<!-- Please also link them to this PR. -->

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
<!-- Please explain why this was necessary. -->

#### Does this contribution introduce any new public APIs or behaviors?
<!-- Please describe them and explain what scenarios they target.  -->

#### How was the contribution tested?
<!-- Please describe how this contribution was tested. -->

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).