### PR TITLE
Disable sequential prefetching for non Parquet objects

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/OpenFileInformation.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/OpenFileInformation.java
@@ -25,7 +25,7 @@ import software.amazon.s3.analyticsaccelerator.request.StreamContext;
  * information and callbacks when opening the file.
  */
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class OpenFileInformation {
   StreamContext streamContext;
   ObjectMetadata objectMetadata;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
@@ -27,6 +27,7 @@ import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.StreamContext;
 import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
+import software.amazon.s3.analyticsaccelerator.util.OpenFileInformation;
 
 /** A BlobStore is a container for Blobs and functions as a data cache. */
 @SuppressFBWarnings(
@@ -69,9 +70,14 @@ public class BlobStore implements Closeable {
    * @param objectKey the etag and S3 URI of the object
    * @param metadata the metadata for the object we are computing
    * @param streamContext contains audit headers to be attached in the request header
+   * @param openFileInformation known file information including input policy
    * @return the blob representing the object from the BlobStore
    */
-  public Blob get(ObjectKey objectKey, ObjectMetadata metadata, StreamContext streamContext) {
+  public Blob get(
+      ObjectKey objectKey,
+      ObjectMetadata metadata,
+      StreamContext streamContext,
+      OpenFileInformation openFileInformation) {
     return blobMap.computeIfAbsent(
         objectKey,
         uri ->
@@ -79,7 +85,7 @@ public class BlobStore implements Closeable {
                 uri,
                 metadata,
                 new BlockManager(
-                    uri, objectClient, metadata, telemetry, configuration, streamContext),
+                    uri, objectClient, metadata, telemetry, configuration, openFileInformation),
                 telemetry));
   }
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
@@ -31,9 +31,7 @@ import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfigurati
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.StreamContext;
-import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
-import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
-import software.amazon.s3.analyticsaccelerator.util.S3URI;
+import software.amazon.s3.analyticsaccelerator.util.*;
 
 @SuppressFBWarnings(
     value = "NP_NONNULL_PARAM_VIOLATION",
@@ -77,7 +75,9 @@ public class BlobStoreTest {
   @Test
   public void testGetReturnsReadableBlob() throws IOException {
     // When: a Blob is asked for
-    Blob blob = blobStore.get(objectKey, objectMetadata, mock(StreamContext.class));
+    Blob blob =
+        blobStore.get(
+            objectKey, objectMetadata, mock(StreamContext.class), OpenFileInformation.DEFAULT);
 
     // Then:
     byte[] b = new byte[TEST_DATA.length()];
@@ -89,7 +89,8 @@ public class BlobStoreTest {
   @Test
   void testEvictKey_ExistingKey() {
     // Setup
-    blobStore.get(objectKey, objectMetadata, mock(StreamContext.class));
+    blobStore.get(
+        objectKey, objectMetadata, mock(StreamContext.class), OpenFileInformation.DEFAULT);
 
     // Test
     boolean result = blobStore.evictKey(objectKey);

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
@@ -36,6 +36,7 @@ import software.amazon.s3.analyticsaccelerator.request.Range;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
 import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
+import software.amazon.s3.analyticsaccelerator.util.OpenFileInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 @SuppressFBWarnings(
@@ -176,8 +177,8 @@ public class BlobTest {
             fakeObjectClient,
             mockMetadataStore,
             TestTelemetry.DEFAULT,
-            PhysicalIOConfiguration.DEFAULT);
-
+            PhysicalIOConfiguration.DEFAULT,
+            OpenFileInformation.DEFAULT);
     return new Blob(objectKey, mockMetadataStore, blockManager, TestTelemetry.DEFAULT);
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
@@ -37,8 +37,8 @@ import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfigurati
 import software.amazon.s3.analyticsaccelerator.io.physical.data.BlobStore;
 import software.amazon.s3.analyticsaccelerator.io.physical.data.MetadataStore;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
-import software.amazon.s3.analyticsaccelerator.request.StreamContext;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
+import software.amazon.s3.analyticsaccelerator.util.OpenFileInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 @SuppressFBWarnings(
@@ -48,6 +48,11 @@ public class PhysicalIOImplTest {
 
   private static final S3URI s3URI = S3URI.of("foo", "bar");
   private static final String etag = "random";
+  private static final S3URI TEST_URI = S3URI.of("test-bucket", "test-key");
+  private static final String TEST_ETAG = "test-etag";
+  private static final long CONTENT_LENGTH = 1024L;
+  private static final ObjectMetadata TEST_METADATA =
+      ObjectMetadata.builder().contentLength(CONTENT_LENGTH).etag(TEST_ETAG).build();
 
   @Test
   void testConstructorThrowsOnNullArgument() {
@@ -55,7 +60,11 @@ public class PhysicalIOImplTest {
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
-              s3URI, null, mock(BlobStore.class), TestTelemetry.DEFAULT, mock(StreamContext.class));
+              s3URI,
+              null,
+              mock(BlobStore.class),
+              TestTelemetry.DEFAULT,
+              OpenFileInformation.DEFAULT);
         });
 
     assertThrows(
@@ -66,43 +75,71 @@ public class PhysicalIOImplTest {
               mock(MetadataStore.class),
               null,
               TestTelemetry.DEFAULT,
-              mock(StreamContext.class));
+              OpenFileInformation.DEFAULT);
         });
 
     assertThrows(
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
-              null, mock(MetadataStore.class), mock(BlobStore.class), TestTelemetry.DEFAULT);
+              null,
+              mock(MetadataStore.class),
+              mock(BlobStore.class),
+              TestTelemetry.DEFAULT,
+              OpenFileInformation.DEFAULT);
         });
 
     assertThrows(
         NullPointerException.class,
         () -> {
-          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), mock(BlobStore.class), null);
-        });
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(s3URI, null, mock(BlobStore.class), TestTelemetry.DEFAULT);
-        });
-
-    assertThrows(
-        NullPointerException.class,
-        () -> {
-          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), null, TestTelemetry.DEFAULT);
+          new PhysicalIOImpl(
+              s3URI,
+              mock(MetadataStore.class),
+              mock(BlobStore.class),
+              null,
+              OpenFileInformation.DEFAULT);
         });
     assertThrows(
         NullPointerException.class,
         () -> {
           new PhysicalIOImpl(
-              null, mock(MetadataStore.class), mock(BlobStore.class), TestTelemetry.DEFAULT);
+              s3URI,
+              null,
+              mock(BlobStore.class),
+              TestTelemetry.DEFAULT,
+              OpenFileInformation.DEFAULT);
         });
 
     assertThrows(
         NullPointerException.class,
         () -> {
-          new PhysicalIOImpl(s3URI, mock(MetadataStore.class), mock(BlobStore.class), null);
+          new PhysicalIOImpl(
+              s3URI,
+              mock(MetadataStore.class),
+              null,
+              TestTelemetry.DEFAULT,
+              OpenFileInformation.DEFAULT);
+        });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(
+              null,
+              mock(MetadataStore.class),
+              mock(BlobStore.class),
+              TestTelemetry.DEFAULT,
+              OpenFileInformation.DEFAULT);
+        });
+
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new PhysicalIOImpl(
+              s3URI,
+              mock(MetadataStore.class),
+              mock(BlobStore.class),
+              null,
+              OpenFileInformation.DEFAULT);
         });
 
     assertThrows(
@@ -123,7 +160,8 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, OpenFileInformation.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -142,7 +180,8 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, OpenFileInformation.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -158,7 +197,8 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, OpenFileInformation.DEFAULT);
 
     byte[] buffer = new byte[5];
     assertEquals(5, physicalIOImplV2.read(buffer, 0, 5, 5));
