### PR TITLE
Adds in constructor for open file information when creating stream.

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
@@ -18,6 +18,7 @@ package software.amazon.s3.analyticsaccelerator.request;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
+import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 
 /** Wrapper class around HeadObjectResponse abstracting away from S3-specific details */
 @Data
@@ -26,4 +27,12 @@ public class ObjectMetadata {
   long contentLength;
 
   @NonNull String etag;
+
+  @Builder
+  private ObjectMetadata(long contentLength, @NonNull String etag) {
+    Preconditions.checkArgument(contentLength >= 0, "content length` must be non-negative");
+
+    this.contentLength = contentLength;
+    this.etag = etag;
+  }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
@@ -30,7 +30,7 @@ public class ObjectMetadata {
 
   @Builder
   private ObjectMetadata(long contentLength, @NonNull String etag) {
-    Preconditions.checkArgument(contentLength >= 0, "content length` must be non-negative");
+    Preconditions.checkArgument(contentLength >= 0, "content length must be non-negative");
 
     this.contentLength = contentLength;
     this.etag = etag;

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/InputPolicy.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/InputPolicy.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.util;
+
+/**
+ * Input policy to be used when reading a while. Useful for integrating applications to pass down a
+ * policy they would like AAL to use, rather than us guessing based on file format.
+ */
+public enum InputPolicy {
+  None,
+  Sequential
+}

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/InputPolicy.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/InputPolicy.java
@@ -16,8 +16,15 @@
 package software.amazon.s3.analyticsaccelerator.util;
 
 /**
- * Input policy to be used when reading a while. Useful for integrating applications to pass down a
+ * Input policy to be used when reading a file. Useful for integrating applications to pass down a
  * policy they would like AAL to use, rather than us guessing based on file format.
+ *
+ * <p>A sequential policy means that the file will be read sequentially, regardless of the file
+ * format. Useful for sequential data types such as CSV, or for applications that read columnar
+ * formats sequentially.
+ *
+ * <p>When no input policy is supplied, AAL will infer what optimisations to use based on the file
+ * extension.
  */
 public enum InputPolicy {
   None,

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/OpenFileInformation.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/OpenFileInformation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.util;
+
+import lombok.Builder;
+import lombok.Value;
+import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
+import software.amazon.s3.analyticsaccelerator.request.StreamContext;
+
+/**
+ * Open file information, useful for allowing the stream opening application to pass down known
+ * information and callbacks when opening the file.
+ */
+@Value
+@Builder
+public class OpenFileInformation {
+  StreamContext streamContext;
+  ObjectMetadata objectMetadata;
+  InputPolicy inputPolicy;
+
+  /** Default set of settings for {@link OpenFileInformation} */
+  public static final OpenFileInformation DEFAULT = OpenFileInformation.builder().build();
+}

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -95,7 +95,7 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
    */
   public S3SeekableInputStream createStream(@NonNull S3URI s3URI, ObjectMetadata metadata)
       throws IOException {
-    objectMetadataStore.storeObjectMetadata(s3URI, metadata);
+    storeObjectMetadata(s3URI, metadata);
     return new S3SeekableInputStream(s3URI, createLogicalIO(s3URI), telemetry);
   }
 
@@ -109,7 +109,7 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
    */
   public S3SeekableInputStream createStream(
       @NonNull S3URI s3URI, @NonNull OpenFileInformation openFileInformation) throws IOException {
-    objectMetadataStore.storeObjectMetadata(s3URI, openFileInformation.getObjectMetadata());
+    storeObjectMetadata(s3URI, openFileInformation.getObjectMetadata());
     return new S3SeekableInputStream(s3URI, createLogicalIO(s3URI, openFileInformation), telemetry);
   }
 
@@ -144,6 +144,10 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
                 openFileInformation.getStreamContext()),
             telemetry);
     }
+  }
+
+  void storeObjectMetadata(S3URI s3URI, ObjectMetadata metadata) {
+    objectMetadataStore.storeObjectMetadata(s3URI, metadata);
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -29,8 +29,8 @@ import software.amazon.s3.analyticsaccelerator.io.physical.data.MetadataStore;
 import software.amazon.s3.analyticsaccelerator.io.physical.impl.PhysicalIOImpl;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
-import software.amazon.s3.analyticsaccelerator.request.StreamContext;
 import software.amazon.s3.analyticsaccelerator.util.ObjectFormatSelector;
+import software.amazon.s3.analyticsaccelerator.util.OpenFileInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 /**
@@ -96,36 +96,40 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
    */
   public S3SeekableInputStream createStream(@NonNull S3URI s3URI, ObjectMetadata metadata)
       throws IOException {
-    Preconditions.checkArgument(metadata.getContentLength() >= 0, "`len` must be non-negative");
-
-    objectMetadataStore.storeObjectMetadata(s3URI, metadata);
-
+    storeObjectMetadata(s3URI, metadata);
     return new S3SeekableInputStream(s3URI, createLogicalIO(s3URI), telemetry);
   }
 
   /**
-   * Create an instance of S3SeekableInputStream with streamContext.
+   * Creates and instance of SeekableStream with file information
    *
    * @param s3URI the object's S3 URI
-   * @param streamContext contains audit headers to be attached in request header
+   * @param openFileInformation known file information this key
    * @return An instance of the input stream.
+   * @throws IOException IoException
    */
-  public S3SeekableInputStream createStream(@NonNull S3URI s3URI, StreamContext streamContext)
-      throws IOException {
-    return new S3SeekableInputStream(s3URI, createLogicalIO(s3URI, streamContext), telemetry);
+  public S3SeekableInputStream createStream(
+      @NonNull S3URI s3URI, @NonNull OpenFileInformation openFileInformation) throws IOException {
+    storeObjectMetadata(s3URI, openFileInformation.getObjectMetadata());
+    return new S3SeekableInputStream(s3URI, createLogicalIO(s3URI, openFileInformation), telemetry);
   }
 
   LogicalIO createLogicalIO(S3URI s3URI) throws IOException {
-    return createLogicalIO(s3URI, null);
+    return createLogicalIO(s3URI, OpenFileInformation.DEFAULT);
   }
 
-  LogicalIO createLogicalIO(S3URI s3URI, StreamContext streamContext) throws IOException {
-    switch (objectFormatSelector.getObjectFormat(s3URI)) {
+  LogicalIO createLogicalIO(S3URI s3URI, OpenFileInformation openFileInformation)
+      throws IOException {
+    switch (objectFormatSelector.getObjectFormat(s3URI, openFileInformation)) {
       case PARQUET:
         return new ParquetLogicalIOImpl(
             s3URI,
             new PhysicalIOImpl(
-                s3URI, objectMetadataStore, objectBlobStore, telemetry, streamContext),
+                s3URI,
+                objectMetadataStore,
+                objectBlobStore,
+                telemetry,
+                openFileInformation.getStreamContext()),
             telemetry,
             configuration.getLogicalIOConfiguration(),
             parquetColumnPrefetchStore);
@@ -134,8 +138,19 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
         return new DefaultLogicalIOImpl(
             s3URI,
             new PhysicalIOImpl(
-                s3URI, objectMetadataStore, objectBlobStore, telemetry, streamContext),
+                s3URI,
+                objectMetadataStore,
+                objectBlobStore,
+                telemetry,
+                openFileInformation.getStreamContext()),
             telemetry);
+    }
+  }
+
+  void storeObjectMetadata(S3URI s3URI, ObjectMetadata metadata) {
+    if (metadata != null) {
+      Preconditions.checkArgument(metadata.getContentLength() >= 0, "`len` must be non-negative");
+      objectMetadataStore.storeObjectMetadata(s3URI, metadata);
     }
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -147,7 +147,9 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
   }
 
   void storeObjectMetadata(S3URI s3URI, ObjectMetadata metadata) {
-    objectMetadataStore.storeObjectMetadata(s3URI, metadata);
+    if (metadata != null) {
+      objectMetadataStore.storeObjectMetadata(s3URI, metadata);
+    }
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -18,7 +18,6 @@ package software.amazon.s3.analyticsaccelerator;
 import java.io.IOException;
 import lombok.Getter;
 import lombok.NonNull;
-import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIO;
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.DefaultLogicalIOImpl;
@@ -96,12 +95,12 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
    */
   public S3SeekableInputStream createStream(@NonNull S3URI s3URI, ObjectMetadata metadata)
       throws IOException {
-    storeObjectMetadata(s3URI, metadata);
+    objectMetadataStore.storeObjectMetadata(s3URI, metadata);
     return new S3SeekableInputStream(s3URI, createLogicalIO(s3URI), telemetry);
   }
 
   /**
-   * Creates and instance of SeekableStream with file information
+   * Creates an instance of SeekableStream with file information
    *
    * @param s3URI the object's S3 URI
    * @param openFileInformation known file information this key
@@ -110,7 +109,7 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
    */
   public S3SeekableInputStream createStream(
       @NonNull S3URI s3URI, @NonNull OpenFileInformation openFileInformation) throws IOException {
-    storeObjectMetadata(s3URI, openFileInformation.getObjectMetadata());
+    objectMetadataStore.storeObjectMetadata(s3URI, openFileInformation.getObjectMetadata());
     return new S3SeekableInputStream(s3URI, createLogicalIO(s3URI, openFileInformation), telemetry);
   }
 
@@ -144,13 +143,6 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
                 telemetry,
                 openFileInformation.getStreamContext()),
             telemetry);
-    }
-  }
-
-  void storeObjectMetadata(S3URI s3URI, ObjectMetadata metadata) {
-    if (metadata != null) {
-      Preconditions.checkArgument(metadata.getContentLength() >= 0, "`len` must be non-negative");
-      objectMetadataStore.storeObjectMetadata(s3URI, metadata);
     }
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStore.java
@@ -128,7 +128,9 @@ public class MetadataStore implements Closeable {
    * @param objectMetadata Object metadata
    */
   public synchronized void storeObjectMetadata(S3URI s3URI, ObjectMetadata objectMetadata) {
-    this.cache.put(s3URI, CompletableFuture.completedFuture(objectMetadata));
+    if (objectMetadata != null) {
+      this.cache.put(s3URI, CompletableFuture.completedFuture(objectMetadata));
+    }
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelector.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelector.java
@@ -38,7 +38,7 @@ public class ObjectFormatSelector {
    * Uses a regex matcher to select the file format based on the file extension of the key.
    *
    * @param s3URI the object's S3 URI
-   * @param openFileInformation known file information for the fil e
+   * @param openFileInformation known file information for the file
    * @return the file format of the object
    */
   public ObjectFormat getObjectFormat(S3URI s3URI, OpenFileInformation openFileInformation) {

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelector.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelector.java
@@ -38,9 +38,22 @@ public class ObjectFormatSelector {
    * Uses a regex matcher to select the file format based on the file extension of the key.
    *
    * @param s3URI the object's S3 URI
+   * @param openFileInformation known file information for the fil e
    * @return the file format of the object
    */
-  public ObjectFormat getObjectFormat(S3URI s3URI) {
+  public ObjectFormat getObjectFormat(S3URI s3URI, OpenFileInformation openFileInformation) {
+
+    // If the supplied policy in open file information is Sequential, then use the default input
+    // stream, regardless of the file format (even if it's parquet!). This is important for
+    // applications like DISTCP, which use a "whole_file" read policy with S3A, where they will
+    // read parquet file sequentially (as they simply need to copy over the file),
+    // instead of the regular parquet pattern of footer first, then specific columns etc., so our
+    // parquet specific optimisations are of no use there :(
+    if (openFileInformation.getInputPolicy() != null
+        && openFileInformation.getInputPolicy().equals(InputPolicy.Sequential)) {
+      return ObjectFormat.DEFAULT;
+    }
+
     if (parquetPattern.matcher(s3URI.getKey()).find()) {
       return ObjectFormat.PARQUET;
     }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
@@ -40,7 +40,7 @@ import software.amazon.s3.analyticsaccelerator.io.logical.impl.DefaultLogicalIOI
 import software.amazon.s3.analyticsaccelerator.io.logical.impl.ParquetLogicalIOImpl;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
-import software.amazon.s3.analyticsaccelerator.request.StreamContext;
+import software.amazon.s3.analyticsaccelerator.util.OpenFileInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 @SuppressFBWarnings(
@@ -99,7 +99,7 @@ public class S3SeekableInputStreamFactoryTest {
 
     inputStream =
         s3SeekableInputStreamFactory.createStream(
-            S3URI.of("bucket", "key"), mock(StreamContext.class));
+            S3URI.of("bucket", "key"), mock(OpenFileInformation.class));
     assertNotNull(inputStream);
   }
 
@@ -156,7 +156,7 @@ public class S3SeekableInputStreamFactoryTest {
     S3SeekableInputStream inputStream = s3SeekableInputStreamFactory.createStream(s3URI);
     assertNotNull(inputStream);
 
-    inputStream = s3SeekableInputStreamFactory.createStream(s3URI, mock(StreamContext.class));
+    inputStream = s3SeekableInputStreamFactory.createStream(s3URI, mock(OpenFileInformation.class));
     assertNotNull(inputStream);
   }
 
@@ -174,7 +174,7 @@ public class S3SeekableInputStreamFactoryTest {
     assertThrows(
         NullPointerException.class,
         () -> {
-          s3SeekableInputStreamFactory.createStream(null, mock(StreamContext.class));
+          s3SeekableInputStreamFactory.createStream(null, mock(OpenFileInformation.class));
         });
   }
 
@@ -205,17 +205,18 @@ public class S3SeekableInputStreamFactoryTest {
         .storeObjectMetadata(testURITXT, objectMetadata);
 
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(testURIParquet, mock(StreamContext.class))
+        s3SeekableInputStreamFactory.createLogicalIO(
+                testURIParquet, mock(OpenFileInformation.class))
             instanceof ParquetLogicalIOImpl);
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(testURIKEYPAR, mock(StreamContext.class))
+        s3SeekableInputStreamFactory.createLogicalIO(testURIKEYPAR, mock(OpenFileInformation.class))
             instanceof ParquetLogicalIOImpl);
 
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(testURIJAVA, mock(StreamContext.class))
+        s3SeekableInputStreamFactory.createLogicalIO(testURIJAVA, mock(OpenFileInformation.class))
             instanceof DefaultLogicalIOImpl);
     assertTrue(
-        s3SeekableInputStreamFactory.createLogicalIO(testURITXT, mock(StreamContext.class))
+        s3SeekableInputStreamFactory.createLogicalIO(testURITXT, mock(OpenFileInformation.class))
             instanceof DefaultLogicalIOImpl);
   }
 
@@ -265,7 +266,8 @@ public class S3SeekableInputStreamFactoryTest {
     S3SeekableInputStreamFactory factory =
         new S3SeekableInputStreamFactory(
             new S3SdkObjectClient(mockS3AsyncClient), S3SeekableInputStreamConfiguration.DEFAULT);
-    S3SeekableInputStream inputStream = factory.createStream(TEST_URI, mock(StreamContext.class));
+    S3SeekableInputStream inputStream =
+        factory.createStream(TEST_URI, mock(OpenFileInformation.class));
     Exception thrownException = assertThrows(Exception.class, inputStream::read);
     assertInstanceOf(IOException.class, thrownException);
     Optional.ofNullable(thrownException.getCause())
@@ -281,7 +283,7 @@ public class S3SeekableInputStreamFactoryTest {
             new S3SdkObjectClient(mockS3AsyncClient), S3SeekableInputStreamConfiguration.DEFAULT);
     Exception thrownException =
         assertThrows(
-            Exception.class, () -> factory.createStream(TEST_URI, mock(StreamContext.class)));
+            Exception.class, () -> factory.createStream(TEST_URI, mock(OpenFileInformation.class)));
     assertInstanceOf(IOException.class, thrownException);
     Optional.ofNullable(thrownException.getCause())
         .ifPresent(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -150,28 +150,4 @@ public class ParquetLogicalIOImplTest {
                 LogicalIOConfiguration.DEFAULT,
                 new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
   }
-
-  @Test
-  void testMetadataWithNegativeContentLength() throws IOException {
-    ObjectClient mockClient = mock(ObjectClient.class);
-    when(mockClient.headObject(any(HeadRequest.class)))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                ObjectMetadata.builder().contentLength(-1).etag("random").build()));
-    S3URI s3URI = S3URI.of("test", "test");
-    MetadataStore metadataStore =
-        new MetadataStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
-    BlobStore blobStore =
-        new BlobStore(mockClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
-    PhysicalIOImpl physicalIO =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
-    assertDoesNotThrow(
-        () ->
-            new ParquetLogicalIOImpl(
-                TEST_URI,
-                physicalIO,
-                TestTelemetry.DEFAULT,
-                LogicalIOConfiguration.DEFAULT,
-                new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)));
-  }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelectorTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelectorTest.java
@@ -30,7 +30,8 @@ public class ObjectFormatSelectorTest {
         new ObjectFormatSelector(LogicalIOConfiguration.DEFAULT);
 
     assertEquals(
-        objectFormatSelector.getObjectFormat(S3URI.of("bucket", key)), ObjectFormat.PARQUET);
+        objectFormatSelector.getObjectFormat(S3URI.of("bucket", key), OpenFileInformation.DEFAULT),
+        ObjectFormat.PARQUET);
   }
 
   @ParameterizedTest
@@ -42,7 +43,8 @@ public class ObjectFormatSelectorTest {
             LogicalIOConfiguration.builder().parquetFormatSelectorRegex("^.*.(pr3|par3)$").build());
 
     assertEquals(
-        objectFormatSelector.getObjectFormat(S3URI.of("bucket", key)), ObjectFormat.PARQUET);
+        objectFormatSelector.getObjectFormat(S3URI.of("bucket", key), OpenFileInformation.DEFAULT),
+        ObjectFormat.PARQUET);
   }
 
   @ParameterizedTest
@@ -52,6 +54,20 @@ public class ObjectFormatSelectorTest {
         new ObjectFormatSelector(LogicalIOConfiguration.DEFAULT);
 
     assertEquals(
-        objectFormatSelector.getObjectFormat(S3URI.of("bucket", key)), ObjectFormat.DEFAULT);
+        objectFormatSelector.getObjectFormat(S3URI.of("bucket", key), OpenFileInformation.DEFAULT),
+        ObjectFormat.DEFAULT);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"key.parquet", "key.par"})
+  public void testDefaultLogicalIOSelectionWithSequentialInputPolicy(String key) {
+    ObjectFormatSelector objectFormatSelector =
+        new ObjectFormatSelector(LogicalIOConfiguration.DEFAULT);
+
+    assertEquals(
+        objectFormatSelector.getObjectFormat(
+            S3URI.of("bucket", key),
+            OpenFileInformation.builder().inputPolicy(InputPolicy.Sequential).build()),
+        ObjectFormat.DEFAULT);
   }
 }


### PR DESCRIPTION
## Description of change

This PR adds in a new constructor `public S3SeekableInputStream createStream(
      @NonNull S3URI s3URI, @NonNull OpenFileInformation openFileInformation) `

This can be used to pass in the streamContext, ObjectMetadata, inputPolicy and whatever else is needed later. 

We need to pass in the input policy, as applications can use a `fs.s3a.experimental.input.fadvise` config 
when opening files with S3A. There are cases when we must respect this value, eg for DISTCP, if fadvise is set to `whole-file`, then we shouldn't use parquet optimisations, even if the file format is parquet. 

#### Relevant issues

N/A

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?

No

#### Does this contribution introduce any new public APIs or behaviors?

Yes, adds in new public constructor.

#### How was the contribution tested?

Ran unit tests locally. 

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).