### PR TITLE
ElastiCache cache for parquet metadata

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapoint.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapoint.java
@@ -117,9 +117,7 @@ public abstract class TelemetryDatapoint {
       return buildCore();
     }
 
-    /**
-     * @return new instance of whatever this builder builds
-     */
+    /** @return new instance of whatever this builder builds */
     protected abstract T buildCore();
   }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapoint.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapoint.java
@@ -117,7 +117,9 @@ public abstract class TelemetryDatapoint {
       return buildCore();
     }
 
-    /** @return new instance of whatever this builder builds */
+    /**
+     * @return new instance of whatever this builder builds
+     */
     protected abstract T buildCore();
   }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapointMeasurement.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapointMeasurement.java
@@ -100,7 +100,9 @@ public abstract class TelemetryDatapointMeasurement {
       return buildCore();
     }
 
-    /** @return new instance of whatever this builder builds */
+    /**
+     * @return new instance of whatever this builder builds
+     */
     protected abstract T buildCore();
   }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapointMeasurement.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapointMeasurement.java
@@ -100,9 +100,7 @@ public abstract class TelemetryDatapointMeasurement {
       return buildCore();
     }
 
-    /**
-     * @return new instance of whatever this builder builds
-     */
+    /** @return new instance of whatever this builder builds */
     protected abstract T buildCore();
   }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/Range.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/Range.java
@@ -17,6 +17,7 @@ package software.amazon.s3.analyticsaccelerator.request;
 
 import lombok.Value;
 import software.amazon.s3.analyticsaccelerator.common.Preconditions;
+import software.amazon.s3.analyticsaccelerator.util.RangeType;
 
 /**
  * Object representing a byte range. This class helps us abstract away from S3 SDK constructs and
@@ -27,6 +28,7 @@ import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 public class Range {
   long start;
   long end;
+  RangeType rangeType;
 
   private static final String TO_HTTP_STRING_FORMAT = "bytes=%d-%d";
   private static final String TO_STRING_FORMAT = "%d-%d";
@@ -44,6 +46,25 @@ public class Range {
 
     this.start = start;
     this.end = end;
+    this.rangeType = RangeType.Block;
+  }
+
+  /**
+   * Construct a range. At least one of the start and end of range should be present. Also provides
+   * option to specify RangeType.
+   *
+   * @param start the start of the range, possibly empty
+   * @param end the end of the range, possibly empty
+   * @param rangeType the section of the parquet file the range refers to.
+   */
+  public Range(long start, long end, RangeType rangeType) {
+    Preconditions.checkArgument(start >= 0, "`start` must not be negative");
+    Preconditions.checkArgument(end >= 0, "`end` must not be negative");
+    Preconditions.checkArgument(start <= end, "`start` must be less than equal to `end`");
+
+    this.start = start;
+    this.end = end;
+    this.rangeType = rangeType;
   }
 
   /**

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/Range.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/Range.java
@@ -46,7 +46,7 @@ public class Range {
 
     this.start = start;
     this.end = end;
-    this.rangeType = RangeType.Block;
+    this.rangeType = RangeType.BLOCK;
   }
 
   /**

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/RangeType.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/RangeType.java
@@ -16,6 +16,7 @@
 package software.amazon.s3.analyticsaccelerator.util;
 
 public enum RangeType {
-  Block,
-  Footer
+  BLOCK,
+  FOOTER_METADATA,
+  FOOTER_PAGE_INDEX
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/RangeType.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/RangeType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.util;
+
+public enum RangeType {
+  Block,
+  Footer
+}

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/RangeType.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/RangeType.java
@@ -15,6 +15,11 @@
  */
 package software.amazon.s3.analyticsaccelerator.util;
 
+/**
+ * Enum to annotate the section of the parquet file the range is associated with. This is primarily
+ * to be used in Block to determine whether the block in question corresponds to tail metadata for
+ * caching purposes.
+ */
 public enum RangeType {
   BLOCK,
   FOOTER_METADATA,

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     implementation(project(":common"))
     implementation(libs.parquet.format)
     implementation(libs.slf4j.api)
+    implementation("io.valkey:valkey-java:5.3.0")
 
     jmhImplementation(libs.s3)
     jmhImplementation(libs.s3.transfer.manager)
@@ -148,8 +149,6 @@ val shadowJar = tasks.withType<ShadowJar> {
 }
 
 val refTest = task<Test>("referenceTest") {
-    maxHeapSize = "2g"
-    jvmArgs = listOf("-Xms1g", "-Xmx2g")
     description = "Runs reference tests."
     group = "verification"
 
@@ -375,10 +374,10 @@ publishing {
         maven {
             name = "sonatype"
             url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
-           credentials {
-               username = findProperty("mavenUsername") as String? ?: ""
-               password = findProperty("mavenPassword") as String? ?: ""
-           }
+            credentials {
+                username = findProperty("mavenUsername") as String? ?: ""
+                password = findProperty("mavenPassword") as String? ?: ""
+            }
         }
     }
 }

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -10,7 +10,7 @@ import com.github.jk1.license.render.TextReportRenderer
 
 val group = "software.amazon.s3.analyticsaccelerator"
 val artefact = "analyticsaccelerator-s3"
-val currentVersionNumber = "1.0.0"
+val currentVersionNumber = "2.0.0"
 
 val isSnapshot = findProperty("snapshotBuild") == "true"
 val currentVersion = if (isSnapshot) "SNAPSHOT" else currentVersionNumber;

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -10,7 +10,7 @@ import com.github.jk1.license.render.TextReportRenderer
 
 val group = "software.amazon.s3.analyticsaccelerator"
 val artefact = "analyticsaccelerator-s3"
-val currentVersionNumber = "2.0.0"
+val currentVersionNumber = "1.0.0"
 
 val isSnapshot = findProperty("snapshotBuild") == "true"
 val currentVersion = if (isSnapshot) "SNAPSHOT" else currentVersionNumber;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -193,8 +193,8 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
     this.objectMetadataStore.close();
     this.objectBlobStore.close();
     this.telemetry.close();
-    if (cache instanceof ValkeyCacheImpl) {
-      ((ValkeyCacheImpl) cache).close();
+    if (cache != null) {
+      cache.close();
     }
   }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -71,7 +71,6 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
   public S3SeekableInputStreamFactory(
           @NonNull ObjectClient objectClient,
           @NonNull S3SeekableInputStreamConfiguration configuration) {
-    LOG.debug("Initializing S3SeekableInputStreamFactory with configuration: {}", configuration);
     this.configuration = configuration;
     this.telemetry = Telemetry.createTelemetry(configuration.getTelemetryConfiguration());
     this.parquetColumnPrefetchStore =
@@ -93,9 +92,6 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
     this.objectBlobStore =
             new BlobStore(objectClient, telemetry, configuration.getPhysicalIOConfiguration(), cache);
 
-    LOG.info("____________________________________________");
-    LOG.info("Modified version successfully loaded (metadata caching)!");
-    LOG.info("____________________________________________");
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -18,7 +18,6 @@ package software.amazon.s3.analyticsaccelerator;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
@@ -89,7 +88,8 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
 
       LOG.info("Cache successfully instantiated");
 
-      this.executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 10);
+      this.executorService =
+          Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 10);
 
     } else {
       LOG.info("Cache disabled");
@@ -98,7 +98,12 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
       this.executorService = null;
     }
     this.objectBlobStore =