@@ -173,7 +213,8 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(fakeObjectClient, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, OpenFileInformation.DEFAULT);
     byte[] buffer = new byte[5];
     assertEquals(5, physicalIOImplV2.readTail(buffer, 0, 5));
     assertEquals(1, blobStore.blobCount());
@@ -211,7 +252,8 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(client, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, OpenFileInformation.DEFAULT);
 
     assertThrows(IOException.class, () -> physicalIOImplV2.read(0));
     assertEquals(0, blobStore.blobCount());
@@ -239,7 +281,8 @@ public class PhysicalIOImplTest {
     BlobStore blobStore =
         new BlobStore(client, TestTelemetry.DEFAULT, PhysicalIOConfiguration.DEFAULT);
     PhysicalIOImpl physicalIOImplV2 =
-        new PhysicalIOImpl(s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT);
+        new PhysicalIOImpl(
+            s3URI, metadataStore, blobStore, TestTelemetry.DEFAULT, OpenFileInformation.DEFAULT);
 
     assertThrows(IOException.class, () -> physicalIOImplV2.read(0));
     assertEquals(0, blobStore.blobCount());


### PR DESCRIPTION
## Description of change

Added support for selective sequential prefetching based on file type. This change enables sequential prefetching specifically for Parquet files and disabling it for non Parquet

#### Does this contribution introduce any breaking changes to the existing APIs or behaviours?
Yes, Disabling sequential prefetching for non Parquet objects

#### Does this contribution introduce any new public APIs or behaviours?
No

#### How was the contribution tested?
<!-- Please describe how this contribution was tested. -->
Updated unit tests for BlockManager, PhysicalIOImpl and S3SeekableInputStreamFactory
Verified behaviour with Parquet and non-Parquet files
Modified existing tests to handle OpenFileInformation

#### Does this contribution need a changelog entry?
No