### PR TITLE
Reduced default block read timeout to 30 seconds

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -39,7 +39,7 @@ public class PhysicalIOConfiguration {
   private static final long DEFAULT_PART_SIZE = 8 * ONE_MB;
   private static final double DEFAULT_SEQUENTIAL_PREFETCH_BASE = 2.0;
   private static final double DEFAULT_SEQUENTIAL_PREFETCH_SPEED = 1.0;
-  private static final long DEFAULT_BLOCK_READ_TIMEOUT = 120_000;
+  private static final long DEFAULT_BLOCK_READ_TIMEOUT = 30_000;
   private static final int DEFAULT_BLOCK_READ_RETRY_COUNT = 20;
 
   /** Capacity, in blobs. {@link PhysicalIOConfiguration#DEFAULT_CAPACITY_BLOB_STORE} by default. */

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
@@ -71,7 +71,7 @@ public class PhysicalIOConfigurationTest {
             + "\tpartSizeBytes: 20\n"
             + "\tsequentialPrefetchBase: 2.0\n"
             + "\tsequentialPrefetchSpeed: 1.0\n"
-            + "\tblockReadTimeout: 120000\n"
+            + "\tblockReadTimeout: 30000\n"
             + "\tblockReadRetryCount: 20\n");
   }
 }


### PR DESCRIPTION
## Description of change
Defult timeout reduced from 120 to 30 seconds. 

#### Relevant issues
https://github.com/awslabs/analytics-accelerator-s3/pull/231

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Executed unit tests

#### Does this contribution need a changelog entry?
N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).