### PR TITLE
Reduce waiting time and retry on GrayTest. Eliminate redundant block …

### DIFF
--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/GrayFailureTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/GrayFailureTest.java
@@ -16,6 +16,8 @@
 package software.amazon.s3.analyticsaccelerator.access;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -61,7 +63,7 @@ public class GrayFailureTest extends IntegrationTestBase {
         S3ClientKind.faultyClients(),
         S3Object.smallObjects(),
         sequentialPatterns(),
-        getS3SeekableInputStreamConfigurations());
+        grayFailureConfigurationKind());
   }
 
   static Stream<Arguments> skippingReads() {
@@ -69,7 +71,7 @@ public class GrayFailureTest extends IntegrationTestBase {
         S3ClientKind.faultyClients(),
         S3Object.smallObjects(),
         skippingPatterns(),
-        getS3SeekableInputStreamConfigurations());
+        grayFailureConfigurationKind());
   }
 
   static Stream<Arguments> parquetReads() {
@@ -77,6 +79,10 @@ public class GrayFailureTest extends IntegrationTestBase {
         S3ClientKind.faultyClients(),
         S3Object.smallObjects(),
         parquetPatterns(),
-        getS3SeekableInputStreamConfigurations());
+        grayFailureConfigurationKind());
+  }
+
+  private static List<AALInputStreamConfigurationKind> grayFailureConfigurationKind() {
+    return Arrays.asList(AALInputStreamConfigurationKind.GRAY_FAILURE);
   }
 }

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/IntegrationTestBase.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/IntegrationTestBase.java
@@ -367,7 +367,7 @@ public abstract class IntegrationTestBase extends ExecutionBase {
    * @return configuration kind
    */
   static List<AALInputStreamConfigurationKind> getS3SeekableInputStreamConfigurations() {
-    return Arrays.asList(AALInputStreamConfigurationKind.values());
+    return Arrays.asList(AALInputStreamConfigurationKind.DEFAULT);
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStore.java
@@ -95,9 +95,9 @@ public class BlockStore implements Closeable {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
 
     long nextMissingByte = pos;
-
-    while (getBlock(nextMissingByte).isPresent()) {
-      nextMissingByte = getBlock(nextMissingByte).get().getEnd() + 1;
+    Optional<Block> nextBlock;
+    while ((nextBlock = getBlock(nextMissingByte)).isPresent()) {
+      nextMissingByte = nextBlock.get().getEnd() + 1;
     }
 
     return nextMissingByte <= getLastObjectByte()

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/AALInputStreamConfigurationKind.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/AALInputStreamConfigurationKind.java
@@ -15,13 +15,12 @@
  */
 package software.amazon.s3.analyticsaccelerator.access;
 
+import java.util.HashMap;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
 import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /** Enum representing meaningful configuration samples for {@link S3ExecutionConfiguration} */
 @AllArgsConstructor
@@ -38,8 +37,8 @@ public enum AALInputStreamConfigurationKind {
     Map<String, String> customConfiguration = new HashMap<>();
     customConfiguration.put(configurationPrefix + ".physicalio.blockreadtimeout", "10000");
     customConfiguration.put(configurationPrefix + ".physicalio.blockreadretrycount", "2");
-    ConnectorConfiguration config = new ConnectorConfiguration(customConfiguration, configurationPrefix);
+    ConnectorConfiguration config =
+        new ConnectorConfiguration(customConfiguration, configurationPrefix);
     return S3SeekableInputStreamConfiguration.fromConfiguration(config);
   }
-
 }

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/AALInputStreamConfigurationKind.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/AALInputStreamConfigurationKind.java
@@ -18,13 +18,28 @@ package software.amazon.s3.analyticsaccelerator.access;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
+import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /** Enum representing meaningful configuration samples for {@link S3ExecutionConfiguration} */
 @AllArgsConstructor
 @Getter
 public enum AALInputStreamConfigurationKind {
-  DEFAULT("DEFAULT", S3SeekableInputStreamConfiguration.DEFAULT);
+  DEFAULT("DEFAULT", S3SeekableInputStreamConfiguration.DEFAULT),
+  GRAY_FAILURE("GRAY_FAILURE", grayFailureConfiguration());
 
   private final String name;
   private final S3SeekableInputStreamConfiguration value;
+
+  private static S3SeekableInputStreamConfiguration grayFailureConfiguration() {
+    String configurationPrefix = "grayfailure";
+    Map<String, String> customConfiguration = new HashMap<>();
+    customConfiguration.put(configurationPrefix + ".physicalio.blockreadtimeout", "10000");
+    customConfiguration.put(configurationPrefix + ".physicalio.blockreadretrycount", "2");
+    ConnectorConfiguration config = new ConnectorConfiguration(customConfiguration, configurationPrefix);
+    return S3SeekableInputStreamConfiguration.fromConfiguration(config);
+  }
+
 }


### PR DESCRIPTION

## Description of change
This PR reduce the timeout time on Gray Failure tests and eliminate one redundant linear search on BlockStore. 

With this PR we will reduce integration test running time to one third. 

#### Relevant issues
None. 

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No. This is only changing integration test behaviour and eliminating one method call. 

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Run Integration Tests

#### Does this contribution need a changelog entry?
NA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).