### PR TITLE
Configurable LogicalIO

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfiguration.java
@@ -32,6 +32,7 @@ import software.amazon.s3.analyticsaccelerator.util.PrefetchMode;
 public class LogicalIOConfiguration {
   private static final boolean DEFAULT_PREFETCH_FOOTER_ENABLED = true;
   private static final boolean DEFAULT_PREFETCH_PAGE_INDEX_ENABLED = true;
+  private static final boolean DEFAULT_USE_FORMAT_SPECIFIC_IO = true;
   private static final long DEFAULT_PREFETCH_FILE_METADATA_SIZE = 32 * ONE_KB;
   private static final long DEFAULT_PREFETCH_LARGE_FILE_METADATA_SIZE = ONE_MB;
   private static final long DEFAULT_PREFETCH_FILE_PAGE_INDEX_SIZE = ONE_MB;
@@ -56,6 +57,10 @@ public class LogicalIOConfiguration {
   @Builder.Default private boolean prefetchPageIndexEnabled = DEFAULT_PREFETCH_PAGE_INDEX_ENABLED;
 
   private static final String PAGE_INDEX_PREFETCH_ENABLED_KEY = "prefetch.page.index.enabled";
+
+  @Builder.Default private boolean useFormatSpecificIO = DEFAULT_USE_FORMAT_SPECIFIC_IO;
+
+  private static final String USE_FORMAT_SPECIFIC_IO_KEY = "use.format.specific.io";
 
   @Builder.Default private long prefetchFileMetadataSize = DEFAULT_PREFETCH_FILE_METADATA_SIZE;
 
@@ -137,6 +142,8 @@ public class LogicalIOConfiguration {
         .prefetchPageIndexEnabled(
             configuration.getBoolean(
                 PAGE_INDEX_PREFETCH_ENABLED_KEY, DEFAULT_PREFETCH_PAGE_INDEX_ENABLED))
+        .useFormatSpecificIO(
+            configuration.getBoolean(USE_FORMAT_SPECIFIC_IO_KEY, DEFAULT_USE_FORMAT_SPECIFIC_IO))
         .prefetchFileMetadataSize(
             configuration.getLong(
                 PREFETCH_FILE_METADATA_SIZE_KEY, DEFAULT_PREFETCH_FILE_METADATA_SIZE))
@@ -186,6 +193,7 @@ public class LogicalIOConfiguration {
     builder.append("LogicalIO configuration:\n");
     builder.append("\tprefetchFooterEnabled: " + prefetchFooterEnabled + "\n");
     builder.append("\tprefetchPageIndexEnabled: " + prefetchPageIndexEnabled + "\n");
+    builder.append("\tuseFormatSpecificIO: " + useFormatSpecificIO + "\n");
     builder.append("\tprefetchFileMetadataSize: " + prefetchFileMetadataSize + "\n");
     builder.append("\tprefetchLargeFileMetadataSize: " + prefetchLargeFileMetadataSize + "\n");
     builder.append("\tprefetchFilePageIndexSize: " + prefetchFilePageIndexSize + "\n");

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelector.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelector.java
@@ -25,6 +25,7 @@ public class ObjectFormatSelector {
   private final Pattern csvPattern;
   private final Pattern jsonPattern;
   private final Pattern txtPattern;
+  private final boolean useFormatSpecificIO;
 
   /**
    * Creates a new instance of {@ObjectFormatSelector}. Used to select the file format of a
@@ -41,6 +42,7 @@ public class ObjectFormatSelector {
         Pattern.compile(configuration.getJsonFormatSelectorRegex(), Pattern.CASE_INSENSITIVE);
     this.txtPattern =
         Pattern.compile(configuration.getTxtFormatSelectorRegex(), Pattern.CASE_INSENSITIVE);
+    this.useFormatSpecificIO = configuration.isUseFormatSpecificIO();
   }
 
   /**
@@ -51,6 +53,10 @@ public class ObjectFormatSelector {
    * @return the file format of the object
    */
   public ObjectFormat getObjectFormat(S3URI s3URI, OpenStreamInformation openStreamInformation) {
+    // If format-specific IO is disabled, always return DEFAULT regardless of file format
+    if (!useFormatSpecificIO) {
+      return ObjectFormat.DEFAULT;
+    }
 
     // If the supplied policy in open stream information is Sequential, then use the default input
     // stream, regardless of the file format (even if it's parquet!). This is important for

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/LogicalIOConfigurationTest.java
@@ -72,6 +72,7 @@ public class LogicalIOConfigurationTest {
         "LogicalIO configuration:\n"
             + "\tprefetchFooterEnabled: true\n"
             + "\tprefetchPageIndexEnabled: true\n"
+            + "\tuseFormatSpecificIO: true\n"
             + "\tprefetchFileMetadataSize: 32768\n"
             + "\tprefetchLargeFileMetadataSize: 1048576\n"
             + "\tprefetchFilePageIndexSize: 10\n"

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelectorTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/util/ObjectFormatSelectorTest.java
@@ -97,4 +97,20 @@ public class ObjectFormatSelectorTest {
         objectFormatSelector.getObjectFormat(
             S3URI.of("bucket", key), OpenStreamInformation.DEFAULT));
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"key.parquet", "key.csv", "key.json", "key.txt"})
+  public void testAllFormatsReturnDefaultWhenFormatSpecificIODisabled(String key) {
+    // Create configuration with useFormatSpecificIO set to false
+    LogicalIOConfiguration config =
+        LogicalIOConfiguration.builder().useFormatSpecificIO(false).build();
+
+    ObjectFormatSelector objectFormatSelector = new ObjectFormatSelector(config);
+
+    assertEquals(
+        ObjectFormat.DEFAULT,
+        objectFormatSelector.getObjectFormat(
+            S3URI.of("bucket", key), OpenStreamInformation.DEFAULT),
+        "All formats should return DEFAULT when format-specific IO is disabled");
+  }
 }


### PR DESCRIPTION
## Description of change
Added configurable LogicalIO selection to allow forcing DefaultLogicalIO usage regardless of file format
<!-- Thank you for submitting a pull request!-->
<!-- Please describe your contribution here. What and why? -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->

<!-- Please add issue numbers. -->
<!-- Please also link them to this PR. -->

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No breaking changes. The default value of `useFormatSpecificIO` is set to `true`, maintaining the existing behaviour where LogicalIO implementation is selected based on file format.


#### Does this contribution introduce any new public APIs or behaviors?
<!-- Please describe them and explain what scenarios they target.  -->
- Added new configuration option `useFormatSpecificIO` to LogicalIOConfiguration
- When set to `false`, always uses DefaultLogicalIO regardless of file format
- When set to `true` (default), maintains existing format-based selection behavior

#### How was the contribution tested?
<!-- Please describe how this contribution was tested. -->
- Added parameterised test in ObjectFormatSelectorTest to verify that when `useFormatSpecificIO` is false, DefaultLogicalIO is used for all file formats (parquet, csv, json, txt)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).