### PR TITLE
add javadoc generation

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/ConnectorConfiguration.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/ConnectorConfiguration.java
@@ -24,9 +24,9 @@ import lombok.Getter;
 import lombok.NonNull;
 
 /**
- * A map based Connector Framework Configuration to modify LogicalIO, PhysicalIO, and ObjectClient
- * settings. Each configuration item is a Key-Value pair, where keys start with a common prefix.
- * Constructors lets to pass this common prefix as well.
+ * A map based Connector Framework Configuration to modify LogicalIO, PhysicalIO, Telemetry, and
+ * ObjectClient settings. Each configuration item is a Key-Value pair, where keys start with a
+ * common prefix. Constructors lets to pass this common prefix as well.
  *
  * <p>Example: Assume we have the following map fs.s3a.connector.logicalio.a = 10
  * fs.s3a.connector.logicalio.b = "foo" fs.s3a.connector.physicalio.a = 42
@@ -49,18 +49,19 @@ public final class ConnectorConfiguration {
   private final Map<String, String> configuration;
 
   /**
-   * Constructs {@link ConnectorConfiguration} from Map<String, String>. All keys are included in
-   * the configuration
+   * Constructs {@link ConnectorConfiguration} from {@code Map<String, String>}. All keys are
+   * included in the configuration
    *
-   * @param configurationMap key/value set of {@link Map} representing the configuration
+   * @param configurationMap key/value set of {@code Map<String, String>} representing the
+   *     configuration
    */
   public ConnectorConfiguration(@NonNull Map<String, String> configurationMap) {
     this(configurationMap, "");
   }
 
   /**
-   * Constructs {@link ConnectorConfiguration} from Map<String, String> and prependPrefix. Keys not
-   * starting with prefix will be omitted from the configuration.
+   * Constructs {@link ConnectorConfiguration} from {@code Map<String, String>} and prependPrefix.
+   * Keys not starting with prefix will be omitted from the configuration.
    *
    * @param configurationMap key/value set of {@link Map} representing the configuration
    * @param prefix prefix for properties related to Connector Framework for S3
@@ -71,8 +72,8 @@ public final class ConnectorConfiguration {
   }
 
   /**
-   * Constructs {@link ConnectorConfiguration} from Iterable of Map.Entry<String, String> and
-   * prependPrefix. Keys not starting with prefix will be omitted from the configuration.
+   * Constructs {@link ConnectorConfiguration} from Iterable of Map.Entry and prependPrefix. Keys
+   * not starting with prefix will be omitted from the configuration.
    *
    * @param iterableConfiguration key/value iterable of {@link Map} entries representing the
    *     configuration

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/Preconditions.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/Preconditions.java
@@ -856,7 +856,6 @@ public final class Preconditions {
    * @param reference an object reference
    * @return the non-null reference that was validated
    * @throws NullPointerException if {@code reference} is null
-   * @see Verify#verifyNotNull Verify.verifyNotNull()
    */
   public static <T> T checkNotNull(T reference) {
     if (reference == null) {
@@ -873,7 +872,6 @@ public final class Preconditions {
    *     string using {@link String#valueOf(Object)}
    * @return the non-null reference that was validated
    * @throws NullPointerException if {@code reference} is null
-   * @see Verify#verifyNotNull Verify.verifyNotNull()
    */
   public static <T> T checkNotNull(T reference, Object errorMessage) {
     if (reference == null) {
@@ -895,7 +893,6 @@ public final class Preconditions {
    *     are converted to strings using {@link String#valueOf(Object)}.
    * @return the non-null reference that was validated
    * @throws NullPointerException if {@code reference} is null
-   * @see Verify#verifyNotNull Verify.verifyNotNull()
    */
   public static <T> T checkNotNull(
       T reference, String errorMessageTemplate, Object... errorMessageArgs) {

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/DefaultTelemetry.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/DefaultTelemetry.java
@@ -83,13 +83,13 @@ public class DefaultTelemetry implements Telemetry {
   }
 
   /**
-   * Executes a given {@link Supplier<T>} and records the telemetry as {@link Operation}.
+   * Executes a given {@link Supplier} and records the telemetry as {@link Operation}.
    *
-   * @param <T> return type of the {@link Supplier<T>}.
+   * @param <T> return type of the {@link Supplier}.
    * @param level telemetry level.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode code to execute.
-   * @return the value that {@link Supplier<T>} returns.
+   * @return the value that {@link Supplier} returns.
    */
   @SneakyThrows
   public <T> T measure(
@@ -109,7 +109,7 @@ public class DefaultTelemetry implements Telemetry {
    * continuations, so any {@link Operation}s that are created in that context need to carry the
    * parenting chain.
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param level telemetry level.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
@@ -166,13 +166,13 @@ public class DefaultTelemetry implements Telemetry {
   }
 
   /**
-   * Executes a given {@link Supplier<T>} and records the telemetry as {@link Operation}.
+   * Executes a given {@link Supplier} and records the telemetry as {@link Operation}.
    *
    * @param level level of the operation to record this execution as.
    * @param operation operation to record this execution as.
    * @param operationCode code to execute.
-   * @param <T> return type of the {@link Supplier<T>}.
-   * @return the value that {@link Supplier<T>} returns.
+   * @param <T> return type of the {@link Supplier}.
+   * @return the value that {@link Supplier} returns.
    */
   @SneakyThrows
   private <T> T measureImpl(
@@ -192,7 +192,7 @@ public class DefaultTelemetry implements Telemetry {
   }
 
   /**
-   * Executes a given {@link Supplier<T>} and records the telemetry conditionally when the predicate
+   * Executes a given {@link Supplier} and records the telemetry conditionally when the predicate
    * evaluates to true.
    *
    * @param <T> the return type of the enclosed computation
@@ -201,7 +201,7 @@ public class DefaultTelemetry implements Telemetry {
    * @param operationCode code to execute.
    * @param shouldMeasure predicate to test with and decide whether the operation should be
    *     recorded.
-   * @return the value that {@link Supplier<T>} returns.
+   * @return the value that {@link Supplier} returns.
    */
   @SneakyThrows
   private <T> T measureConditionallyImpl(
@@ -237,7 +237,7 @@ public class DefaultTelemetry implements Telemetry {
    * @param level level of the operation to record this execution as.
    * @param operation operation to record this execution as.
    * @param operationCode the future to measure the execution of.
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @return an instance of {@link CompletableFuture} that returns the same result as the one passed
    *     in.
    */
@@ -276,7 +276,7 @@ public class DefaultTelemetry implements Telemetry {
    * recorded if the future was not completed, which is checked via {@link
    * CompletableFuture#isDone()}
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param level telemetry level.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/Telemetry.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/Telemetry.java
@@ -38,13 +38,13 @@ public interface Telemetry extends Closeable {
       @NonNull TelemetryAction operationCode);
 
   /**
-   * Measures a given {@link Supplier <T>} and record the telemetry as {@link Operation}.
+   * Measures a given {@link Supplier} and record the telemetry as {@link Operation}.
    *
-   * @param <T> return type of the {@link Supplier<T>}.
+   * @param <T> return type of the {@link Supplier}.
    * @param level telemetry level.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode code to execute.
-   * @return the value that {@link Supplier<T>} returns.
+   * @return the value that {@link Supplier} returns.
    */
   <T> T measure(
       @NonNull TelemetryLevel level,
@@ -57,7 +57,7 @@ public interface Telemetry extends Closeable {
    * continuations, so any {@link Operation}s that are created in that context need to carry the
    * parenting chain.
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param level telemetry level.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
@@ -77,7 +77,7 @@ public interface Telemetry extends Closeable {
    * recorded if the future was not completed, which is checked via {@link
    * CompletableFuture#isDone()}
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param level telemetry level.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
@@ -110,13 +110,13 @@ public interface Telemetry extends Closeable {
   }
 
   /**
-   * Measures a given {@link Supplier <T>} and record the telemetry as {@link Operation}. This is
-   * done at {@link TelemetryLevel#CRITICAL}.
+   * Measures a given {@link Supplier} and record the telemetry as {@link Operation}. This is done
+   * at {@link TelemetryLevel#CRITICAL}.
    *
-   * @param <T> return type of the {@link Supplier<T>}.
+   * @param <T> return type of the {@link Supplier}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode code to execute.
-   * @return the value that {@link Supplier<T>} returns.
+   * @return the value that {@link Supplier} returns.
    */
   default <T> T measureCritical(
       OperationSupplier operationSupplier, TelemetrySupplier<T> operationCode) {
@@ -129,7 +129,7 @@ public interface Telemetry extends Closeable {
    * continuations, so any {@link Operation}s that are created in that context need to carry the
    * parenting chain. This is done at {@link TelemetryLevel#CRITICAL}.
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link CompletableFuture} that returns the same result as the one passed
@@ -148,7 +148,7 @@ public interface Telemetry extends Closeable {
    * recorded if the future was not completed, which is checked via {@link
    * CompletableFuture#isDone()}. This is done at {@link TelemetryLevel#CRITICAL}.
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @param operationTimeout Timeout duration (in milliseconds) for operation
@@ -175,13 +175,13 @@ public interface Telemetry extends Closeable {
   }
 
   /**
-   * Measures a given {@link Supplier <T>} and record the telemetry as {@link Operation}. This is
-   * done at {@link TelemetryLevel#STANDARD}.
+   * Measures a given {@link Supplier} and record the telemetry as {@link Operation}. This is done
+   * at {@link TelemetryLevel#STANDARD}.
    *
-   * @param <T> return type of the {@link Supplier<T>}.
+   * @param <T> return type of the {@link Supplier}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode code to execute.
-   * @return the value that {@link Supplier<T>} returns.
+   * @return the value that {@link Supplier} returns.
    */
   default <T> T measureStandard(
       OperationSupplier operationSupplier, TelemetrySupplier<T> operationCode) {
@@ -194,7 +194,7 @@ public interface Telemetry extends Closeable {
    * continuations, so any {@link Operation}s that are created in that context need to carry the
    * parenting chain. This is done at {@link TelemetryLevel#STANDARD}.
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link CompletableFuture} that returns the same result as the one passed
@@ -213,7 +213,7 @@ public interface Telemetry extends Closeable {
    * recorded if the future was not completed, which is checked via {@link
    * CompletableFuture#isDone()}. This is done at {@link TelemetryLevel#STANDARD}.
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @param operationTimeout Timeout duration (in milliseconds) for operation
@@ -240,13 +240,13 @@ public interface Telemetry extends Closeable {
   }
 
   /**
-   * Measures a given {@link Supplier <T>} and record the telemetry as {@link Operation}. This is
-   * done at {@link TelemetryLevel#VERBOSE}.
+   * Measures a given {@link Supplier} and record the telemetry as {@link Operation}. This is done
+   * at {@link TelemetryLevel#VERBOSE}.
    *
-   * @param <T> return type of the {@link Supplier<T>}.
+   * @param <T> return type of the {@link Supplier}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode code to execute.
-   * @return the value that {@link Supplier<T>} returns.
+   * @return the value that {@link Supplier} returns.
    */
   default <T> T measureVerbose(
       OperationSupplier operationSupplier, TelemetrySupplier<T> operationCode) {
@@ -259,7 +259,7 @@ public interface Telemetry extends Closeable {
    * continuations, so any {@link Operation}s that are created in that context need to carry the
    * parenting chain. This is done at {@link TelemetryLevel#VERBOSE}.
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link CompletableFuture} that returns the same result as the one passed
@@ -278,7 +278,7 @@ public interface Telemetry extends Closeable {
    * recorded if the future was not completed, which is checked via {@link
    * CompletableFuture#isDone()}. This is done at {@link TelemetryLevel#VERBOSE}.
    *
-   * @param <T> - return type of the {@link CompletableFuture<T>}.
+   * @param <T> - return type of the {@link CompletableFuture}.
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @param operationTimeout Timeout duration (in milliseconds) for operation

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectClient.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectClient.java
@@ -25,7 +25,7 @@ public interface ObjectClient extends Closeable {
    * Make a headObject request to the object store.
    *
    * @param headRequest The HEAD request to be sent
-   * @return HeadObjectResponse
+   * @return an instance of {@link CompletableFuture} of type {@link ObjectMetadata}
    */
   CompletableFuture<ObjectMetadata> headObject(HeadRequest headRequest);
 
@@ -33,7 +33,7 @@ public interface ObjectClient extends Closeable {
    * Make a getObject request to the object store.
    *
    * @param getRequest The GET request to be sent
-   * @return ResponseInputStream<GetObjectResponse>
+   * @return an instance of {@link CompletableFuture} of type {@link ObjectContent}
    */
   CompletableFuture<ObjectContent> getObject(GetRequest getRequest);
 
@@ -42,7 +42,7 @@ public interface ObjectClient extends Closeable {
    *
    * @param getRequest The GET request to be sent
    * @param streamContext audit headers to be attached in the request header
-   * @return ResponseInputStream<GetObjectResponse>
+   * @return an instance of {@link CompletableFuture} of type {@link ObjectContent}
    */
   CompletableFuture<ObjectContent> getObject(GetRequest getRequest, StreamContext streamContext);
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/ObjectMetadata.java
@@ -24,8 +24,22 @@ import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 @Data
 @Builder
 public class ObjectMetadata {
+  /**
+   * The length of the object content in bytes. This value must be non-negative.
+   *
+   * @param contentLength the content length to set
+   * @return the builder instance
+   * @throws IllegalArgumentException if contentLength is negative
+   */
   long contentLength;
 
+  /**
+   * The entity tag of the object.
+   *
+   * @param etag the etag to set
+   * @return the builder instance
+   * @throws NullPointerException if etag is null
+   */
   @NonNull String etag;
 
   @Builder

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/InputPolicy.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/InputPolicy.java
@@ -16,15 +16,15 @@
 package software.amazon.s3.analyticsaccelerator.util;
 
 /**
- * Input policy to be used when reading a file. Useful for integrating applications to pass down a
- * policy they would like AAL to use, rather than us guessing based on file format.
+ * Input policy to be used when reading an object. Useful for integrating applications to pass down
+ * a policy they would like AAL to use, rather than us guessing based on object key extension.
  *
- * <p>A sequential policy means that the file will be read sequentially, regardless of the file
- * format. Useful for sequential data types such as CSV, or for applications that read columnar
- * formats sequentially.
+ * <p>A sequential policy means that the object will be read sequentially, regardless of the format.
+ * Useful for sequential data types such as CSV, or for applications that read columnar formats
+ * sequentially.
  *
- * <p>When no input policy is supplied, AAL will infer what optimisations to use based on the file
- * extension.
+ * <p>When no input policy is supplied, AAL will infer what optimisations to use based on the object
+ * key extension.
  */
 public enum InputPolicy {
   None,

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/OpenStreamInformation.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/OpenStreamInformation.java
@@ -15,21 +15,32 @@
  */
 package software.amazon.s3.analyticsaccelerator.util;
 
+import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Getter;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.StreamContext;
 
 /**
- * Open file information, useful for allowing the stream opening application to pass down known
- * information and callbacks when opening the file.
+ * Open stream information, useful for allowing the stream opening application to pass down known
+ * information and callbacks when opening the stream. @Value annotation makes this class immutable
+ * and automatically generates: - All-args constructor - Getters for all fields -
+ * equals/hashCode/toString methods
+ *
+ * <p>Available getters: - getStreamContext(): Returns the stream context - getObjectMetadata():
+ * Returns the object metadata - getInputPolicy(): Returns the input policy
+ *
+ * <p>Builder usage: OpenStreamInformation info = OpenStreamInformation.builder()
+ * .streamContext(context) .objectMetadata(metadata) .inputPolicy(policy) .build();
+ *
+ * <p>Or use the default instance: {@code OpenStreamInformation.DEFAULT}
  */
-@Value
-@Builder
+@Builder(access = AccessLevel.PUBLIC)
+@Getter
 public class OpenStreamInformation {
-  StreamContext streamContext;
-  ObjectMetadata objectMetadata;
-  InputPolicy inputPolicy;
+  private final StreamContext streamContext;
+  private final ObjectMetadata objectMetadata;
+  private final InputPolicy inputPolicy;
 
   /** Default set of settings for {@link OpenStreamInformation} */
   public static final OpenStreamInformation DEFAULT = OpenStreamInformation.builder().build();

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -285,10 +285,46 @@ tasks.register<Jar>("customJavadocJar") {
 
 
 tasks.javadoc {
+
+    // Include sources from subprojects
+    val includedProjects = listOf(":common", ":object-client")
+    includedProjects.forEach {projectPath ->
+        val subproject = project(projectPath)
+        source(subproject.sourceSets.main.get().allJava)
+        classpath += subproject.sourceSets.main.get().compileClasspath
+        classpath += subproject.sourceSets.main.get().output
+    }
+
+    // Include only specific classes from common module
+    include("**/ObjectMetadata.java")
+    include("**/ObjectContent.java")
+
+    include("**/ConnectorConfiguration.java")
+    include("**/S3URI.java")
+    include("**/OpenStreamInformation*")
+    include("**/InputPolicy.java")
+    include("**/StreamContext.java")
+
+
+
+    // Include only specific classes from object-client module
+    include("**/S3SdkObjectClient.java")
+
+
+    // Include only specific classes from input-stream module
+    include("**/S3SeekableInputStreamFactory.java")
+    include("**/S3SeekableInputStream.java")
+    include("**/S3SeekableInputStreamConfiguration.java")
+    include("**/S3SeekableInputStreamFactory.java")
+    include("**/PrefetchMode.java")
+
     options {
         (this as StandardJavadocDocletOptions).apply {
-            addStringOption("Xdoclint:none", "-quiet")}
+            addStringOption("Xdoclint:none", "-quiet")
+            addStringOption("encoding", "UTF-8")
+        }
     }
+
 }
 
 val signingEnabled = project.hasProperty("signingEnabled") && project.property("signingEnabled") == "true"

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/IntegrationTestBase.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/IntegrationTestBase.java
@@ -130,17 +130,13 @@ public abstract class IntegrationTestBase extends ExecutionBase {
       S3AsyncClient s3Client = this.getS3ExecutionContext().getS3Client();
       S3SeekableInputStream stream = s3AALClientStreamReader.createReadStream(s3Object);
 
-      int readAheadBytes =
-          (int)
-              AALInputStreamConfigurationKind.getValue()
-                  .getPhysicalIOConfiguration()
-                  .getReadAheadBytes();
+      int readAheadBytes = 100;
 
       // Read first 100 bytes
-      readAndAssert(stream, buffer, 0, 100);
+      readAndAssert(stream, buffer, 0, readAheadBytes);
 
       // Read next 100 bytes
-      readAndAssert(stream, buffer, 100, 100);
+      readAndAssert(stream, buffer, 100, readAheadBytes);
 
       // Change the file
       s3Client

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,13 +26,13 @@ import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
 
 /** Configuration for {@link S3SeekableInputStream} */
-@Getter
-@Builder
+@Getter(AccessLevel.PACKAGE)
+@Builder(access = AccessLevel.PACKAGE)
 @EqualsAndHashCode
 public class S3SeekableInputStreamConfiguration {
-  public static final String PHYSICAL_IO_PREFIX = "physicalio";
-  public static final String LOGICAL_IO_PREFIX = "logicalio";
-  public static final String TELEMETRY_PREFIX = "telemetry";
+  private static final String PHYSICAL_IO_PREFIX = "physicalio";
+  private static final String LOGICAL_IO_PREFIX = "logicalio";
+  private static final String TELEMETRY_PREFIX = "telemetry";
 
   @Builder.Default @NonNull private PhysicalIOConfiguration physicalIOConfiguration = PhysicalIOConfiguration.DEFAULT;
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -16,6 +16,7 @@
 package software.amazon.s3.analyticsaccelerator;
 
 import java.io.IOException;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
@@ -42,12 +43,10 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
  * {@link S3SeekableInputStreamFactory#createStream(S3URI)} to vend correct {@link
  * SeekableInputStream}.
  */
-@Getter
+@Getter(AccessLevel.PACKAGE)
 public class S3SeekableInputStreamFactory implements AutoCloseable {
-  private final ObjectClient objectClient;
   private final S3SeekableInputStreamConfiguration configuration;
   private final ParquetColumnPrefetchStore parquetColumnPrefetchStore;
-
   private final MetadataStore objectMetadataStore;
   private final BlobStore objectBlobStore;
   private final Telemetry telemetry;
@@ -64,7 +63,6 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
   public S3SeekableInputStreamFactory(
       @NonNull ObjectClient objectClient,
       @NonNull S3SeekableInputStreamConfiguration configuration) {
-    this.objectClient = objectClient;
     this.configuration = configuration;
     this.telemetry = Telemetry.createTelemetry(configuration.getTelemetryConfiguration());
     this.parquetColumnPrefetchStore =
@@ -87,7 +85,7 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
   }
 
   /**
-   * Create an instance of S3SeekableInputStream with provided metadata.
+   * This method is deprecated. Please use {@link #createStream(S3URI, OpenStreamInformation)}
    *
    * @param s3URI the object's S3 URI
    * @param metadata the metadata for the object

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamConfigurationTest.java
@@ -32,7 +32,10 @@ import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfigurati
     value = "NP_NONNULL_PARAM_VIOLATION",
     justification = "We mean to pass nulls to checks")
 public class S3SeekableInputStreamConfigurationTest {
-  private static final String TEST_PREFIX = "s3.connector";
+  public static final String TEST_PREFIX = "s3.connector";
+  public static final String LOGICAL_IO_PREFIX = "logicalio";
+  public static final String PHYSICAL_IO_PREFIX = "physicalio";
+  public static final String TELEMETRY_PREFIX = "telemetry";
 
   @Test
   void testDefaultBuilder() {

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactoryTest.java
@@ -62,7 +62,6 @@ public class S3SeekableInputStreamFactoryTest {
     assertEquals(
         S3SeekableInputStreamConfiguration.DEFAULT,
         s3SeekableInputStreamFactory.getConfiguration());
-    assertEquals(objectClient, s3SeekableInputStreamFactory.getObjectClient());
   }
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfigurationTest.java
@@ -16,9 +16,9 @@
 package software.amazon.s3.analyticsaccelerator.io.logical;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfigurationTest.LOGICAL_IO_PREFIX;
 
 import org.junit.jupiter.api.Test;
-import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfigurationTest;
 import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
 import software.amazon.s3.analyticsaccelerator.util.PrefetchMode;
@@ -46,8 +46,7 @@ public class LogicalIOConfigurationTest {
   void testFromConfiguration() {
     ConnectorConfiguration configuration =
         S3SeekableInputStreamConfigurationTest.getConfiguration();
-    ConnectorConfiguration mappedConfiguration =
-        configuration.map(S3SeekableInputStreamConfiguration.LOGICAL_IO_PREFIX);
+    ConnectorConfiguration mappedConfiguration = configuration.map(LOGICAL_IO_PREFIX);
     LogicalIOConfiguration logicalIOConfiguration =
         LogicalIOConfiguration.fromConfiguration(mappedConfiguration);
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
@@ -16,9 +16,9 @@
 package software.amazon.s3.analyticsaccelerator.io.physical;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfigurationTest.PHYSICAL_IO_PREFIX;
 
 import org.junit.jupiter.api.Test;
-import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfigurationTest;
 import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
 
@@ -42,8 +42,7 @@ public class PhysicalIOConfigurationTest {
   void testFromConfiguration() {
     ConnectorConfiguration configuration =
         S3SeekableInputStreamConfigurationTest.getConfiguration();
-    ConnectorConfiguration mappedConfiguration =
-        configuration.map(S3SeekableInputStreamConfiguration.PHYSICAL_IO_PREFIX);
+    ConnectorConfiguration mappedConfiguration = configuration.map(PHYSICAL_IO_PREFIX);
 
     PhysicalIOConfiguration physicalIOConfiguration =
         PhysicalIOConfiguration.fromConfiguration(mappedConfiguration);

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
@@ -52,7 +52,7 @@ public class S3SdkObjectClient implements ObjectClient {
    *
    * @param s3AsyncClient Underlying client to be used for making requests to S3.
    */
-  public S3SdkObjectClient(S3AsyncClient s3AsyncClient) {
+  public S3SdkObjectClient(@NonNull S3AsyncClient s3AsyncClient) {
     this(s3AsyncClient, ObjectClientConfiguration.DEFAULT);
   }
 
@@ -64,7 +64,7 @@ public class S3SdkObjectClient implements ObjectClient {
    * @param s3AsyncClient Underlying client to be used for making requests to S3.
    * @param closeAsyncClient if true, close the passed client on close.
    */
-  public S3SdkObjectClient(S3AsyncClient s3AsyncClient, boolean closeAsyncClient) {
+  public S3SdkObjectClient(@NonNull S3AsyncClient s3AsyncClient, boolean closeAsyncClient) {
     this(s3AsyncClient, ObjectClientConfiguration.DEFAULT, closeAsyncClient);
   }
 
@@ -76,7 +76,8 @@ public class S3SdkObjectClient implements ObjectClient {
    * @param objectClientConfiguration Configuration for object client.
    */
   public S3SdkObjectClient(
-      S3AsyncClient s3AsyncClient, ObjectClientConfiguration objectClientConfiguration) {
+      @NonNull S3AsyncClient s3AsyncClient,
+      @NonNull ObjectClientConfiguration objectClientConfiguration) {
     this(s3AsyncClient, objectClientConfiguration, true);
   }
 
@@ -107,12 +108,6 @@ public class S3SdkObjectClient implements ObjectClient {
     }
   }
 
-  /**
-   * Make a headObject request to the object store.
-   *
-   * @param headRequest The HEAD request to be sent
-   * @return HeadObjectResponse
-   */
   @Override
   public CompletableFuture<ObjectMetadata> headObject(HeadRequest headRequest) {
     HeadObjectRequest.Builder builder =
@@ -144,24 +139,11 @@ public class S3SdkObjectClient implements ObjectClient {
         .exceptionally(handleException(headRequest.getS3Uri()));
   }
 
-  /**
-   * Make a getObject request to the object store.
-   *
-   * @param getRequest The GET request to be sent
-   * @return ResponseInputStream<GetObjectResponse>
-   */
   @Override
   public CompletableFuture<ObjectContent> getObject(GetRequest getRequest) {
     return getObject(getRequest, null);
   }
 
-  /**
-   * Make a getObject request to the object store.
-   *
-   * @param getRequest The GET request to be sent
-   * @param streamContext audit headers to be attached in the request header
-   * @return ResponseInputStream<GetObjectResponse>
-   */
   @Override
   public CompletableFuture<ObjectContent> getObject(
       GetRequest getRequest, StreamContext streamContext) {


### PR DESCRIPTION
## Description of change
Fixing some issues with javadoc generation and restricting javadoc to only supported interface. 

#### Relevant issues
N/A

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
./gradlew clean build
./gradlew javadoc
./gradlew integrationTests

#### Does this contribution need a changelog entry?
- Yes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).