### PR TITLE
Added retry to Block prefetch

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -197,20 +197,19 @@ public class BlockManager implements Closeable {
           List<Range> missingRanges =
               ioPlanner.planRead(pos, effectiveEndFinal, getLastObjectByte());
           List<Range> splits = rangeOptimiser.splitRanges(missingRanges);
-          splits.forEach(
-              r -> {
-                Block block =
-                    new Block(
-                        objectKey,
-                        objectClient,
-                        telemetry,
-                        r.getStart(),
-                        r.getEnd(),
-                        generation,
-                        readMode,
-                        streamContext);
-                blockStore.add(block);
-              });
+          for (Range r : splits) {
+            Block block =
+                new Block(
+                    objectKey,
+                    objectClient,
+                    telemetry,
+                    r.getStart(),
+                    r.getEnd(),
+                    generation,
+                    readMode,
+                    streamContext);
+            blockStore.add(block);
+          }
         });
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamUtils.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamUtils.java
@@ -20,6 +20,7 @@ import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_KB;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.*;
 import software.amazon.s3.analyticsaccelerator.request.ObjectContent;
 
 /** Utility class for stream operations. */
@@ -31,21 +32,39 @@ public class StreamUtils {
    * Convert an InputStream from the underlying object to a byte array.
    *
    * @param objectContent the part of the object
+   * @param timeoutMs read timeout in milliseconds
    * @return a byte array
    */
-  public static byte[] toByteArray(ObjectContent objectContent) {
+  public static byte[] toByteArray(ObjectContent objectContent, long timeoutMs)
+      throws IOException, TimeoutException {
     InputStream inStream = objectContent.getStream();
     ByteArrayOutputStream outStream = new ByteArrayOutputStream();
     byte[] buffer = new byte[BUFFER_SIZE];
 
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    Future<Void> future =
+        executorService.submit(
+            () -> {
+              try {
+                int numBytesRead;
+                while ((numBytesRead = inStream.read(buffer, 0, buffer.length)) != -1) {
+                  outStream.write(buffer, 0, numBytesRead);
+                }
+                return null;
+              } finally {
+                inStream.close();
+              }
+            });
+
     try {
-      int numBytesRead;
-      while ((numBytesRead = inStream.read(buffer, 0, buffer.length)) != -1) {
-        outStream.write(buffer, 0, numBytesRead);
-      }
-      inStream.close();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+      future.get(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      future.cancel(true);
+      throw new TimeoutException("Read operation timed out");
+    } catch (Exception e) {
+      throw new IOException("Error reading stream", e);
+    } finally {
+      executorService.shutdown();
     }
 
     return outStream.toByteArray();

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamUtils.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/StreamUtils.java
@@ -21,10 +21,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.s3.analyticsaccelerator.io.physical.data.Block;
 import software.amazon.s3.analyticsaccelerator.request.ObjectContent;
 
 /** Utility class for stream operations. */

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
@@ -204,7 +204,7 @@ public class BlockManagerTest {
         .thenThrow(S3Exception.builder().message("PreconditionFailed").statusCode(412).build());
 
     assertThrows(
-        S3Exception.class,
+        IOException.class,
         () -> blockManager.makePositionAvailable(readAheadBytes + 1, ReadMode.SYNC));
   }
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.OptionalLong;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
@@ -41,6 +42,7 @@ public class BlockStoreTest {
   private static final ObjectKey objectKey = ObjectKey.builder().s3URI(TEST_URI).etag(ETAG).build();
   private static final int OBJECT_SIZE = 100;
 
+  @SneakyThrows
   @Test
   public void test__blockStore__getBlockAfterAddBlock() {
     // Given: empty BlockStore
@@ -90,6 +92,7 @@ public class BlockStoreTest {
     assertEquals(OptionalLong.empty(), blockStore.findNextMissingByte(14));
   }
 
+  @SneakyThrows
   @Test
   public void test__blockStore__findNextAvailableByteCorrect() {
     // Given: BlockStore with blocks (2,3), (5,10), (12,15)

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -16,20 +16,15 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletableFuture;
-
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
-import software.amazon.s3.analyticsaccelerator.request.GetRequest;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
-import software.amazon.s3.analyticsaccelerator.request.ObjectContent;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
 import software.amazon.s3.analyticsaccelerator.util.FakeStuckObjectClient;

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -16,13 +16,20 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
+import software.amazon.s3.analyticsaccelerator.request.GetRequest;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
+import software.amazon.s3.analyticsaccelerator.request.ObjectContent;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.FakeObjectClient;
 import software.amazon.s3.analyticsaccelerator.util.FakeStuckObjectClient;
@@ -182,6 +189,7 @@ public class BlockTest {
                 null));
   }
 
+  @SneakyThrows
   @Test
   void testReadBoundaries() {
     final String TEST_DATA = "test-data";
@@ -203,6 +211,7 @@ public class BlockTest {
     assertThrows(IllegalArgumentException.class, () -> block.read(b, 10, 3, 1));
   }
 
+  @SneakyThrows
   @Test
   void testContains() {
     final String TEST_DATA = "test-data";
@@ -220,6 +229,7 @@ public class BlockTest {
     assertFalse(block.contains(TEST_DATA.length() + 1));
   }
 
+  @SneakyThrows
   @Test
   void testContainsBoundaries() {
     final String TEST_DATA = "test-data";
@@ -255,6 +265,7 @@ public class BlockTest {
     assertThrows(IOException.class, () -> block.read(4));
   }
 
+  @SneakyThrows
   @Test
   void testClose() {
     final String TEST_DATA = "test-data";


### PR DESCRIPTION
## Description of change
This PR adds timeout and retry logic to Block object in case reading from stream gets stuck during prefetch.  

#### Relevant issues
- AWS Java SDK V2 has an issue of getting stuck time to time: https://github.com/aws/aws-sdk-java-v2/issues/5755
- https://github.com/awslabs/analytics-accelerator-s3/pull/219

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
- Executed unit tests
- Executed integration tests

#### Does this contribution need a changelog entry?
- No

#### Next Steps
- In a follow-up PR, we need to make timeout milliseconds and retry count as configurable

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).