### PR TITLE
fix: Ensure proper project evaluation for javadoc task

### DIFF
--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -28,6 +28,9 @@ plugins {
     java
 }
 
+evaluationDependsOn(":common")
+evaluationDependsOn(":object-client")
+
 licenseReport {
     renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html", "Backend"), TextReportRenderer())
 }
@@ -288,7 +291,7 @@ tasks.javadoc {
 
     // Include sources from subprojects
     val includedProjects = listOf(":common", ":object-client")
-    includedProjects.forEach {projectPath ->
+    includedProjects.forEach { projectPath ->
         val subproject = project(projectPath)
         source(subproject.sourceSets.main.get().allJava)
         classpath += subproject.sourceSets.main.get().compileClasspath


### PR DESCRIPTION
## Description of change
This makes sure build does not fail even when the signing is enabled.

#### Relevant issues
NA

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
`./gradlew clean build`

#### Does this contribution need a changelog entry?
No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).