-        new BlobStore(objectClient, telemetry, configuration.getPhysicalIOConfiguration(), cache, executorService);
+        new BlobStore(
+            objectClient,
+            telemetry,
+            configuration.getPhysicalIOConfiguration(),
+            cache,
+            executorService);
   }
 
   /**
@@ -198,16 +203,15 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
    */
   @Override
   public void close() throws IOException {
+    handleCacheClosure(cache, configuration.getPhysicalIOConfiguration().isEnableCacheFlush());
+
     this.objectMetadataStore.close();
     this.objectBlobStore.close();
     this.telemetry.close();
-
-    handleCacheClosure(cache, configuration.getPhysicalIOConfiguration().isEnableCacheFlush());
   }
 
   private void handleCacheClosure(Cache cache, boolean shouldFlushCache) {
     if (cache != null) {
-
       if (shouldFlushCache) {
         LOG.info("Cache is being closed");
         LOG.info("Starting to clear cache");
@@ -225,6 +229,5 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
 
       cache.close();
     }
-
   }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTask.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTask.java
@@ -26,7 +26,6 @@ import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIO;
 import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlan;
 import software.amazon.s3.analyticsaccelerator.request.Range;
-import software.amazon.s3.analyticsaccelerator.util.RangeType;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 import software.amazon.s3.analyticsaccelerator.util.StreamAttributes;
 
@@ -74,8 +73,7 @@ public class ParquetPrefetchTailTask {
           try {
             long contentLength = physicalIO.metadata().getContentLength();
             List<Range> ranges =
-                ParquetUtils.getFileTailPrefetchRanges(
-                    logicalIOConfiguration, 0, contentLength);
+                ParquetUtils.getFileTailPrefetchRanges(logicalIOConfiguration, 0, contentLength);
 
             IOPlan ioPlan = new IOPlan(ranges);
             // Create a non-empty IOPlan only if we have a valid range to work with

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTask.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTask.java
@@ -26,6 +26,7 @@ import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIO;
 import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlan;
 import software.amazon.s3.analyticsaccelerator.request.Range;
+import software.amazon.s3.analyticsaccelerator.util.RangeType;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 import software.amazon.s3.analyticsaccelerator.util.StreamAttributes;
 
@@ -73,7 +74,9 @@ public class ParquetPrefetchTailTask {
           try {
             long contentLength = physicalIO.metadata().getContentLength();
             List<Range> ranges =
-                ParquetUtils.getFileTailPrefetchRanges(logicalIOConfiguration, 0, contentLength);
+                ParquetUtils.getFileTailPrefetchRanges(
+                    logicalIOConfiguration, 0, contentLength);
+
             IOPlan ioPlan = new IOPlan(ranges);
             // Create a non-empty IOPlan only if we have a valid range to work with
             physicalIO.execute(ioPlan);

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetUtils.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetUtils.java
@@ -88,7 +88,8 @@ public final class ParquetUtils {
           ranges.add(
               new Range(
                   fileMetadataStartIndex - footerPrefetchSize.getPageIndexPrefetchSize(),
-                  fileMetadataStartIndex - 1));
+                  fileMetadataStartIndex - 1,
+                  RangeType.Footer));
         }
 
         return ranges;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetUtils.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetUtils.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import software.amazon.s3.analyticsaccelerator.io.logical.LogicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.request.Range;
 import software.amazon.s3.analyticsaccelerator.util.PrefetchMode;
+import software.amazon.s3.analyticsaccelerator.util.RangeType;
 
 /** Utils class for the Parquet logical layer. */
 public final class ParquetUtils {
@@ -81,7 +82,7 @@ public final class ParquetUtils {
       if (!shouldPrefetchSmallFile) {
         long fileMetadataStartIndex =
             contentLength - footerPrefetchSize.getFileMetadataPrefetchSize();
-        ranges.add(new Range(fileMetadataStartIndex, contentLength - 1));
+        ranges.add(new Range(fileMetadataStartIndex, contentLength - 1, RangeType.Footer));
 
         if (logicalIOConfiguration.isPrefetchPageIndexEnabled()) {
           ranges.add(

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetUtils.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetUtils.java
@@ -82,14 +82,14 @@ public final class ParquetUtils {
       if (!shouldPrefetchSmallFile) {
         long fileMetadataStartIndex =
             contentLength - footerPrefetchSize.getFileMetadataPrefetchSize();
-        ranges.add(new Range(fileMetadataStartIndex, contentLength - 1, RangeType.Footer));
+        ranges.add(new Range(fileMetadataStartIndex, contentLength - 1, RangeType.FOOTER_METADATA));
 
         if (logicalIOConfiguration.isPrefetchPageIndexEnabled()) {
           ranges.add(
               new Range(
                   fileMetadataStartIndex - footerPrefetchSize.getPageIndexPrefetchSize(),
                   fileMetadataStartIndex - 1,
-                  RangeType.Footer));
+                  RangeType.FOOTER_PAGE_INDEX));
         }
 
         return ranges;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/Cache.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/Cache.java
@@ -15,7 +15,10 @@
  */
 package software.amazon.s3.analyticsaccelerator.io.physical;
 
-/** An interface defining how the ElastiCache cache should behave */
+/**
+ * A Cache interface defining how the ElastiCache cache should behave, to be used in a shared cache
+ * that may be accessed by any node for the duration of a workload
+ */
 public interface Cache {
 
   /**
@@ -24,7 +27,7 @@ public interface Cache {
    * @param key the key to fetch from ElastiCache
    * @return the value associated with the key in ElastiCache
    */
-  byte[] get(byte[] key);
+  byte[] get(String key);
 
   /**
    * Sets the value in ElastiCache for a key, given that key and value
@@ -32,7 +35,7 @@ public interface Cache {
    * @param key the key for which to set the value in ElastiCache
    * @param value the value to set in ElastiCache for the given key
    */
-  void set(byte[] key, byte[] value);
+  void set(String key, byte[] value);
 
   /** Closes the connection to the ElastiCache server */
   void close();

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/Cache.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/Cache.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.io.physical;
+
+/** An interface defining how the ElastiCache cache should behave */
+public interface Cache {
+
+    /**
+     * Fetches the value from ElastiCache given a key
+     *
+     * @param key the key to fetch from ElastiCache
+     * @return the value associated with the key in ElastiCache
+     */
+    byte[] get(byte[] key);
+
+    /**
+     * Sets the value in ElastiCache for a key, given that key and value
+     *
+     * @param key the key for which to set the value in ElastiCache
+     * @param value the value to set in ElastiCache for the given key
+     */
+    void set(byte[] key, byte[] value);
+
+    /** Closes the connection to the ElastiCache server */
+    void close();
+}

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/Cache.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/Cache.java
@@ -39,4 +39,7 @@ public interface Cache {
 
   /** Closes the connection to the ElastiCache server */
   void close();
+
+  /** Clears all data from the cache */
+  void clearCache();
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/Cache.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/Cache.java
@@ -18,22 +18,22 @@ package software.amazon.s3.analyticsaccelerator.io.physical;
 /** An interface defining how the ElastiCache cache should behave */
 public interface Cache {
 
-    /**
-     * Fetches the value from ElastiCache given a key
-     *
-     * @param key the key to fetch from ElastiCache
-     * @return the value associated with the key in ElastiCache
-     */
-    byte[] get(byte[] key);
+  /**
+   * Fetches the value from ElastiCache given a key
+   *
+   * @param key the key to fetch from ElastiCache
+   * @return the value associated with the key in ElastiCache
+   */
+  byte[] get(byte[] key);
 
-    /**
-     * Sets the value in ElastiCache for a key, given that key and value
-     *
-     * @param key the key for which to set the value in ElastiCache
-     * @param value the value to set in ElastiCache for the given key
-     */
-    void set(byte[] key, byte[] value);
+  /**
+   * Sets the value in ElastiCache for a key, given that key and value
+   *
+   * @param key the key for which to set the value in ElastiCache
+   * @param value the value to set in ElastiCache for the given key
+   */
+  void set(byte[] key, byte[] value);
 
-    /** Closes the connection to the ElastiCache server */
-    void close();
+  /** Closes the connection to the ElastiCache server */
+  void close();
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -134,32 +134,32 @@ public class PhysicalIOConfiguration {
    */
   public static PhysicalIOConfiguration fromConfiguration(ConnectorConfiguration configuration) {
     return PhysicalIOConfiguration.builder()
-        .blobStoreCapacity(
-            configuration.getInt(BLOB_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_BLOB_STORE))
-        .metadataStoreCapacity(
-            configuration.getInt(METADATA_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_METADATA_STORE))
-        .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
-        .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
-        .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
-        .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
-        .sequentialPrefetchBase(
-            configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
-        .sequentialPrefetchSpeed(
-            configuration.getDouble(
-                SEQUENTIAL_PREFETCH_SPEED_KEY, DEFAULT_SEQUENTIAL_PREFETCH_SPEED))
-        .blockReadTimeout(configuration.getLong(BLOCK_READ_TIMEOUT_KEY, DEFAULT_BLOCK_READ_TIMEOUT))
-        .blockReadRetryCount(
-            configuration.getInt(BLOCK_READ_RETRY_COUNT_KEY, DEFAULT_BLOCK_READ_RETRY_COUNT))
-        .enableTailMetadataCaching(
-            configuration.getBoolean(
-                ENABLE_TAIL_METADATA_CACHING_KEY, DEFAULT_ENABLE_TAIL_METADATA_CACHING))
-        .cacheEndpoint(
-                configuration.getString(
-                        CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
-        .enableCacheFlush(
-                configuration.getBoolean(
-                        ENABLE_CACHE_FLUSH_KEY, DEFAULT_ENABLE_CACHE_FLUSH))
-        .build();
+            .blobStoreCapacity(
+                    configuration.getInt(BLOB_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_BLOB_STORE))
+            .metadataStoreCapacity(
+                    configuration.getInt(METADATA_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_METADATA_STORE))
+            .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
+            .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
+            .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
+            .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
+            .sequentialPrefetchBase(
+                    configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
+            .sequentialPrefetchSpeed(
+                    configuration.getDouble(
+                            SEQUENTIAL_PREFETCH_SPEED_KEY, DEFAULT_SEQUENTIAL_PREFETCH_SPEED))
+            .blockReadTimeout(configuration.getLong(BLOCK_READ_TIMEOUT_KEY, DEFAULT_BLOCK_READ_TIMEOUT))
+            .blockReadRetryCount(
+                    configuration.getInt(BLOCK_READ_RETRY_COUNT_KEY, DEFAULT_BLOCK_READ_RETRY_COUNT))
+            .enableTailMetadataCaching(
+                    configuration.getBoolean(
+                            ENABLE_TAIL_METADATA_CACHING_KEY, DEFAULT_ENABLE_TAIL_METADATA_CACHING))
+            .cacheEndpoint(
+                    configuration.getString(
+                            CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
+            .enableCacheFlush(
+                    configuration.getBoolean(
+                            ENABLE_CACHE_FLUSH_KEY, DEFAULT_ENABLE_CACHE_FLUSH))
+            .build();
   }
 
   /**
@@ -182,36 +182,37 @@ public class PhysicalIOConfiguration {
    */
   @Builder
   private PhysicalIOConfiguration(
-      int blobStoreCapacity,
-      int metadataStoreCapacity,
-      long blockSizeBytes,
-      long readAheadBytes,
-      long maxRangeSizeBytes,
-      long partSizeBytes,
-      double sequentialPrefetchBase,
-      double sequentialPrefetchSpeed,
-      long blockReadTimeout,
-      int blockReadRetryCount,
-      boolean enableTailMetadataCaching,
-      String cacheEndpoint) {
+          int blobStoreCapacity,
+          int metadataStoreCapacity,
+          long blockSizeBytes,
+          long readAheadBytes,
+          long maxRangeSizeBytes,
+          long partSizeBytes,
+          double sequentialPrefetchBase,
+          double sequentialPrefetchSpeed,
+          long blockReadTimeout,
+          int blockReadRetryCount,
+          boolean enableTailMetadataCaching,
+          String cacheEndpoint,
+          boolean enableCacheFlush) {
     Preconditions.checkArgument(blobStoreCapacity > 0, "`blobStoreCapacity` must be positive");
     Preconditions.checkArgument(
-        metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
+            metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
     Preconditions.checkArgument(blockSizeBytes > 0, "`blockSizeBytes` must be positive");
     Preconditions.checkArgument(readAheadBytes > 0, "`readAheadLengthBytes` must be positive");
     Preconditions.checkArgument(maxRangeSizeBytes > 0, "`maxRangeSize` must be positive");
     Preconditions.checkArgument(partSizeBytes > 0, "`partSize` must be positive");
     Preconditions.checkArgument(
-        sequentialPrefetchBase > 0, "`sequentialPrefetchBase` must be positive");
+            sequentialPrefetchBase > 0, "`sequentialPrefetchBase` must be positive");
     Preconditions.checkArgument(
-        sequentialPrefetchSpeed > 0, "`sequentialPrefetchSpeed` must be positive");
+            sequentialPrefetchSpeed > 0, "`sequentialPrefetchSpeed` must be positive");
     Preconditions.checkArgument(blockReadTimeout > 0, "`blockReadTimeout` must be positive");
     Preconditions.checkArgument(blockReadRetryCount > 0, "`blockReadRetryCount` must be positive");
 
     if (enableTailMetadataCaching) {
       Preconditions.checkArgument(
-          cacheEndpoint != null && !cacheEndpoint.isEmpty(),
-          "`cacheEndpoint` must be set when tail metadata caching is enabled");
+              cacheEndpoint != null && !cacheEndpoint.isEmpty(),
+              "`cacheEndpoint` must be set when tail metadata caching is enabled");
     }
 
     this.blobStoreCapacity = blobStoreCapacity;
@@ -226,6 +227,7 @@ public class PhysicalIOConfiguration {
     this.blockReadRetryCount = blockReadRetryCount;
     this.enableTailMetadataCaching = enableTailMetadataCaching;
     this.cacheEndpoint = cacheEndpoint;
+    this.enableCacheFlush = enableCacheFlush;
   }
 
   @Override
@@ -247,6 +249,8 @@ public class PhysicalIOConfiguration {
     if (enableTailMetadataCaching) {
       builder.append("\tcacheEndpoint: " + cacheEndpoint + "\n");
     }
+    builder.append("\tenableCacheFlush: " + enableCacheFlush + "\n");
+
 
     return builder.toString();
   }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -42,7 +42,6 @@ public class PhysicalIOConfiguration {
   private static final long DEFAULT_BLOCK_READ_TIMEOUT = 30_000;
   private static final int DEFAULT_BLOCK_READ_RETRY_COUNT = 20;
   private static final boolean DEFAULT_ENABLE_TAIL_METADATA_CACHING = false;
-  //  TODO: find a way to pass the cache endpoint down without hardcoding
   private static final String DEFAULT_CACHE_ENDPOINT = "";
 
   /** Capacity, in blobs. {@link PhysicalIOConfiguration#DEFAULT_CAPACITY_BLOB_STORE} by default. */

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -41,6 +41,8 @@ public class PhysicalIOConfiguration {
   private static final double DEFAULT_SEQUENTIAL_PREFETCH_SPEED = 1.0;
   private static final long DEFAULT_BLOCK_READ_TIMEOUT = 30_000;
   private static final int DEFAULT_BLOCK_READ_RETRY_COUNT = 20;
+  private static final boolean DEFAULT_ENABLE_TAIL_METADATA_CACHING = true;
+  private static final String DEFAULT_CACHE_ENDPOINT = "";
 
   /** Capacity, in blobs. {@link PhysicalIOConfiguration#DEFAULT_CAPACITY_BLOB_STORE} by default. */
   @Builder.Default private int blobStoreCapacity = DEFAULT_CAPACITY_BLOB_STORE;
@@ -105,6 +107,16 @@ public class PhysicalIOConfiguration {
 
   private static final String BLOCK_READ_RETRY_COUNT_KEY = "blockreadretrycount";
 
+  /** Enable tail metadata caching with ElastiCache */
+  @Builder.Default private boolean enableTailMetadataCaching = DEFAULT_ENABLE_TAIL_METADATA_CACHING;
+
+  private static final String ENABLE_TAIL_METADATA_CACHING_KEY = "cache.enabled";
+
+  /** ElastiCache endpoint */
+  @Builder.Default private String cacheEndpoint = DEFAULT_CACHE_ENDPOINT;
+
+  private static final String CACHE_ENDPOINT_KEY = "cache.endpoint";
+
   /** Default set of settings for {@link PhysicalIO} */
   public static final PhysicalIOConfiguration DEFAULT = PhysicalIOConfiguration.builder().build();
 
@@ -116,23 +128,27 @@ public class PhysicalIOConfiguration {
    */
   public static PhysicalIOConfiguration fromConfiguration(ConnectorConfiguration configuration) {
     return PhysicalIOConfiguration.builder()
-        .blobStoreCapacity(
-            configuration.getInt(BLOB_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_BLOB_STORE))
-        .metadataStoreCapacity(
-            configuration.getInt(METADATA_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_METADATA_STORE))
-        .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
-        .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
-        .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
-        .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
-        .sequentialPrefetchBase(
-            configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
-        .sequentialPrefetchSpeed(
-            configuration.getDouble(
-                SEQUENTIAL_PREFETCH_SPEED_KEY, DEFAULT_SEQUENTIAL_PREFETCH_SPEED))
-        .blockReadTimeout(configuration.getLong(BLOCK_READ_TIMEOUT_KEY, DEFAULT_BLOCK_READ_TIMEOUT))
-        .blockReadRetryCount(
-            configuration.getInt(BLOCK_READ_RETRY_COUNT_KEY, DEFAULT_BLOCK_READ_RETRY_COUNT))
-        .build();
+            .blobStoreCapacity(
+                    configuration.getInt(BLOB_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_BLOB_STORE))
+            .metadataStoreCapacity(
+                    configuration.getInt(METADATA_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_METADATA_STORE))
+            .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
+            .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
+            .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
+            .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
+            .sequentialPrefetchBase(
+                    configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
+            .sequentialPrefetchSpeed(
+                    configuration.getDouble(
+                            SEQUENTIAL_PREFETCH_SPEED_KEY, DEFAULT_SEQUENTIAL_PREFETCH_SPEED))
+            .blockReadTimeout(configuration.getLong(BLOCK_READ_TIMEOUT_KEY, DEFAULT_BLOCK_READ_TIMEOUT))
+            .blockReadRetryCount(
+                    configuration.getInt(BLOCK_READ_RETRY_COUNT_KEY, DEFAULT_BLOCK_READ_RETRY_COUNT))
+            .enableTailMetadataCaching(
+                    configuration.getBoolean(
+                            ENABLE_TAIL_METADATA_CACHING_KEY, DEFAULT_ENABLE_TAIL_METADATA_CACHING))
+            .cacheEndpoint(configuration.getString(CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
+            .build();
   }
 
   /**
@@ -153,29 +169,37 @@ public class PhysicalIOConfiguration {
    */
   @Builder
   private PhysicalIOConfiguration(
-      int blobStoreCapacity,
-      int metadataStoreCapacity,
-      long blockSizeBytes,
-      long readAheadBytes,
-      long maxRangeSizeBytes,
-      long partSizeBytes,
-      double sequentialPrefetchBase,
-      double sequentialPrefetchSpeed,
-      long blockReadTimeout,
-      int blockReadRetryCount) {
+          int blobStoreCapacity,
+          int metadataStoreCapacity,
+          long blockSizeBytes,
+          long readAheadBytes,
+          long maxRangeSizeBytes,
+          long partSizeBytes,
+          double sequentialPrefetchBase,
+          double sequentialPrefetchSpeed,
+          long blockReadTimeout,
+          int blockReadRetryCount,
+          boolean enableTailMetadataCaching,
+          String cacheEndpoint) {
     Preconditions.checkArgument(blobStoreCapacity > 0, "`blobStoreCapacity` must be positive");
     Preconditions.checkArgument(
-        metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
+            metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
     Preconditions.checkArgument(blockSizeBytes > 0, "`blockSizeBytes` must be positive");
     Preconditions.checkArgument(readAheadBytes > 0, "`readAheadLengthBytes` must be positive");
     Preconditions.checkArgument(maxRangeSizeBytes > 0, "`maxRangeSize` must be positive");
     Preconditions.checkArgument(partSizeBytes > 0, "`partSize` must be positive");
     Preconditions.checkArgument(
-        sequentialPrefetchBase > 0, "`sequentialPrefetchBase` must be positive");
+            sequentialPrefetchBase > 0, "`sequentialPrefetchBase` must be positive");
     Preconditions.checkArgument(
-        sequentialPrefetchSpeed > 0, "`sequentialPrefetchSpeed` must be positive");
+            sequentialPrefetchSpeed > 0, "`sequentialPrefetchSpeed` must be positive");
     Preconditions.checkArgument(blockReadTimeout > 0, "`blockReadTimeout` must be positive");
     Preconditions.checkArgument(blockReadRetryCount > 0, "`blockReadRetryCount` must be positive");
+
+    if (enableTailMetadataCaching) {
+      Preconditions.checkArgument(
+              cacheEndpoint != null && !cacheEndpoint.isEmpty(),
+              "`cacheEndpoint` must be set when tail metadata caching is enabled");
+    }
 
     this.blobStoreCapacity = blobStoreCapacity;
     this.metadataStoreCapacity = metadataStoreCapacity;
@@ -187,6 +211,8 @@ public class PhysicalIOConfiguration {
     this.sequentialPrefetchSpeed = sequentialPrefetchSpeed;
     this.blockReadTimeout = blockReadTimeout;
     this.blockReadRetryCount = blockReadRetryCount;
+    this.enableTailMetadataCaching = enableTailMetadataCaching;
+    this.cacheEndpoint = cacheEndpoint;
   }
 
   @Override
@@ -204,6 +230,10 @@ public class PhysicalIOConfiguration {
     builder.append("\tsequentialPrefetchSpeed: " + sequentialPrefetchSpeed + "\n");
     builder.append("\tblockReadTimeout: " + blockReadTimeout + "\n");
     builder.append("\tblockReadRetryCount: " + blockReadRetryCount + "\n");
+    builder.append("\tenableTailMetadataCaching: " + enableTailMetadataCaching + "\n");
+    if (enableTailMetadataCaching) {
+      builder.append("\tcacheEndpoint: " + cacheEndpoint + "\n");
+    }
 
     return builder.toString();
   }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -42,6 +42,7 @@ public class PhysicalIOConfiguration {
   private static final long DEFAULT_BLOCK_READ_TIMEOUT = 30_000;
   private static final int DEFAULT_BLOCK_READ_RETRY_COUNT = 20;
   private static final boolean DEFAULT_ENABLE_TAIL_METADATA_CACHING = true;
+//  TODO: find a way to pass the cache endpoint down without hardcoding
   private static final String DEFAULT_CACHE_ENDPOINT = "";
 
   /** Capacity, in blobs. {@link PhysicalIOConfiguration#DEFAULT_CAPACITY_BLOB_STORE} by default. */

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -134,32 +134,29 @@ public class PhysicalIOConfiguration {
    */
   public static PhysicalIOConfiguration fromConfiguration(ConnectorConfiguration configuration) {
     return PhysicalIOConfiguration.builder()
-            .blobStoreCapacity(
-                    configuration.getInt(BLOB_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_BLOB_STORE))
-            .metadataStoreCapacity(
-                    configuration.getInt(METADATA_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_METADATA_STORE))
-            .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
-            .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
-            .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
-            .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
-            .sequentialPrefetchBase(
-                    configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
-            .sequentialPrefetchSpeed(
-                    configuration.getDouble(
-                            SEQUENTIAL_PREFETCH_SPEED_KEY, DEFAULT_SEQUENTIAL_PREFETCH_SPEED))
-            .blockReadTimeout(configuration.getLong(BLOCK_READ_TIMEOUT_KEY, DEFAULT_BLOCK_READ_TIMEOUT))
-            .blockReadRetryCount(
-                    configuration.getInt(BLOCK_READ_RETRY_COUNT_KEY, DEFAULT_BLOCK_READ_RETRY_COUNT))
-            .enableTailMetadataCaching(
-                    configuration.getBoolean(
-                            ENABLE_TAIL_METADATA_CACHING_KEY, DEFAULT_ENABLE_TAIL_METADATA_CACHING))
-            .cacheEndpoint(
-                    configuration.getString(
-                            CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
-            .enableCacheFlush(
-                    configuration.getBoolean(
-                            ENABLE_CACHE_FLUSH_KEY, DEFAULT_ENABLE_CACHE_FLUSH))
-            .build();
+        .blobStoreCapacity(
+            configuration.getInt(BLOB_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_BLOB_STORE))
+        .metadataStoreCapacity(
+            configuration.getInt(METADATA_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_METADATA_STORE))
+        .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
+        .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
+        .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
+        .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
+        .sequentialPrefetchBase(
+            configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
+        .sequentialPrefetchSpeed(
+            configuration.getDouble(
+                SEQUENTIAL_PREFETCH_SPEED_KEY, DEFAULT_SEQUENTIAL_PREFETCH_SPEED))
+        .blockReadTimeout(configuration.getLong(BLOCK_READ_TIMEOUT_KEY, DEFAULT_BLOCK_READ_TIMEOUT))
+        .blockReadRetryCount(
+            configuration.getInt(BLOCK_READ_RETRY_COUNT_KEY, DEFAULT_BLOCK_READ_RETRY_COUNT))
+        .enableTailMetadataCaching(
+            configuration.getBoolean(
+                ENABLE_TAIL_METADATA_CACHING_KEY, DEFAULT_ENABLE_TAIL_METADATA_CACHING))
+        .cacheEndpoint(configuration.getString(CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
+        .enableCacheFlush(
+            configuration.getBoolean(ENABLE_CACHE_FLUSH_KEY, DEFAULT_ENABLE_CACHE_FLUSH))
+        .build();
   }
 
   /**
@@ -182,37 +179,37 @@ public class PhysicalIOConfiguration {
    */
   @Builder
   private PhysicalIOConfiguration(
-          int blobStoreCapacity,
-          int metadataStoreCapacity,
-          long blockSizeBytes,
-          long readAheadBytes,
-          long maxRangeSizeBytes,
-          long partSizeBytes,
-          double sequentialPrefetchBase,
-          double sequentialPrefetchSpeed,
-          long blockReadTimeout,
-          int blockReadRetryCount,
-          boolean enableTailMetadataCaching,
-          String cacheEndpoint,
-          boolean enableCacheFlush) {
+      int blobStoreCapacity,
+      int metadataStoreCapacity,
+      long blockSizeBytes,
+      long readAheadBytes,
+      long maxRangeSizeBytes,
+      long partSizeBytes,
+      double sequentialPrefetchBase,
+      double sequentialPrefetchSpeed,
+      long blockReadTimeout,
+      int blockReadRetryCount,
+      boolean enableTailMetadataCaching,
+      String cacheEndpoint,
+      boolean enableCacheFlush) {
     Preconditions.checkArgument(blobStoreCapacity > 0, "`blobStoreCapacity` must be positive");
     Preconditions.checkArgument(
-            metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
+        metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
     Preconditions.checkArgument(blockSizeBytes > 0, "`blockSizeBytes` must be positive");
     Preconditions.checkArgument(readAheadBytes > 0, "`readAheadLengthBytes` must be positive");
     Preconditions.checkArgument(maxRangeSizeBytes > 0, "`maxRangeSize` must be positive");
     Preconditions.checkArgument(partSizeBytes > 0, "`partSize` must be positive");
     Preconditions.checkArgument(
-            sequentialPrefetchBase > 0, "`sequentialPrefetchBase` must be positive");
+        sequentialPrefetchBase > 0, "`sequentialPrefetchBase` must be positive");
     Preconditions.checkArgument(
-            sequentialPrefetchSpeed > 0, "`sequentialPrefetchSpeed` must be positive");
+        sequentialPrefetchSpeed > 0, "`sequentialPrefetchSpeed` must be positive");
     Preconditions.checkArgument(blockReadTimeout > 0, "`blockReadTimeout` must be positive");
     Preconditions.checkArgument(blockReadRetryCount > 0, "`blockReadRetryCount` must be positive");
 
     if (enableTailMetadataCaching) {
       Preconditions.checkArgument(
-              cacheEndpoint != null && !cacheEndpoint.isEmpty(),
-              "`cacheEndpoint` must be set when tail metadata caching is enabled");
+          cacheEndpoint != null && !cacheEndpoint.isEmpty(),
+          "`cacheEndpoint` must be set when tail metadata caching is enabled");
     }
 
     this.blobStoreCapacity = blobStoreCapacity;
@@ -250,7 +247,6 @@ public class PhysicalIOConfiguration {
       builder.append("\tcacheEndpoint: " + cacheEndpoint + "\n");
     }
     builder.append("\tenableCacheFlush: " + enableCacheFlush + "\n");
-
 
     return builder.toString();
   }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -43,6 +43,7 @@ public class PhysicalIOConfiguration {
   private static final int DEFAULT_BLOCK_READ_RETRY_COUNT = 20;
   private static final boolean DEFAULT_ENABLE_TAIL_METADATA_CACHING = false;
   private static final String DEFAULT_CACHE_ENDPOINT = "";
+  private static final boolean DEFAULT_ENABLE_CACHE_FLUSH = false;
 
   /** Capacity, in blobs. {@link PhysicalIOConfiguration#DEFAULT_CAPACITY_BLOB_STORE} by default. */
   @Builder.Default private int blobStoreCapacity = DEFAULT_CAPACITY_BLOB_STORE;
@@ -117,6 +118,11 @@ public class PhysicalIOConfiguration {
 
   private static final String CACHE_ENDPOINT_KEY = "cache.endpoint";
 
+  /** Enable cache flushes after stream is closed */
+  @Builder.Default private boolean enableCacheFlush = DEFAULT_ENABLE_CACHE_FLUSH;
+
+  private static final String ENABLE_CACHE_FLUSH_KEY = "cache.flush";
+
   /** Default set of settings for {@link PhysicalIO} */
   public static final PhysicalIOConfiguration DEFAULT = PhysicalIOConfiguration.builder().build();
 
@@ -147,7 +153,12 @@ public class PhysicalIOConfiguration {
         .enableTailMetadataCaching(
             configuration.getBoolean(
                 ENABLE_TAIL_METADATA_CACHING_KEY, DEFAULT_ENABLE_TAIL_METADATA_CACHING))
-        .cacheEndpoint(configuration.getString(CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
+        .cacheEndpoint(
+                configuration.getString(
+                        CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
+        .enableCacheFlush(
+                configuration.getBoolean(
+                        ENABLE_CACHE_FLUSH_KEY, DEFAULT_ENABLE_CACHE_FLUSH))
         .build();
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -41,8 +41,8 @@ public class PhysicalIOConfiguration {
   private static final double DEFAULT_SEQUENTIAL_PREFETCH_SPEED = 1.0;
   private static final long DEFAULT_BLOCK_READ_TIMEOUT = 30_000;
   private static final int DEFAULT_BLOCK_READ_RETRY_COUNT = 20;
-  private static final boolean DEFAULT_ENABLE_TAIL_METADATA_CACHING = true;
-//  TODO: find a way to pass the cache endpoint down without hardcoding
+  private static final boolean DEFAULT_ENABLE_TAIL_METADATA_CACHING = false;
+  //  TODO: find a way to pass the cache endpoint down without hardcoding
   private static final String DEFAULT_CACHE_ENDPOINT = "";
 
   /** Capacity, in blobs. {@link PhysicalIOConfiguration#DEFAULT_CAPACITY_BLOB_STORE} by default. */
@@ -129,27 +129,27 @@ public class PhysicalIOConfiguration {
    */
   public static PhysicalIOConfiguration fromConfiguration(ConnectorConfiguration configuration) {
     return PhysicalIOConfiguration.builder()
-            .blobStoreCapacity(
-                    configuration.getInt(BLOB_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_BLOB_STORE))
-            .metadataStoreCapacity(
-                    configuration.getInt(METADATA_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_METADATA_STORE))
-            .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
-            .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
-            .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
-            .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
-            .sequentialPrefetchBase(
-                    configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
-            .sequentialPrefetchSpeed(
-                    configuration.getDouble(
-                            SEQUENTIAL_PREFETCH_SPEED_KEY, DEFAULT_SEQUENTIAL_PREFETCH_SPEED))
-            .blockReadTimeout(configuration.getLong(BLOCK_READ_TIMEOUT_KEY, DEFAULT_BLOCK_READ_TIMEOUT))
-            .blockReadRetryCount(
-                    configuration.getInt(BLOCK_READ_RETRY_COUNT_KEY, DEFAULT_BLOCK_READ_RETRY_COUNT))
-            .enableTailMetadataCaching(
-                    configuration.getBoolean(
-                            ENABLE_TAIL_METADATA_CACHING_KEY, DEFAULT_ENABLE_TAIL_METADATA_CACHING))
-            .cacheEndpoint(configuration.getString(CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
-            .build();
+        .blobStoreCapacity(
+            configuration.getInt(BLOB_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_BLOB_STORE))
+        .metadataStoreCapacity(
+            configuration.getInt(METADATA_STORE_CAPACITY_KEY, DEFAULT_CAPACITY_METADATA_STORE))
+        .blockSizeBytes(configuration.getLong(BLOCK_SIZE_BYTES_KEY, DEFAULT_BLOCK_SIZE_BYTES))
+        .readAheadBytes(configuration.getLong(READ_AHEAD_BYTES_KEY, DEFAULT_READ_AHEAD_BYTES))
+        .maxRangeSizeBytes(configuration.getLong(MAX_RANGE_SIZE_BYTES_KEY, DEFAULT_MAX_RANGE_SIZE))
+        .partSizeBytes(configuration.getLong(PART_SIZE_BYTES_KEY, DEFAULT_PART_SIZE))
+        .sequentialPrefetchBase(
+            configuration.getDouble(SEQUENTIAL_PREFETCH_BASE_KEY, DEFAULT_SEQUENTIAL_PREFETCH_BASE))
+        .sequentialPrefetchSpeed(
+            configuration.getDouble(
+                SEQUENTIAL_PREFETCH_SPEED_KEY, DEFAULT_SEQUENTIAL_PREFETCH_SPEED))
+        .blockReadTimeout(configuration.getLong(BLOCK_READ_TIMEOUT_KEY, DEFAULT_BLOCK_READ_TIMEOUT))
+        .blockReadRetryCount(
+            configuration.getInt(BLOCK_READ_RETRY_COUNT_KEY, DEFAULT_BLOCK_READ_RETRY_COUNT))
+        .enableTailMetadataCaching(
+            configuration.getBoolean(
+                ENABLE_TAIL_METADATA_CACHING_KEY, DEFAULT_ENABLE_TAIL_METADATA_CACHING))
+        .cacheEndpoint(configuration.getString(CACHE_ENDPOINT_KEY, DEFAULT_CACHE_ENDPOINT))
+        .build();
   }
 
   /**
@@ -167,39 +167,41 @@ public class PhysicalIOConfiguration {
    *     prefetched physical blocks.
    * @param blockReadTimeout Timeout duration (in milliseconds) for reading a block object from S3
    * @param blockReadRetryCount Number of retries for block read failure
+   * @param enableTailMetadataCaching Boolean flag to enable or disable tail metadata caching
+   * @param cacheEndpoint The endpoint of the ElastiCache cache in use
    */
   @Builder
   private PhysicalIOConfiguration(
-          int blobStoreCapacity,
-          int metadataStoreCapacity,
-          long blockSizeBytes,
-          long readAheadBytes,
-          long maxRangeSizeBytes,
-          long partSizeBytes,
-          double sequentialPrefetchBase,
-          double sequentialPrefetchSpeed,
-          long blockReadTimeout,
-          int blockReadRetryCount,
-          boolean enableTailMetadataCaching,
-          String cacheEndpoint) {
+      int blobStoreCapacity,
+      int metadataStoreCapacity,
+      long blockSizeBytes,
+      long readAheadBytes,
+      long maxRangeSizeBytes,
+      long partSizeBytes,
+      double sequentialPrefetchBase,
+      double sequentialPrefetchSpeed,
+      long blockReadTimeout,
+      int blockReadRetryCount,
+      boolean enableTailMetadataCaching,
+      String cacheEndpoint) {
     Preconditions.checkArgument(blobStoreCapacity > 0, "`blobStoreCapacity` must be positive");
     Preconditions.checkArgument(
-            metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
+        metadataStoreCapacity > 0, "`metadataStoreCapacity` must be positive");
     Preconditions.checkArgument(blockSizeBytes > 0, "`blockSizeBytes` must be positive");
     Preconditions.checkArgument(readAheadBytes > 0, "`readAheadLengthBytes` must be positive");
     Preconditions.checkArgument(maxRangeSizeBytes > 0, "`maxRangeSize` must be positive");
     Preconditions.checkArgument(partSizeBytes > 0, "`partSize` must be positive");
     Preconditions.checkArgument(
-            sequentialPrefetchBase > 0, "`sequentialPrefetchBase` must be positive");
+        sequentialPrefetchBase > 0, "`sequentialPrefetchBase` must be positive");
     Preconditions.checkArgument(
-            sequentialPrefetchSpeed > 0, "`sequentialPrefetchSpeed` must be positive");
+        sequentialPrefetchSpeed > 0, "`sequentialPrefetchSpeed` must be positive");
     Preconditions.checkArgument(blockReadTimeout > 0, "`blockReadTimeout` must be positive");
     Preconditions.checkArgument(blockReadRetryCount > 0, "`blockReadRetryCount` must be positive");
 
     if (enableTailMetadataCaching) {
       Preconditions.checkArgument(
-              cacheEndpoint != null && !cacheEndpoint.isEmpty(),
-              "`cacheEndpoint` must be set when tail metadata caching is enabled");
+          cacheEndpoint != null && !cacheEndpoint.isEmpty(),
+          "`cacheEndpoint` must be set when tail metadata caching is enabled");
     }
 
     this.blobStoreCapacity = blobStoreCapacity;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Blob.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Blob.java
@@ -92,7 +92,7 @@ public class Blob implements Closeable {
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
     Preconditions.checkArgument(off < buf.length, "`off` must be less than size of buffer");
 
-    blockManager.makeRangeAvailable(pos, len, ReadMode.SYNC);
+    blockManager.makeRangeAvailable(pos, len, null, ReadMode.SYNC);
 
     long nextPosition = pos;
     int numBytesRead = 0;
@@ -141,7 +141,7 @@ public class Blob implements Closeable {
           try {
             for (Range range : plan.getPrefetchRanges()) {
               this.blockManager.makeRangeAvailable(
-                  range.getStart(), range.getLength(), ReadMode.ASYNC);
+                  range.getStart(), range.getLength(), range.getRangeType(), ReadMode.ASYNC);
             }
 
             return IOPlanExecution.builder().state(IOPlanState.SUBMITTED).build();

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Blob.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Blob.java
@@ -30,6 +30,7 @@ import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.Range;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
+import software.amazon.s3.analyticsaccelerator.util.RangeType;
 import software.amazon.s3.analyticsaccelerator.util.StreamAttributes;
 
 /** A Blob representing an object. */
@@ -92,7 +93,7 @@ public class Blob implements Closeable {
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
     Preconditions.checkArgument(off < buf.length, "`off` must be less than size of buffer");
 
-    blockManager.makeRangeAvailable(pos, len, null, ReadMode.SYNC);
+    blockManager.makeRangeAvailable(pos, len, RangeType.BLOCK, ReadMode.SYNC);
 
     long nextPosition = pos;
     int numBytesRead = 0;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.Cache;
@@ -103,7 +102,14 @@ public class BlobStore implements Closeable {
                 uri,
                 metadata,
                 new BlockManager(
-                    uri, objectClient, metadata, telemetry, configuration, cache, executorService, streamContext),
+                    uri,
+                    objectClient,
+                    metadata,
+                    telemetry,
+                    configuration,
+                    cache,
+                    executorService,
+                    streamContext),
                 telemetry));
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
+import software.amazon.s3.analyticsaccelerator.io.physical.Cache;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
@@ -30,14 +31,15 @@ import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 
 /** A BlobStore is a container for Blobs and functions as a data cache. */
 @SuppressFBWarnings(
-    value = "SIC_INNER_SHOULD_BE_STATIC_ANON",
-    justification =
-        "Inner class is created very infrequently, and fluency justifies the extra pointer")
+        value = "SIC_INNER_SHOULD_BE_STATIC_ANON",
+        justification =
+                "Inner class is created very infrequently, and fluency justifies the extra pointer")
 public class BlobStore implements Closeable {
   private final Map<ObjectKey, Blob> blobMap;
   private final ObjectClient objectClient;
   private final Telemetry telemetry;
   private final PhysicalIOConfiguration configuration;
+  private final Cache cache;
 
   /**
    * Construct an instance of BlobStore.
@@ -47,20 +49,22 @@ public class BlobStore implements Closeable {
    * @param configuration the PhysicalIO configuration
    */
   public BlobStore(
-      @NonNull ObjectClient objectClient,
-      @NonNull Telemetry telemetry,
-      @NonNull PhysicalIOConfiguration configuration) {
+          @NonNull ObjectClient objectClient,
+          @NonNull Telemetry telemetry,
+          @NonNull PhysicalIOConfiguration configuration,
+          Cache cache) {
     this.objectClient = objectClient;
     this.telemetry = telemetry;
     this.blobMap =
-        Collections.synchronizedMap(
-            new LinkedHashMap<ObjectKey, Blob>() {
-              @Override
-              protected boolean removeEldestEntry(final Map.Entry<ObjectKey, Blob> eldest) {
-                return this.size() > configuration.getBlobStoreCapacity();
-              }
-            });
+            Collections.synchronizedMap(
+                    new LinkedHashMap<ObjectKey, Blob>() {
+                      @Override
+                      protected boolean removeEldestEntry(final Map.Entry<ObjectKey, Blob> eldest) {
+                        return this.size() > configuration.getBlobStoreCapacity();
+                      }
+                    });
     this.configuration = configuration;
+    this.cache = cache;
   }
 
   /**
@@ -73,14 +77,14 @@ public class BlobStore implements Closeable {
    */
   public Blob get(ObjectKey objectKey, ObjectMetadata metadata, StreamContext streamContext) {
     return blobMap.computeIfAbsent(
-        objectKey,
-        uri ->
-            new Blob(
-                uri,
-                metadata,
-                new BlockManager(
-                    uri, objectClient, metadata, telemetry, configuration, streamContext),
-                telemetry));
+            objectKey,
+            uri ->
+                    new Blob(
+                            uri,
+                            metadata,
+                            new BlockManager(
+                                    uri, objectClient, metadata, telemetry, configuration, cache, streamContext),
+                            telemetry));
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStore.java
@@ -20,6 +20,8 @@ import java.io.Closeable;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.Cache;
@@ -40,6 +42,7 @@ public class BlobStore implements Closeable {
   private final Telemetry telemetry;
   private final PhysicalIOConfiguration configuration;
   private final Cache cache;
+  private final ExecutorService executorService;
 
   /**
    * Construct an instance of BlobStore.
@@ -52,7 +55,7 @@ public class BlobStore implements Closeable {
       @NonNull ObjectClient objectClient,
       @NonNull Telemetry telemetry,
       @NonNull PhysicalIOConfiguration configuration) {
-    this(objectClient, telemetry, configuration, null);
+    this(objectClient, telemetry, configuration, null, null);
   }
 
   /**
@@ -67,7 +70,8 @@ public class BlobStore implements Closeable {
       @NonNull ObjectClient objectClient,
       @NonNull Telemetry telemetry,
       @NonNull PhysicalIOConfiguration configuration,
-      Cache cache) {
+      Cache cache,
+      ExecutorService executorService) {
     this.objectClient = objectClient;
     this.telemetry = telemetry;
     this.blobMap =
@@ -80,6 +84,7 @@ public class BlobStore implements Closeable {
             });
     this.configuration = configuration;
     this.cache = cache;
+    this.executorService = executorService;
   }
 
   /**
@@ -98,7 +103,7 @@ public class BlobStore implements Closeable {
                 uri,
                 metadata,
                 new BlockManager(
-                    uri, objectClient, metadata, telemetry, configuration, cache, streamContext),
+                    uri, objectClient, metadata, telemetry, configuration, cache, executorService, streamContext),
                 telemetry));
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -18,7 +18,6 @@ package software.amazon.s3.analyticsaccelerator.io.physical.data;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.*;
-
 import lombok.Getter;
 import lombok.NonNull;
 import org.slf4j.Logger;
@@ -189,19 +188,19 @@ public class Block implements Closeable {
     this.initialisationTask = new CompletableFuture<>();
 
     if (executorService != null) {
-        executorService.submit(() -> {
-          try {
-            generateSourceAndData();
-            initialisationTask.complete(null);
-          } catch (IOException e) {
-            initialisationTask.completeExceptionally(e);
-            throw new RuntimeException(e);
-          }
-        });
+      executorService.submit(
+          () -> {
+            try {
+              generateSourceAndData();
+              initialisationTask.complete(null);
+            } catch (IOException e) {
+              initialisationTask.completeExceptionally(e);
+              throw new RuntimeException(e);
+            }
+          });
     } else {
       generateSourceAndData();
     }
-
   }
 
   /** Method to help construct source and data */

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -100,6 +100,7 @@ public class Block implements Closeable {
         telemetry,
         start,
         end,
+        RangeType.BLOCK,
         generation,
         readMode,
         readTimeout,
@@ -118,6 +119,7 @@ public class Block implements Closeable {
    * @param telemetry an instance of {@link Telemetry} to use
    * @param start start of the block
    * @param end end of the block
+   * @param rangeType the type associated with the provided range
    * @param generation generation of the block in a sequential read pattern (should be 0 by default)
    * @param readMode read mode describing whether this is a sync or async fetch
    * @param readTimeout Timeout duration (in milliseconds) for reading a block object from S3
@@ -133,6 +135,7 @@ public class Block implements Closeable {
       @NonNull Telemetry telemetry,
       long start,
       long end,
+      RangeType rangeType,
       long generation,
       @NonNull ReadMode readMode,
       long readTimeout,
@@ -159,7 +162,7 @@ public class Block implements Closeable {
     this.generation = generation;
     this.telemetry = telemetry;
     this.objectKey = objectKey;
-    this.range = new Range(start, end);
+    this.range = new Range(start, end, rangeType);
     this.objectClient = objectClient;
     this.streamContext = streamContext;
     this.readMode = readMode;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -15,8 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
-import static software.amazon.s3.analyticsaccelerator.util.Constants.PARQUET_FOOTER_LENGTH_SIZE;
-import static software.amazon.s3.analyticsaccelerator.util.Constants.PARQUET_MAGIC_STR_LENGTH;
+import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -376,7 +375,9 @@ public class Block implements Closeable {
    * @return true if the current block is a tail block, false otherwise
    */
   private boolean isTailMetadata() {
-    return start + PARQUET_MAGIC_STR_LENGTH + PARQUET_FOOTER_LENGTH_SIZE == contentLength;
+    /** hardcoded right now such that ONE_MB matches DEFAULT_PREFETCH_LARGE_FILE_METADATA_SIZE */
+    //    TODO: find a way to adjust this dynamically instead of just using ONE_MB (if necessary)
+    return start + 8 * ONE_MB + 8 * ONE_MB >= contentLength;
   }
 
   /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -197,22 +197,24 @@ public class Block implements Closeable {
 
           if (cachedData != null) {
             LOG.info(
-                "Cache hit for tail metadata: {}. Request took: {}ms, start = {}, end = {}.",
+                "Cache hit for tail metadata: {}. Request took: {}ms, start = {}, end = {}. RangeType: {}",
                 cacheKey,
                 String.format("%.2f", cacheGetMsDuration),
                 range.getStart(),
-                range.getEnd());
+                range.getEnd(),
+                range.getRangeType());
 
             data = CompletableFuture.completedFuture(cachedData);
             return;
 
           } else {
             LOG.info(
-                "Cache miss for tail metadata: {}. Request took: {}ms, start = {}, end = {}.",
+                "Cache miss for tail metadata: {}. Request took: {}ms, start = {}, end = {}. RangeType: {}",
                 cacheKey,
                 String.format("%.2f", cacheGetMsDuration),
                 range.getStart(),
-                range.getEnd());
+                range.getEnd(),
+                range.getRangeType());
           }
         }
 
@@ -251,12 +253,13 @@ public class Block implements Closeable {
                     double s3GetMsDuration = s3GetDuration / 1_000_000.0;
 
                     LOG.info(
-                        "S3 GET request for: {}. Request took: {}ms, start = {}, end = {}. Is cache enabled = {}",
+                        "S3 GET request for: {}. Request took: {}ms, start = {}, end = {}. Is cache enabled = {}. RangeType: {}",
                         this.objectKey.getS3URI(),
                         String.format("%.2f", s3GetMsDuration),
                         range.getStart(),
                         range.getEnd(),
-                        enableTailMetadataCaching);
+                        enableTailMetadataCaching,
+                        range.getRangeType());
 
                     if (enableTailMetadataCaching && isTailMetadata(range) && Block.cache != null) {
                       String cacheKey = generateCacheKey();
@@ -269,11 +272,12 @@ public class Block implements Closeable {
                       double cacheSetMsDuration = cacheSetDuration / 1_000_000.0;
 
                       LOG.info(
-                          "Cached tail metadata: {}. Cache set took: {}ms, start = {}, end = {}.",
+                          "Cached tail metadata: {}. Cache set took: {}ms, start = {}, end = {}. RangeType: {}",
                           cacheKey,
                           String.format("%.2f", cacheSetMsDuration),
                           range.getStart(),
-                          range.getEnd());
+                          range.getEnd(),
+                          range.getRangeType());
                     }
 
                     return fetchedData;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -199,7 +199,14 @@ public class Block implements Closeable {
             }
           });
     } else {
-      generateSourceAndData();
+      try {
+        generateSourceAndData();
+        this.initialisationTask.complete(null);
+
+      } catch (IOException e) {
+        initialisationTask.completeExceptionally(e);
+        throw e;
+      }
     }
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -19,7 +19,6 @@ import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import lombok.Getter;
@@ -188,7 +187,7 @@ public class Block implements Closeable {
 
           long cacheGetStartTime = System.nanoTime();
 
-          byte[] cachedData = Block.cache.get(cacheKey.getBytes(StandardCharsets.UTF_8));
+          byte[] cachedData = Block.cache.get(cacheKey);
 
           long cacheGetDuration = System.nanoTime() - cacheGetStartTime;
           double cacheGetMsDuration = cacheGetDuration / 1_000_000.0;
@@ -260,7 +259,7 @@ public class Block implements Closeable {
 
                       long cacheSetStartTime = System.nanoTime();
 
-                      Block.cache.set(cacheKey.getBytes(StandardCharsets.UTF_8), fetchedData);
+                      Block.cache.set(cacheKey, fetchedData);
 
                       long cacheSetDuration = System.nanoTime() - cacheSetStartTime;
                       double cacheSetMsDuration = cacheSetDuration / 1_000_000.0;
@@ -435,5 +434,9 @@ public class Block implements Closeable {
    */
   private String generateCacheKey() {
     return objectKey.getS3URI() + "#" + objectKey.getEtag() + "#" + range;
+  }
+
+  static void resetCacheForTesting() {
+    cache = null;
   }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -210,6 +210,7 @@ public class BlockManager implements Closeable {
                     telemetry,
                     r.getStart(),
                     r.getEnd(),
+                    r.getRangeType(),
                     generation,
                     readMode,
                     this.configuration.getBlockReadTimeout(),

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -24,6 +24,7 @@ import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Operation;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
+import software.amazon.s3.analyticsaccelerator.io.physical.Cache;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.io.physical.prefetcher.SequentialPatternDetector;
 import software.amazon.s3.analyticsaccelerator.io.physical.prefetcher.SequentialReadProgression;
@@ -47,6 +48,7 @@ public class BlockManager implements Closeable {
   private final IOPlanner ioPlanner;
   private final PhysicalIOConfiguration configuration;
   private final RangeOptimiser rangeOptimiser;
+  private final Cache cache;
   private StreamContext streamContext;
 
   private static final String OPERATION_MAKE_RANGE_AVAILABLE = "block.manager.make.range.available";
@@ -61,12 +63,12 @@ public class BlockManager implements Closeable {
    * @param configuration the physicalIO configuration
    */
   public BlockManager(
-      @NonNull ObjectKey objectKey,
-      @NonNull ObjectClient objectClient,
-      @NonNull ObjectMetadata metadata,
-      @NonNull Telemetry telemetry,
-      @NonNull PhysicalIOConfiguration configuration) {
-    this(objectKey, objectClient, metadata, telemetry, configuration, null);
+          @NonNull ObjectKey objectKey,
+          @NonNull ObjectClient objectClient,
+          @NonNull ObjectMetadata metadata,
+          @NonNull Telemetry telemetry,
+          @NonNull PhysicalIOConfiguration configuration) {
+    this(objectKey, objectClient, metadata, telemetry, configuration, null, null);
   }
 
   /**
@@ -80,17 +82,19 @@ public class BlockManager implements Closeable {
    * @param streamContext contains audit headers to be attached in the request header
    */
   public BlockManager(
-      @NonNull ObjectKey objectKey,
-      @NonNull ObjectClient objectClient,
-      @NonNull ObjectMetadata metadata,
-      @NonNull Telemetry telemetry,
-      @NonNull PhysicalIOConfiguration configuration,
-      StreamContext streamContext) {
+          @NonNull ObjectKey objectKey,
+          @NonNull ObjectClient objectClient,
+          @NonNull ObjectMetadata metadata,
+          @NonNull Telemetry telemetry,
+          @NonNull PhysicalIOConfiguration configuration,
+          Cache cache,
+          StreamContext streamContext) {
     this.objectKey = objectKey;
     this.objectClient = objectClient;
     this.metadata = metadata;
     this.telemetry = telemetry;
     this.configuration = configuration;
+    this.cache = cache;
     this.blockStore = new BlockStore(objectKey, metadata);
     this.patternDetector = new SequentialPatternDetector(blockStore);
     this.sequentialReadProgression = new SequentialReadProgression(configuration);
@@ -153,7 +157,7 @@ public class BlockManager implements Closeable {
    * @throws IOException if an I/O error occurs
    */
   public synchronized void makeRangeAvailable(long pos, long len, ReadMode readMode)
-      throws IOException {
+          throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
 
@@ -173,9 +177,9 @@ public class BlockManager implements Closeable {
     if (readMode != ReadMode.ASYNC && patternDetector.isSequentialRead(pos)) {
       generation = patternDetector.getGeneration(pos);
       effectiveEnd =
-          Math.max(
-              effectiveEnd,
-              truncatePos(pos + sequentialReadProgression.getSizeForGeneration(generation)));
+              Math.max(
+                      effectiveEnd,
+                      truncatePos(pos + sequentialReadProgression.getSizeForGeneration(generation)));
     } else {
       generation = 0;
     }
@@ -183,36 +187,39 @@ public class BlockManager implements Closeable {
     // Fix "effectiveEnd", so we can pass it into the lambda
     final long effectiveEndFinal = effectiveEnd;
     this.telemetry.measureStandard(
-        () ->
-            Operation.builder()
-                .name(OPERATION_MAKE_RANGE_AVAILABLE)
-                .attribute(StreamAttributes.uri(this.objectKey.getS3URI()))
-                .attribute(StreamAttributes.etag(this.objectKey.getEtag()))
-                .attribute(StreamAttributes.range(pos, pos + len - 1))
-                .attribute(StreamAttributes.effectiveRange(pos, effectiveEndFinal))
-                .attribute(StreamAttributes.generation(generation))
-                .build(),
-        () -> {
-          // Determine the missing ranges and fetch them
-          List<Range> missingRanges =
-              ioPlanner.planRead(pos, effectiveEndFinal, getLastObjectByte());
-          List<Range> splits = rangeOptimiser.splitRanges(missingRanges);
-          for (Range r : splits) {
-            Block block =
-                new Block(
-                    objectKey,
-                    objectClient,
-                    telemetry,
-                    r.getStart(),
-                    r.getEnd(),
-                    generation,
-                    readMode,
-                    this.configuration.getBlockReadTimeout(),
-                    this.configuration.getBlockReadRetryCount(),
-                    streamContext);
-            blockStore.add(block);
-          }
-        });
+            () ->
+                    Operation.builder()
+                            .name(OPERATION_MAKE_RANGE_AVAILABLE)
+                            .attribute(StreamAttributes.uri(this.objectKey.getS3URI()))
+                            .attribute(StreamAttributes.etag(this.objectKey.getEtag()))
+                            .attribute(StreamAttributes.range(pos, pos + len - 1))
+                            .attribute(StreamAttributes.effectiveRange(pos, effectiveEndFinal))
+                            .attribute(StreamAttributes.generation(generation))
+                            .build(),
+            () -> {
+              // Determine the missing ranges and fetch them
+              List<Range> missingRanges =
+                      ioPlanner.planRead(pos, effectiveEndFinal, getLastObjectByte());
+              List<Range> splits = rangeOptimiser.splitRanges(missingRanges);
+              for (Range r : splits) {
+                Block block =
+                        new Block(
+                                objectKey,
+                                objectClient,
+                                telemetry,
+                                r.getStart(),
+                                r.getEnd(),
+                                generation,
+                                readMode,
+                                this.configuration.getBlockReadTimeout(),
+                                this.configuration.getBlockReadRetryCount(),
+                                metadata.getContentLength(),
+                                this.configuration.isEnableTailMetadataCaching(),
+                                cache,
+                                streamContext);
+                blockStore.add(block);
+              }
+            });
   }
 
   private long getLastObjectByte() {

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
-
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Operation;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -130,7 +130,7 @@ public class BlockManager implements Closeable {
       return;
     }
 
-    makeRangeAvailable(pos, 1, null, readMode);
+    makeRangeAvailable(pos, 1, RangeType.BLOCK, readMode);
   }
 
   private boolean isRangeAvailable(long pos, long len) throws IOException {

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.ExecutorService;
+
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Operation;
@@ -50,6 +52,7 @@ public class BlockManager implements Closeable {
   private final PhysicalIOConfiguration configuration;
   private final RangeOptimiser rangeOptimiser;
   private final Cache cache;
+  private final ExecutorService executorService;
   private StreamContext streamContext;
 
   private static final String OPERATION_MAKE_RANGE_AVAILABLE = "block.manager.make.range.available";
@@ -69,7 +72,7 @@ public class BlockManager implements Closeable {
       @NonNull ObjectMetadata metadata,
       @NonNull Telemetry telemetry,
       @NonNull PhysicalIOConfiguration configuration) {
-    this(objectKey, objectClient, metadata, telemetry, configuration, null, null);
+    this(objectKey, objectClient, metadata, telemetry, configuration, null, null, null);
   }
 
   /**
@@ -90,6 +93,7 @@ public class BlockManager implements Closeable {
       @NonNull Telemetry telemetry,
       @NonNull PhysicalIOConfiguration configuration,
       Cache cache,
+      ExecutorService executorService,
       StreamContext streamContext) {
     this.objectKey = objectKey;
     this.objectClient = objectClient;
@@ -97,6 +101,7 @@ public class BlockManager implements Closeable {
     this.telemetry = telemetry;
     this.configuration = configuration;
     this.cache = cache;
+    this.executorService = executorService;
     this.blockStore = new BlockStore(objectKey, metadata);
     this.patternDetector = new SequentialPatternDetector(blockStore);
     this.sequentialReadProgression = new SequentialReadProgression(configuration);
@@ -219,6 +224,7 @@ public class BlockManager implements Closeable {
                     metadata.getContentLength(),
                     this.configuration.isEnableTailMetadataCaching(),
                     cache,
+                    executorService,
                     streamContext);
             blockStore.add(block);
           }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlanner.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlanner.java
@@ -22,6 +22,7 @@ import java.util.OptionalLong;
 import lombok.NonNull;
 import software.amazon.s3.analyticsaccelerator.common.Preconditions;
 import software.amazon.s3.analyticsaccelerator.request.Range;
+import software.amazon.s3.analyticsaccelerator.util.RangeType;
 
 /**
  * Class responsible for implementing how to plan reads over a BlockStore. Today its main
@@ -49,7 +50,8 @@ public class IOPlanner {
    * @return a list of Ranges that need to be fetched
    * @throws IOException if an I/O error occurs
    */
-  public List<Range> planRead(long pos, long end, long lastObjectByte) throws IOException {
+  public List<Range> planRead(long pos, long end, RangeType rangeType, long lastObjectByte)
+      throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must be non-negative");
     Preconditions.checkArgument(pos <= end, "`pos` must be less than or equal to `end`");
     Preconditions.checkArgument(
@@ -70,7 +72,7 @@ public class IOPlanner {
         endOfRange = Math.min(end, lastObjectByte);
       }
 
-      missingRanges.add(new Range(nextMissingByte.getAsLong(), endOfRange));
+      missingRanges.add(new Range(nextMissingByte.getAsLong(), endOfRange, rangeType));
       nextMissingByte = blockStore.findNextMissingByte(endOfRange + 1);
     }
     return missingRanges;

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/RangeOptimiser.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/RangeOptimiser.java
@@ -20,6 +20,7 @@ import java.util.List;
 import lombok.Value;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.request.Range;
+import software.amazon.s3.analyticsaccelerator.util.RangeType;
 
 /**
  * RangeSplitter is responsible for splitting up big ranges into smaller reads. The need for such
@@ -44,7 +45,7 @@ public class RangeOptimiser {
     List<Range> splits = new LinkedList<>();
     for (Range range : ranges) {
       if (range.getLength() > configuration.getMaxRangeSizeBytes()) {
-        splitRange(range.getStart(), range.getEnd()).forEach(splits::add);
+        splitRange(range.getStart(), range.getEnd(), range.getRangeType()).forEach(splits::add);
       } else {
         splits.add(range);
       }
@@ -53,13 +54,13 @@ public class RangeOptimiser {
     return splits;
   }
 
-  private List<Range> splitRange(long start, long end) {
+  private List<Range> splitRange(long start, long end, RangeType rangeType) {
     long nextRangeStart = start;
     List<Range> generatedRanges = new LinkedList<>();
 
     while (nextRangeStart < end) {
       long rangeEnd = Math.min(nextRangeStart + configuration.getPartSizeBytes() - 1, end);
-      generatedRanges.add(new Range(nextRangeStart, rangeEnd));
+      generatedRanges.add(new Range(nextRangeStart, rangeEnd, rangeType));
       nextRangeStart = rangeEnd + 1;
     }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
@@ -89,4 +89,10 @@ public class ValkeyCacheImpl implements Cache {
       jedisCluster.close();
     }
   }
+
+  /** Closes the ElastiCache cache for benchmarking */
+  @Override
+  public void clearCache() {
+    jedisCluster.flushAll();
+  }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
@@ -34,6 +34,11 @@ public class ValkeyCacheImpl implements Cache {
      */
     public ValkeyCacheImpl(String endpoint) {
 
+        ConnectionPoolConfig config = new ConnectionPoolConfig();
+        config.setMaxTotal(64);
+        config.setMaxIdle(64);
+        config.setMinIdle(32);
+
         JedisClientConfig clientConfig = DefaultJedisClientConfig.builder().ssl(true).build();
         this.max_attempts = 5;
         this.jedisCluster =
@@ -41,8 +46,8 @@ public class ValkeyCacheImpl implements Cache {
                         new HostAndPort(endpoint, 6379),
                         clientConfig,
                         max_attempts,
-                        new ConnectionPoolConfig());
-
+                        config
+                );
     }
 
     /**

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
@@ -24,59 +24,54 @@ import software.amazon.s3.analyticsaccelerator.io.physical.Cache;
 
 /** A Valkey implementation of the Cache frontend */
 public class ValkeyCacheImpl implements Cache {
-    private final JedisCluster jedisCluster;
-    private final int max_attempts;
+  private final JedisCluster jedisCluster;
+  private final int max_attempts;
 
-    /**
-     * Construct a new instance of ValkeyCacheImpl.
-     *
-     * @param endpoint the ElastiCache endpoint of the serverless Valkey cache
-     */
-    public ValkeyCacheImpl(String endpoint) {
+  /**
+   * Construct a new instance of ValkeyCacheImpl.
+   *
+   * @param endpoint the ElastiCache endpoint of the serverless Valkey cache
+   */
+  public ValkeyCacheImpl(String endpoint) {
 
-        ConnectionPoolConfig config = new ConnectionPoolConfig();
-        config.setMaxTotal(64);
-        config.setMaxIdle(64);
-        config.setMinIdle(32);
+    ConnectionPoolConfig config = new ConnectionPoolConfig();
+    config.setMaxTotal(64);
+    config.setMaxIdle(64);
+    config.setMinIdle(32);
 
-        JedisClientConfig clientConfig = DefaultJedisClientConfig.builder().ssl(true).build();
-        this.max_attempts = 5;
-        this.jedisCluster =
-                new JedisCluster(
-                        new HostAndPort(endpoint, 6379),
-                        clientConfig,
-                        max_attempts,
-                        config
-                );
+    JedisClientConfig clientConfig = DefaultJedisClientConfig.builder().ssl(true).build();
+    this.max_attempts = 5;
+    this.jedisCluster =
+        new JedisCluster(new HostAndPort(endpoint, 6379), clientConfig, max_attempts, config);
+  }
+
+  /**
+   * Fetches the value from the Valkey ElastiCache given a key
+   *
+   * @param key the key to fetch from the Valkey ElastiCache
+   * @return the value associated with the key in the Valkey ElastiCache
+   */
+  @Override
+  public byte[] get(byte[] key) {
+    return jedisCluster.get(key);
+  }
+
+  /**
+   * Sets the value in the Valkey ElastiCache for a key, given that key and value
+   *
+   * @param key the key for which to set the value in the Valkey ElastiCache
+   * @param value the value to set in the Valkey ElastiCache for the given key
+   */
+  @Override
+  public void set(byte[] key, byte[] value) {
+    jedisCluster.set(key, value);
+  }
+
+  /** Closes the connection to the Valkey ElastiCache server */
+  @Override
+  public void close() {
+    if (jedisCluster != null) {
+      jedisCluster.close();
     }
-
-    /**
-     * Fetches the value from the Valkey ElastiCache given a key
-     *
-     * @param key the key to fetch from the Valkey ElastiCache
-     * @return the value associated with the key in the Valkey ElastiCache
-     */
-    @Override
-    public byte[] get(byte[] key) {
-        return jedisCluster.get(key);
-    }
-
-    /**
-     * Sets the value in the Valkey ElastiCache for a key, given that key and value
-     *
-     * @param key the key for which to set the value in the Valkey ElastiCache
-     * @param value the value to set in the Valkey ElastiCache for the given key
-     */
-    @Override
-    public void set(byte[] key, byte[] value) {
-        jedisCluster.set(key, value);
-    }
-
-    /** Closes the connection to the Valkey ElastiCache server */
-    @Override
-    public void close() {
-        if (jedisCluster != null) {
-            jedisCluster.close();
-        }
-    }
+  }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.io.physical.impl;
+
+import io.valkey.ConnectionPoolConfig;
+import io.valkey.DefaultJedisClientConfig;
+import io.valkey.HostAndPort;
+import io.valkey.JedisClientConfig;
+import io.valkey.JedisCluster;
+import software.amazon.s3.analyticsaccelerator.io.physical.Cache;
+
+/** A Valkey implementation of the Cache frontend */
+public class ValkeyCacheImpl implements Cache {
+    private final JedisCluster jedisCluster;
+    private final int max_attempts;
+
+    /**
+     * Construct a new instance of ValkeyCacheImpl.
+     *
+     * @param endpoint the ElastiCache endpoint of the serverless Valkey cache
+     */
+    public ValkeyCacheImpl(String endpoint) {
+
+        JedisClientConfig clientConfig = DefaultJedisClientConfig.builder().ssl(true).build();
+        this.max_attempts = 5;
+        this.jedisCluster =
+                new JedisCluster(
+                        new HostAndPort(endpoint, 6379),
+                        clientConfig,
+                        max_attempts,
+                        new ConnectionPoolConfig());
+
+    }
+
+    /**
+     * Fetches the value from the Valkey ElastiCache given a key
+     *
+     * @param key the key to fetch from the Valkey ElastiCache
+     * @return the value associated with the key in the Valkey ElastiCache
+     */
+    @Override
+    public byte[] get(byte[] key) {
+        return jedisCluster.get(key);
+    }
+
+    /**
+     * Sets the value in the Valkey ElastiCache for a key, given that key and value
+     *
+     * @param key the key for which to set the value in the Valkey ElastiCache
+     * @param value the value to set in the Valkey ElastiCache for the given key
+     */
+    @Override
+    public void set(byte[] key, byte[] value) {
+        jedisCluster.set(key, value);
+    }
+
+    /** Closes the connection to the Valkey ElastiCache server */
+    @Override
+    public void close() {
+        if (jedisCluster != null) {
+            jedisCluster.close();
+        }
+    }
+}

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImpl.java
@@ -60,8 +60,6 @@ public class ValkeyCacheImpl implements Cache {
     this.jedisCluster = jedisCluster;
   }
 
-
-
   /**
    * Fetches the value from the Valkey ElastiCache given a key
    *

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
@@ -72,6 +72,7 @@ public class PhysicalIOConfigurationTest {
             + "\tsequentialPrefetchBase: 2.0\n"
             + "\tsequentialPrefetchSpeed: 1.0\n"
             + "\tblockReadTimeout: 30000\n"
-            + "\tblockReadRetryCount: 20\n");
+            + "\tblockReadRetryCount: 20\n"
+            + "\tenableTailMetadataCaching: false\n");
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
@@ -149,8 +149,8 @@ public class BlobTest {
 
     // Then: correct ranges are submitted
     assertEquals(SUBMITTED, execution.getState());
-    verify(blockManager).makeRangeAvailable(0, 101, ReadMode.ASYNC);
-    verify(blockManager).makeRangeAvailable(999, 2, ReadMode.ASYNC);
+    verify(blockManager).makeRangeAvailable(0, 101, null, ReadMode.ASYNC);
+    verify(blockManager).makeRangeAvailable(999, 2, null, ReadMode.ASYNC);
   }
 
   @Test

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
@@ -168,7 +168,7 @@ public class BlockManagerTest {
     blockManager.makePositionAvailable(64 * ONE_KB + 1, ReadMode.SYNC);
 
     // When: requesting the byte at 64KB
-    blockManager.makeRangeAvailable(64 * ONE_KB, 100, ReadMode.SYNC);
+    blockManager.makeRangeAvailable(64 * ONE_KB, 100, null, ReadMode.SYNC);
     ArgumentCaptor<GetRequest> requestCaptor = ArgumentCaptor.forClass(GetRequest.class);
     verify(objectClient, times(3)).getObject(requestCaptor.capture(), any());
 
@@ -217,13 +217,13 @@ public class BlockManagerTest {
             objectClient,
             128 * ONE_MB,
             PhysicalIOConfiguration.builder().sequentialPrefetchBase(2.0).build());
-    blockManager.makeRangeAvailable(20_837_974, 8_323_072, ReadMode.SYNC);
-    blockManager.makeRangeAvailable(20_772_438, 65_536, ReadMode.SYNC);
-    blockManager.makeRangeAvailable(29_161_046, 4_194_305, ReadMode.SYNC);
-    blockManager.makeRangeAvailable(106_182_410, 1_048_576, ReadMode.SYNC);
+    blockManager.makeRangeAvailable(20_837_974, 8_323_072, null, ReadMode.SYNC);
+    blockManager.makeRangeAvailable(20_772_438, 65_536, null, ReadMode.SYNC);
+    blockManager.makeRangeAvailable(29_161_046, 4_194_305, null, ReadMode.SYNC);
+    blockManager.makeRangeAvailable(106_182_410, 1_048_576, null, ReadMode.SYNC);
 
     // When: [29161046 - 37549653] is requested
-    blockManager.makeRangeAvailable(29_161_046, 8_388_608, ReadMode.SYNC);
+    blockManager.makeRangeAvailable(29_161_046, 8_388_608, null, ReadMode.SYNC);
 
     // Then: position 33_355_351 should be available
     // This was throwing before, and it shouldn't, given that 33_355_351 is contained in [29161046 -

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -403,6 +403,4 @@ public class BlockTest {
 
     verify(mockCache).set(any(), any());
   }
-
-
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -116,8 +116,7 @@ public class BlockTest {
                 0,
                 ReadMode.SYNC,
                 DEFAULT_READ_TIMEOUT,
-                DEFAULT_READ_RETRY_COUNT,
-                null));
+                DEFAULT_READ_RETRY_COUNT));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -130,8 +129,7 @@ public class BlockTest {
                 0,
                 ReadMode.SYNC,
                 DEFAULT_READ_TIMEOUT,
-                DEFAULT_READ_RETRY_COUNT,
-                null));
+                DEFAULT_READ_RETRY_COUNT));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -144,8 +142,7 @@ public class BlockTest {
                 0,
                 ReadMode.SYNC,
                 DEFAULT_READ_TIMEOUT,
-                DEFAULT_READ_RETRY_COUNT,
-                null));
+                DEFAULT_READ_RETRY_COUNT));
     assertThrows(
         NullPointerException.class,
         () ->
@@ -158,8 +155,7 @@ public class BlockTest {
                 0,
                 null,
                 DEFAULT_READ_TIMEOUT,
-                DEFAULT_READ_RETRY_COUNT,
-                null));
+                DEFAULT_READ_RETRY_COUNT));
   }
 
   @Test
@@ -178,8 +174,7 @@ public class BlockTest {
                 0,
                 ReadMode.SYNC,
                 DEFAULT_READ_TIMEOUT,
-                DEFAULT_READ_RETRY_COUNT,
-                null));
+                DEFAULT_READ_RETRY_COUNT));
     assertThrows(
         IllegalArgumentException.class,
         () ->
@@ -192,8 +187,7 @@ public class BlockTest {
                 0,
                 ReadMode.SYNC,
                 DEFAULT_READ_TIMEOUT,
-                DEFAULT_READ_RETRY_COUNT,
-                null));
+                DEFAULT_READ_RETRY_COUNT));
     assertThrows(
         IllegalArgumentException.class,
         () ->
@@ -232,8 +226,7 @@ public class BlockTest {
                 TEST_DATA.length(),
                 ReadMode.SYNC,
                 DEFAULT_READ_TIMEOUT,
-                DEFAULT_READ_RETRY_COUNT,
-                null));
+                DEFAULT_READ_RETRY_COUNT));
   }
 
   @SneakyThrows

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -357,6 +357,7 @@ public class BlockTest {
             0,
             true,
             mockCache,
+            null,
             null);
 
     byte[] buffer = new byte[TEST_DATA.length()];
@@ -395,6 +396,7 @@ public class BlockTest {
             0,
             true,
             mockCache,
+            null,
             null);
 
     byte[] buffer = new byte[TEST_DATA.length()];
@@ -430,6 +432,7 @@ public class BlockTest {
             0,
             false,
             mockCache,
+            null,
             null);
 
     byte[] buffer = new byte[TEST_DATA.length()];
@@ -464,6 +467,7 @@ public class BlockTest {
             0,
             true,
             mockCache,
+            null,
             null);
 
     byte[] buffer = new byte[TEST_DATA.length()];
@@ -500,6 +504,7 @@ public class BlockTest {
             contentLength,
             true,
             mockCache,
+            null,
             null);
 
     byte[] buffer = new byte[TEST_DATA.length()];

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -478,41 +478,4 @@ public class BlockTest {
     verify(mockCache, never()).get(any(String.class));
     verify(mockCache, never()).set(any(String.class), any(byte[].class));
   }
-
-  @Test
-  void testNonMetadataBlockDoesNotUseCache() throws IOException {
-    Block.resetCacheForTesting();
-
-    String TEST_DATA = "test-data";
-    ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
-    Cache mockCache = mock(Cache.class);
-
-    long contentLength = 16 * 1024 * 1024 + 1;
-
-    Block block =
-        new Block(
-            objectKey,
-            fakeObjectClient,
-            TestTelemetry.DEFAULT,
-            0,
-            TEST_DATA.length(),
-            RangeType.FOOTER_METADATA,
-            0,
-            ReadMode.SYNC,
-            DEFAULT_READ_TIMEOUT,
-            DEFAULT_READ_RETRY_COUNT,
-            contentLength,
-            true,
-            mockCache,
-            null,
-            null);
-
-    byte[] buffer = new byte[TEST_DATA.length()];
-    block.read(buffer, 0, buffer.length, 0);
-
-    assertEquals(TEST_DATA, new String(buffer, StandardCharsets.UTF_8));
-
-    verify(mockCache, never()).get(any());
-    verify(mockCache, never()).set(any(), any());
-  }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
@@ -53,9 +53,9 @@ public class IOPlannerTest {
     BlockStore blockStore = new BlockStore(objectKey, mockMetadataStore);
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
-    assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(-5, 10, 100));
-    assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(10, 5, 100));
-    assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(5, 5, 2));
+    assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(-5, 10, null, 100));
+    assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(10, 5, null, 100));
+    assertThrows(IllegalArgumentException.class, () -> ioPlanner.planRead(5, 5, null, 2));
   }
 
   @Test
@@ -68,7 +68,7 @@ public class IOPlannerTest {
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     // When: a read plan is requested for a range
-    List<Range> missingRanges = ioPlanner.planRead(10, 100, OBJECT_SIZE - 1);
+    List<Range> missingRanges = ioPlanner.planRead(10, 100, null, OBJECT_SIZE - 1);
 
     // Then: it just falls through
     List<Range> expected = new LinkedList<>();
@@ -101,7 +101,7 @@ public class IOPlannerTest {
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     // When: a read plan is requested for a range (0, 400)
-    List<Range> missingRanges = ioPlanner.planRead(0, 400, OBJECT_SIZE - 1);
+    List<Range> missingRanges = ioPlanner.planRead(0, 400, null, OBJECT_SIZE - 1);
 
     // Then: we only request (0, 99) and (201, 400)
     List<Range> expected = new LinkedList<>();
@@ -121,7 +121,7 @@ public class IOPlannerTest {
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     // When: a read plan is requested for a range (0, 400)
-    List<Range> missingRanges = ioPlanner.planRead(0, 400, OBJECT_SIZE - 1);
+    List<Range> missingRanges = ioPlanner.planRead(0, 400, null, OBJECT_SIZE - 1);
 
     // Then: we request the single byte range (0, 0)
     List<Range> expected = new LinkedList<>();

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImplTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.io.physical.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.valkey.JedisCluster;
+import io.valkey.exceptions.JedisException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+@SuppressFBWarnings(
+    value = "NP_NONNULL_PARAM_VIOLATION",
+    justification = "We mean to pass nulls to checks")
+public class ValkeyCacheImplTest {
+
+  @Test
+  void testConstructorThrowsOnNullArgument() {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new ValkeyCacheImpl((String) null);
+        });
+  }
+
+  @Test
+  void testConstructorHandlesInvalidEndpoint() {
+    final String TEST_ENDPOINT = "test-endpoint";
+
+    assertThrows(JedisException.class, () -> new ValkeyCacheImpl(TEST_ENDPOINT));
+  }
+
+
+  @Test
+  void testGetSuccessful() {
+    JedisCluster mockCluster = mock(JedisCluster.class);
+
+    final String TEST_KEY = "test-key";
+    final byte[] TEST_KEY_BYTES = TEST_KEY.getBytes(StandardCharsets.UTF_8);
+
+    final String TEST_VALUE = "test-value";
+    final byte[] TEST_VALUE_BYTES = TEST_VALUE.getBytes(StandardCharsets.UTF_8);
+
+    when(mockCluster.get(TEST_KEY_BYTES)).thenReturn(TEST_VALUE_BYTES);
+
+    ValkeyCacheImpl cache = new ValkeyCacheImpl(mockCluster);
+    byte[] result = cache.get(TEST_KEY);
+
+    assertArrayEquals(TEST_VALUE_BYTES, result);
+    verify(mockCluster).get(TEST_KEY_BYTES);
+  }
+
+  @Test
+  void testSetSuccessful() {
+    JedisCluster mockCluster = mock(JedisCluster.class);
+
+    final String TEST_KEY = "test-key";
+    final byte[] TEST_KEY_BYTES = TEST_KEY.getBytes(StandardCharsets.UTF_8);
+
+    final String TEST_VALUE = "test-value";
+    final byte[] TEST_VALUE_BYTES = TEST_VALUE.getBytes(StandardCharsets.UTF_8);
+
+    ValkeyCacheImpl cache = new ValkeyCacheImpl(mockCluster);
+    cache.set(TEST_KEY, TEST_VALUE_BYTES);
+
+    verify(mockCluster).set(TEST_KEY_BYTES, TEST_VALUE_BYTES);
+  }
+
+  @Test
+  void testCloseSuccessful() {
+    JedisCluster mockCluster = mock(JedisCluster.class);
+
+    ValkeyCacheImpl cache = new ValkeyCacheImpl(mockCluster);
+
+    cache.close();
+
+    verify(mockCluster, times(1)).close();
+  }
+}

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/ValkeyCacheImplTest.java
@@ -45,7 +45,6 @@ public class ValkeyCacheImplTest {
     assertThrows(JedisException.class, () -> new ValkeyCacheImpl(TEST_ENDPOINT));
   }
 
-
   @Test
   void testGetSuccessful() {
     JedisCluster mockCluster = mock(JedisCluster.class);

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/UserAgent.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/UserAgent.java
@@ -31,7 +31,7 @@ public final class UserAgent {
    */
   private static final String UA_DENYLIST_REGEX = "[() ,/:;<=>?@\\[\\]{}\\\\]";
 
-  private String userAgent = UA_STRING + "/" + VERSION_INFO;
+  private String userAgent = UA_STRING + "/" + VERSION_INFO + "/" + "sharedCache";
 
   /**
    * Prepend hard-coded user-agent string with input string provided.


### PR DESCRIPTION
## Description of change
<!-- Thank you for submitting a pull request!-->
<!-- Please describe your contribution here. What and why? -->
<!-- Please ensure your commit messages follow these [guidelines](https://chris.beams.io/posts/git-commit/). -->
Implements integration with Valkey ElastiCache in order to cache repeated calls to S3 for parquet file metadata.

TODO: Add metrics to track cache hits / misses and actual savings compared to S3.

#### Relevant issues
<!-- Please add issue numbers. -->
<!-- Please also link them to this PR. -->

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
<!-- Please explain why this was necessary. -->

No

#### Does this contribution introduce any new public APIs or behaviors?
<!-- Please describe them and explain what scenarios they target.  -->

No

#### How was the contribution tested?
<!-- Please describe how this contribution was tested. -->

Unit tests and by running internal benchmarks

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).