### PR TITLE
fix: setting log path for telemetry

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/LoggingTelemetryReporter.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/LoggingTelemetryReporter.java
@@ -39,7 +39,7 @@ class LoggingTelemetryReporter implements TelemetryReporter {
   public static Level DEFAULT_LOGGING_LEVEL = Level.DEBUG;
 
   /** Default logger name */
-  public static String DEFAULT_LOGGING_NAME = "com.amazon.connector.s3.telemetry";
+  public static String DEFAULT_LOGGING_NAME = "software.amazon.s3.analyticsaccelerator.telemetry";
 
   /** Creates a new instance of {@link LoggingTelemetryReporter} with sensible defaults. */
   public LoggingTelemetryReporter() {

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -72,16 +72,16 @@ Options under `<CONNECTOR_PREFIX>.physicalio.`
 ## Telemetry Configuration
 Options under `<CONNECTOR_PREFIX>.telemetry.`
 
-| Option                                | Default                             | Description                                                              |
-|---------------------------------------|-------------------------------------|--------------------------------------------------------------------------|
-| `level`                               | `STANDARD`                          | Telemetry detail level (valid values: `CRITICAL`, `STANDARD`, `VERBOSE`) |
-| `std.out.enabled`                     | `false`                             | Enable stdout telemetry output                                           |
-| `logging.enabled`                     | `true`                              | Enable logging telemetry output                                          |
-| `aggregations.enabled`                | `false`                             | Enable telemetry aggregations                                            |
-| `aggregations.flush.interval.seconds` | `-1`                                | Interval to flush aggregated telemetry                                   |
-| `logging.level`                       | `INFO`                              | Log level for telemetry                                                  |
-| `logging.name`                        | `com.amazon.connector.s3.telemetry` | Logger name for telemetry                                                |
-| `format`                              | `default`                           | Telemetry output format (valid values: `json`, `default`)                |
+| Option                                | Default                                             | Description                                                              |
+|---------------------------------------|-----------------------------------------------------|--------------------------------------------------------------------------|
+| `level`                               | `STANDARD`                                          | Telemetry detail level (valid values: `CRITICAL`, `STANDARD`, `VERBOSE`) |
+| `std.out.enabled`                     | `false`                                             | Enable stdout telemetry output                                           |
+| `logging.enabled`                     | `true`                                              | Enable logging telemetry output                                          |
+| `aggregations.enabled`                | `false`                                             | Enable telemetry aggregations                                            |
+| `aggregations.flush.interval.seconds` | `-1`                                                | Interval to flush aggregated telemetry                                   |
+| `logging.level`                       | `DEBUG`                                             | Log level for telemetry                                                  |
+| `logging.name`                        | `software.amazon.s3.analyticsaccelerator.telemetry` | Logger name for telemetry                                                |
+| `format`                              | `default`                                           | Telemetry output format (valid values: `json`, `default`)                |
 
 ## Object Client Configuration
 Options under `<CONNECTOR_PREFIX>.`


### PR DESCRIPTION
## Description of change
We updated our path to software.amazon.s3.analyticsaccelerator and we need to do this for telemetry so our log settings are shared for our log names.
For example without this you would need to do the following:

```
echo "logger.aal.name = software.amazon.s3.analyticsaccelerator
logger.aal.level = debug" >> /home/ec2-user/spark/conf/log4j2.properties
echo "logger.telemetry.name = com.amazon.connector.s3
logger.telemetry.level = debug" >> /home/ec2-user/spark/conf/log4j2.properties
```

now you can just do 
```
echo "logger.aal.name = software.amazon.s3.analyticsaccelerator
logger.aal.level = debug" >> /home/ec2-user/spark/conf/log4j2.properties
```

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
With custom runs

#### Does this contribution need a changelog entry?
- [x] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).