### PR TITLE
[Fix]:Failing  ref tests

### DIFF
--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -148,6 +148,8 @@ val shadowJar = tasks.withType<ShadowJar> {
 }
 
 val refTest = task<Test>("referenceTest") {
+    maxHeapSize = "2g"
+    jvmArgs = listOf("-Xms1g", "-Xmx2g")
     description = "Runs reference tests."
     group = "verification"
 


### PR DESCRIPTION
## Description of change
Fixing reference tests failing intermittently in AAL

#### Root Cause:
Tests generate random data between 0-16MB and run 1000 times. When stream/buffer sizes repeatedly hit upper range (close to 16MB), combined with string conversions and multiple copies of data in memory, we encounter Java Heap OutOfMemoryError. Tests fails intermittently and pass on rerun because random size generation might not hit the problematic range consecutively.
<!-- Thank you for submitting a pull request!-->
<!-- Please describe your contribution here. What and why? -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

#### Relevant issues
https://github.com/awslabs/analytics-accelerator-s3/issues/162
<!-- Please add issue numbers. -->
<!-- Please also link them to this PR. -->

#### How was the contribution tested?
Tests were configured to run with maximum allowed stream size (16MB) and buffer size (16MB) instead of random sizes to validate the implementation under worst-case scenarios. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).