### PR TITLE
auditing - initial changes

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/StreamAuditContext.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/StreamAuditContext.java
@@ -31,7 +31,7 @@ import lombok.Getter;
  */
 @Builder(access = AccessLevel.PUBLIC)
 @Getter
-public class StreamContext {
+public class StreamAuditContext {
   private final String spanId;
   private final String operationName;
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/StreamContext.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/StreamContext.java
@@ -14,41 +14,23 @@
  * limitations under the License.
  */
 package software.amazon.s3.analyticsaccelerator.request;
-/**
- * The StreamContext interface provides methods for modifying and building referrer header which
- * will then be attached to subsequent HTTP requests.
- */
-public interface StreamContext {
 
-  /**
-   * Modifies and builds the referrer header string for a given request context.
-   *
-   * <p>Implementation Note: To ensure thread safety, implementations should create and modify a
-   * copy of the internal state rather than modifying the original object directly. This is crucial
-   * as multiple threads may be accessing the same StreamContext instance concurrently.
-   *
-   * <p>Example implementation:
-   *
-   * <pre>
-   * public class S3AStreamContext implements StreamContext {
-   *     private final HttpReferrerAuditHeader referrer;
-   *
-   *     public S3AStreamContext(HttpReferrerAuditHeader referrer) {
-   *         this.referrer = referrer;
-   *     }
-   *
-   *     &#64;Override
-   *     public String modifyAndBuildReferrerHeader(GetRequest getRequestContext) {
-   *         // Create a copy to ensure thread safety
-   *         HttpReferrerAuditHeader copyReferrer = new HttpReferrerAuditHeader(this.referrer);
-   *         copyReferrer.set(AuditConstants.PARAM_RANGE, getRequestContext.getRange().toHttpString());
-   *         return copyReferrer.buildHttpReferrer();
-   *     }
-   * }
-   * </pre>
-   *
-   * @param getRequestContext the request context for building the referrer header
-   * @return the modified and built referrer header as a String
-   */
-  public String modifyAndBuildReferrerHeader(GetRequest getRequestContext);
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * This is a class to contain any stream specific information, such as what is the higher level operation that this
+ * stream belongs to? Useful for the integration with S3A, it allows S3A to pass in the spanId and
+ * operation name with which a stream is opened. This is used by S3A's audit logging, which is of the form
+ * "3eb3c657-3e59-4f20-b484-e215c90c49f2-00000011 Executing op_open with {action_http_head_request....", where
+ * 3eb3c657-3e59-4f20-b484-e215c90c49f2-00000011 is the span_id for the open() operation, and ` op_open` is the
+ * operation name. See <a href="https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/auditing.md">...</a>
+ * for more details.
+ */
+@Builder(access = AccessLevel.PUBLIC)
+@Getter
+public class StreamContext {
+  private final String spanId;
+  private final String operationName;
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/StreamContext.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/StreamContext.java
@@ -20,12 +20,13 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * This is a class to contain any stream specific information, such as what is the higher level operation that this
- * stream belongs to? Useful for the integration with S3A, it allows S3A to pass in the spanId and
- * operation name with which a stream is opened. This is used by S3A's audit logging, which is of the form
- * "3eb3c657-3e59-4f20-b484-e215c90c49f2-00000011 Executing op_open with {action_http_head_request....", where
- * 3eb3c657-3e59-4f20-b484-e215c90c49f2-00000011 is the span_id for the open() operation, and ` op_open` is the
- * operation name. See <a href="https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/auditing.md">...</a>
+ * This is a class to contain any stream specific information, such as what is the higher level
+ * operation that this stream belongs to? Useful for the integration with S3A, it allows S3A to pass
+ * in the spanId and operation name with which a stream is opened. This is used by S3A's audit
+ * logging, which is of the form "3eb3c657-3e59-4f20-b484-e215c90c49f2-00000011 Executing op_open
+ * with {action_http_head_request....", where 3eb3c657-3e59-4f20-b484-e215c90c49f2-00000011 is the
+ * span_id for the open() operation, and ` op_open` is the operation name. See <a
+ * href="https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/site/markdown/tools/hadoop-aws/auditing.md">...</a>
  * for more details.
  */
 @Builder(access = AccessLevel.PUBLIC)

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/OpenStreamInformation.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/util/OpenStreamInformation.java
@@ -19,7 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
-import software.amazon.s3.analyticsaccelerator.request.StreamContext;
+import software.amazon.s3.analyticsaccelerator.request.StreamAuditContext;
 
 /**
  * Open stream information, useful for allowing the stream opening application to pass down known
@@ -38,7 +38,7 @@ import software.amazon.s3.analyticsaccelerator.request.StreamContext;
 @Builder(access = AccessLevel.PUBLIC)
 @Getter
 public class OpenStreamInformation {
-  private final StreamContext streamContext;
+  private final StreamAuditContext streamAuditContext;
   private final ObjectMetadata objectMetadata;
   private final InputPolicy inputPolicy;
 

--- a/common/src/test/java/software/amazon/s3/analyticsaccelerator/util/OpenStreamInformationTest.java
+++ b/common/src/test/java/software/amazon/s3/analyticsaccelerator/util/OpenStreamInformationTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
-import software.amazon.s3.analyticsaccelerator.request.StreamContext;
+import software.amazon.s3.analyticsaccelerator.request.StreamAuditContext;
 
 public class OpenStreamInformationTest {
 
@@ -29,41 +29,41 @@ public class OpenStreamInformationTest {
     OpenStreamInformation info = OpenStreamInformation.DEFAULT;
 
     assertNotNull(info, "Default instance should not be null");
-    assertNull(info.getStreamContext(), "Default streamContext should be null");
+    assertNull(info.getStreamAuditContext(), "Default streamContext should be null");
     assertNull(info.getObjectMetadata(), "Default objectMetadata should be null");
     assertNull(info.getInputPolicy(), "Default inputPolicy should be null");
   }
 
   @Test
   public void testBuilderWithAllFields() {
-    StreamContext mockContext = Mockito.mock(StreamContext.class);
+    StreamAuditContext mockContext = Mockito.mock(StreamAuditContext.class);
     ObjectMetadata mockMetadata = Mockito.mock(ObjectMetadata.class);
     InputPolicy mockPolicy = Mockito.mock(InputPolicy.class);
 
     OpenStreamInformation info =
         OpenStreamInformation.builder()
-            .streamContext(mockContext)
+            .streamAuditContext(mockContext)
             .objectMetadata(mockMetadata)
             .inputPolicy(mockPolicy)
             .build();
 
-    assertSame(mockContext, info.getStreamContext(), "StreamContext should match");
+    assertSame(mockContext, info.getStreamAuditContext(), "StreamContext should match");
     assertSame(mockMetadata, info.getObjectMetadata(), "ObjectMetadata should match");
     assertSame(mockPolicy, info.getInputPolicy(), "InputPolicy should match");
   }
 
   @Test
   public void testBuilderWithPartialFields() {
-    StreamContext mockContext = Mockito.mock(StreamContext.class);
+    StreamAuditContext mockContext = Mockito.mock(StreamAuditContext.class);
     ObjectMetadata mockMetadata = Mockito.mock(ObjectMetadata.class);
 
     OpenStreamInformation info =
         OpenStreamInformation.builder()
-            .streamContext(mockContext)
+            .streamAuditContext(mockContext)
             .objectMetadata(mockMetadata)
             .build();
 
-    assertSame(mockContext, info.getStreamContext(), "StreamContext should match");
+    assertSame(mockContext, info.getStreamAuditContext(), "StreamContext should match");
     assertSame(mockMetadata, info.getObjectMetadata(), "ObjectMetadata should match");
     assertNull(info.getInputPolicy(), "InputPolicy should be null");
   }
@@ -71,21 +71,21 @@ public class OpenStreamInformationTest {
   @Test
   public void testBuilderFieldRetention() {
     // Create mocks
-    StreamContext mockContext = Mockito.mock(StreamContext.class);
+    StreamAuditContext mockContext = Mockito.mock(StreamAuditContext.class);
     ObjectMetadata mockMetadata = Mockito.mock(ObjectMetadata.class);
     InputPolicy mockPolicy = Mockito.mock(InputPolicy.class);
 
     // Build object
     OpenStreamInformation info =
         OpenStreamInformation.builder()
-            .streamContext(mockContext)
+            .streamAuditContext(mockContext)
             .objectMetadata(mockMetadata)
             .inputPolicy(mockPolicy)
             .build();
 
     // Verify field retention
     assertNotNull(info, "Built object should not be null");
-    assertNotNull(info.getStreamContext(), "StreamContext should be retained");
+    assertNotNull(info.getStreamAuditContext(), "StreamContext should be retained");
     assertNotNull(info.getObjectMetadata(), "ObjectMetadata should be retained");
     assertNotNull(info.getInputPolicy(), "InputPolicy should be retained");
   }
@@ -94,12 +94,12 @@ public class OpenStreamInformationTest {
   public void testNullFields() {
     OpenStreamInformation info =
         OpenStreamInformation.builder()
-            .streamContext(null)
+            .streamAuditContext(null)
             .objectMetadata(null)
             .inputPolicy(null)
             .build();
 
-    assertNull(info.getStreamContext(), "StreamContext should be null");
+    assertNull(info.getStreamAuditContext(), "StreamContext should be null");
     assertNull(info.getObjectMetadata(), "ObjectMetadata should be null");
     assertNull(info.getInputPolicy(), "InputPolicy should be null");
   }

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
@@ -15,8 +15,10 @@
  */
 package software.amazon.s3.analyticsaccelerator;
 
-import static software.amazon.s3.analyticsaccelerator.request.RequestAttributes.OPERATION_NAME;
-import static software.amazon.s3.analyticsaccelerator.request.RequestAttributes.SPAN_ID;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.HEADER_REFERER;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.HEADER_USER_AGENT;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.OPERATION_NAME;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.SPAN_ID;
 
 import java.io.UncheckedIOException;
 import java.util.Optional;
@@ -40,9 +42,7 @@ import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 /** Object client, based on AWS SDK v2 */
-public class S3SdkObjectClient implements ObjectClient {
-  private static final String HEADER_USER_AGENT = "User-Agent";
-  private static final String HEADER_REFERER = "Referer";
+public class S3SdkObjectClient implements ObjectClient {;
 
   @Getter @NonNull private final S3AsyncClient s3AsyncClient;
   @NonNull private final Telemetry telemetry;
@@ -125,9 +125,9 @@ public class S3SdkObjectClient implements ObjectClient {
 
     requestOverrideConfigurationBuilder.putHeader(HEADER_USER_AGENT, this.userAgent.getUserAgent());
 
-    if (openStreamInformation.getStreamContext() != null) {
+    if (openStreamInformation.getStreamAuditContext() != null) {
       attachStreamContextToExecutionAttributes(
-          requestOverrideConfigurationBuilder, openStreamInformation.getStreamContext());
+          requestOverrideConfigurationBuilder, openStreamInformation.getStreamAuditContext());
     }
 
     builder.overrideConfiguration(requestOverrideConfigurationBuilder.build());
@@ -168,9 +168,9 @@ public class S3SdkObjectClient implements ObjectClient {
             .putHeader(HEADER_REFERER, getRequest.getReferrer().toString())
             .putHeader(HEADER_USER_AGENT, this.userAgent.getUserAgent());
 
-    if (openStreamInformation.getStreamContext() != null) {
+    if (openStreamInformation.getStreamAuditContext() != null) {
       attachStreamContextToExecutionAttributes(
-          requestOverrideConfigurationBuilder, openStreamInformation.getStreamContext());
+          requestOverrideConfigurationBuilder, openStreamInformation.getStreamAuditContext());
     }
 
     builder.overrideConfiguration(requestOverrideConfigurationBuilder.build());
@@ -205,9 +205,9 @@ public class S3SdkObjectClient implements ObjectClient {
 
   private void attachStreamContextToExecutionAttributes(
       AwsRequestOverrideConfiguration.Builder requestOverrideConfigurationBuilder,
-      StreamContext streamContext) {
+      StreamAuditContext streamAuditContext) {
     requestOverrideConfigurationBuilder
-        .putExecutionAttribute(SPAN_ID, streamContext.getSpanId())
-        .putExecutionAttribute(OPERATION_NAME, streamContext.getOperationName());
+        .putExecutionAttribute(SPAN_ID, streamAuditContext.getSpanId())
+        .putExecutionAttribute(OPERATION_NAME, streamAuditContext.getOperationName());
   }
 }

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
@@ -42,7 +42,7 @@ import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 /** Object client, based on AWS SDK v2 */
-public class S3SdkObjectClient implements ObjectClient {;
+public class S3SdkObjectClient implements ObjectClient {
 
   @Getter @NonNull private final S3AsyncClient s3AsyncClient;
   @NonNull private final Telemetry telemetry;

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/Constants.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/Constants.java
@@ -17,15 +17,17 @@ package software.amazon.s3.analyticsaccelerator.request;
 
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 
-/**
- * These execution attributes are specific to the hadoop S3A integration, and are required for S3A's
- * auditing feature. These execution attributes can be set per request, which are then picked up by
- * execution interceptors in S3A. See S3A's LoggingAuditor for more usage.
- */
-public final class RequestAttributes {
-  /** Prevent instantiation, this is meant to be a facade */
-  private RequestAttributes() {}
+public final class Constants {
+  private Constants() {}
 
+  public static final String HEADER_USER_AGENT = "User-Agent";
+  public static final String HEADER_REFERER = "Referer";
+
+  //  These execution attributes are specific to the hadoop S3A integration, and are required for
+  // S3A's
+  //   auditing feature. These execution attributes can be set per request, which are then picked up
+  // by
+  //   execution interceptors in S3A. See S3A's LoggingAuditor for more usage.
   public static final ExecutionAttribute<String> SPAN_ID = new ExecutionAttribute<>("span");
   public static final ExecutionAttribute<String> OPERATION_NAME =
       new ExecutionAttribute<>("operation");

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/Constants.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/Constants.java
@@ -17,17 +17,17 @@ package software.amazon.s3.analyticsaccelerator.request;
 
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 
+/** Class for request related constants. */
 public final class Constants {
   private Constants() {}
 
   public static final String HEADER_USER_AGENT = "User-Agent";
   public static final String HEADER_REFERER = "Referer";
 
-  //  These execution attributes are specific to the hadoop S3A integration, and are required for
-  // S3A's
-  //   auditing feature. These execution attributes can be set per request, which are then picked up
-  // by
-  //   execution interceptors in S3A. See S3A's LoggingAuditor for more usage.
+  // These execution attributes are specific to the hadoop S3A integration, and are required for
+  // S3A's auditing feature. These execution attributes can be set per request, which are then
+  // picked up
+  // by execution interceptors in S3A. See S3A's LoggingAuditor for usage.
   public static final ExecutionAttribute<String> SPAN_ID = new ExecutionAttribute<>("span");
   public static final ExecutionAttribute<String> OPERATION_NAME =
       new ExecutionAttribute<>("operation");

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/RequestAttributes.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/RequestAttributes.java
@@ -18,12 +18,12 @@ package software.amazon.s3.analyticsaccelerator.request;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 
 /**
- * These execution attributes are specific to the hadoop S3A integration, and are required for S3A's auditing feature.
- * These execution attributes can be set per request, which are then picked up by execution interceptors in S3A.
- * See S3A's LoggingAuditor for more usage.
+ * These execution attributes are specific to the hadoop S3A integration, and are required for S3A's
+ * auditing feature. These execution attributes can be set per request, which are then picked up by
+ * execution interceptors in S3A. See S3A's LoggingAuditor for more usage.
  */
-public class RequestAttributes
-{
-    public static final ExecutionAttribute<String> SPAN_ID  = new ExecutionAttribute<>("span");
-    public static final ExecutionAttribute<String> OPERATION_NAME  = new ExecutionAttribute<>("operation");
+public class RequestAttributes {
+  public static final ExecutionAttribute<String> SPAN_ID = new ExecutionAttribute<>("span");
+  public static final ExecutionAttribute<String> OPERATION_NAME =
+      new ExecutionAttribute<>("operation");
 }

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/RequestAttributes.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/RequestAttributes.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.request;
+
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+
+/**
+ * These execution attributes are specific to the hadoop S3A integration, and are required for S3A's auditing feature.
+ * These execution attributes can be set per request, which are then picked up by execution interceptors in S3A.
+ * See S3A's LoggingAuditor for more usage.
+ */
+public class RequestAttributes
+{
+    public static final ExecutionAttribute<String> SPAN_ID  = new ExecutionAttribute<>("span");
+    public static final ExecutionAttribute<String> OPERATION_NAME  = new ExecutionAttribute<>("operation");
+}

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/RequestAttributes.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/request/RequestAttributes.java
@@ -22,7 +22,10 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
  * auditing feature. These execution attributes can be set per request, which are then picked up by
  * execution interceptors in S3A. See S3A's LoggingAuditor for more usage.
  */
-public class RequestAttributes {
+public final class RequestAttributes {
+  /** Prevent instantiation, this is meant to be a facade */
+  private RequestAttributes() {}
+
   public static final ExecutionAttribute<String> SPAN_ID = new ExecutionAttribute<>("span");
   public static final ExecutionAttribute<String> OPERATION_NAME =
       new ExecutionAttribute<>("operation");

--- a/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
+++ b/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
@@ -223,15 +223,27 @@ public class S3SdkObjectClientTest {
   }
 
   @Test
-  void testGetObjectWithAuditHeaders() {
+  void testObjectClientClose() {
+    try (S3AsyncClient s3AsyncClient = createMockClient()) {
+      try (S3SdkObjectClient client = new S3SdkObjectClient(s3AsyncClient)) {
+        client.headObject(
+            HeadRequest.builder().s3Uri(S3URI.of("bucket", "key")).build(),
+            OpenStreamInformation.DEFAULT);
+      }
+      verify(s3AsyncClient, times(1)).close();
+    }
+  }
+
+  @Test
+  void testGetObjectAttachesExecutionAttributes() {
     S3AsyncClient mockS3AsyncClient = createMockClient();
 
     S3SdkObjectClient client = new S3SdkObjectClient(mockS3AsyncClient);
 
-    OpenStreamInformation openStreamInformation = mock(OpenStreamInformation.class);
-    StreamContext mockStreamContext = mock(StreamContext.class);
-    when(openStreamInformation.getStreamContext()).thenReturn(mockStreamContext);
-    when(mockStreamContext.modifyAndBuildReferrerHeader(any())).thenReturn("audit-referrer-value");
+    OpenStreamInformation openStreamInformation =
+        OpenStreamInformation.builder()
+            .streamContext(StreamContext.builder().spanId("12345").operationName("op_open").build())
+            .build();
 
     GetRequest getRequest =
         GetRequest.builder()
@@ -255,26 +267,40 @@ public class S3SdkObjectClientTest {
 
     GetObjectRequest capturedRequest = requestCaptor.getValue();
     assertEquals(
-        "audit-referrer-value",
-        capturedRequest.overrideConfiguration().get().headers().get(HEADER_REFERER).get(0));
-    assertEquals(ETAG, capturedRequest.ifMatch());
+        "12345",
+        capturedRequest
+            .overrideConfiguration()
+            .get()
+            .executionAttributes()
+            .getAttributes()
+            .get(RequestAttributes.SPAN_ID));
+    assertEquals(
+        "op_open",
+        capturedRequest
+            .overrideConfiguration()
+            .get()
+            .executionAttributes()
+            .getAttributes()
+            .get(RequestAttributes.OPERATION_NAME));
   }
 
   @Test
-  void testGetObjectWithoutAuditHeaders() {
+  void testGetObjectDoesNotAttachExecutionAttributesWhenNotSet() {
     S3AsyncClient mockS3AsyncClient = createMockClient();
 
     S3SdkObjectClient client = new S3SdkObjectClient(mockS3AsyncClient);
+
+    OpenStreamInformation openStreamInformation = OpenStreamInformation.DEFAULT;
 
     GetRequest getRequest =
         GetRequest.builder()
             .s3Uri(S3URI.of("bucket", "key"))
             .range(new Range(0, 20))
             .etag(ETAG)
-            .referrer(new Referrer("original-referrer", ReadMode.SYNC))
+            .referrer(new Referrer("bytes=0-20", ReadMode.SYNC))
             .build();
 
-    client.getObject(getRequest, OpenStreamInformation.DEFAULT);
+    client.getObject(getRequest, openStreamInformation);
 
     ArgumentCaptor<GetObjectRequest> requestCaptor =
         ArgumentCaptor.forClass(GetObjectRequest.class);
@@ -288,22 +314,94 @@ public class S3SdkObjectClientTest {
 
     GetObjectRequest capturedRequest = requestCaptor.getValue();
     assertEquals(
-        "original-referrer,readMode=SYNC",
-        capturedRequest.overrideConfiguration().get().headers().get(HEADER_REFERER).get(0));
-
-    assertEquals(ETAG, capturedRequest.ifMatch());
+        null,
+        capturedRequest
+            .overrideConfiguration()
+            .get()
+            .executionAttributes()
+            .getAttributes()
+            .get(RequestAttributes.SPAN_ID));
+    assertEquals(
+        null,
+        capturedRequest
+            .overrideConfiguration()
+            .get()
+            .executionAttributes()
+            .getAttributes()
+            .get(RequestAttributes.OPERATION_NAME));
   }
 
   @Test
-  void testObjectClientClose() {
-    try (S3AsyncClient s3AsyncClient = createMockClient()) {
-      try (S3SdkObjectClient client = new S3SdkObjectClient(s3AsyncClient)) {
-        client.headObject(
-            HeadRequest.builder().s3Uri(S3URI.of("bucket", "key")).build(),
-            OpenStreamInformation.DEFAULT);
-      }
-      verify(s3AsyncClient, times(1)).close();
-    }
+  void testHeadObjectAttachesExecutionAttributes() {
+    S3AsyncClient mockS3AsyncClient = createMockClient();
+
+    S3SdkObjectClient client = new S3SdkObjectClient(mockS3AsyncClient);
+
+    OpenStreamInformation openStreamInformation =
+        OpenStreamInformation.builder()
+            .streamContext(StreamContext.builder().spanId("12345").operationName("op_open").build())
+            .build();
+
+    HeadRequest headRequest = HeadRequest.builder().s3Uri(S3URI.of("bucket", "key")).build();
+
+    client.headObject(headRequest, openStreamInformation);
+
+    ArgumentCaptor<HeadObjectRequest> requestCaptor =
+        ArgumentCaptor.forClass(HeadObjectRequest.class);
+    verify(mockS3AsyncClient).headObject(requestCaptor.capture());
+
+    HeadObjectRequest capturedRequest = requestCaptor.getValue();
+    assertEquals(
+        "12345",
+        capturedRequest
+            .overrideConfiguration()
+            .get()
+            .executionAttributes()
+            .getAttributes()
+            .get(RequestAttributes.SPAN_ID));
+    assertEquals(
+        "op_open",
+        capturedRequest
+            .overrideConfiguration()
+            .get()
+            .executionAttributes()
+            .getAttributes()
+            .get(RequestAttributes.OPERATION_NAME));
+  }
+
+  @Test
+  void testHeadObjectDoesNotAttachExecutionAttributesWhenNotSet() {
+    S3AsyncClient mockS3AsyncClient = createMockClient();
+
+    S3SdkObjectClient client = new S3SdkObjectClient(mockS3AsyncClient);
+
+    OpenStreamInformation openStreamInformation = OpenStreamInformation.DEFAULT;
+
+    HeadRequest headRequest = HeadRequest.builder().s3Uri(S3URI.of("bucket", "key")).build();
+
+    client.headObject(headRequest, openStreamInformation);
+
+    ArgumentCaptor<HeadObjectRequest> requestCaptor =
+        ArgumentCaptor.forClass(HeadObjectRequest.class);
+    verify(mockS3AsyncClient).headObject(requestCaptor.capture());
+
+    HeadObjectRequest capturedRequest = requestCaptor.getValue();
+    assertEquals(
+        null,
+        capturedRequest
+            .overrideConfiguration()
+            .get()
+            .executionAttributes()
+            .getAttributes()
+            .get(RequestAttributes.SPAN_ID));
+    assertEquals(
+        null,
+        capturedRequest
+            .overrideConfiguration()
+            .get()
+            .executionAttributes()
+            .getAttributes()
+            .get(RequestAttributes.OPERATION_NAME));
   }
 
   @SuppressWarnings("unchecked")

--- a/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
+++ b/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
@@ -242,7 +242,8 @@ public class S3SdkObjectClientTest {
 
     OpenStreamInformation openStreamInformation =
         OpenStreamInformation.builder()
-            .streamContext(StreamContext.builder().spanId("12345").operationName("op_open").build())
+            .streamAuditContext(
+                StreamAuditContext.builder().spanId("12345").operationName("op_open").build())
             .build();
 
     GetRequest getRequest =
@@ -339,7 +340,8 @@ public class S3SdkObjectClientTest {
 
     OpenStreamInformation openStreamInformation =
         OpenStreamInformation.builder()
-            .streamContext(StreamContext.builder().spanId("12345").operationName("op_open").build())
+            .streamAuditContext(
+                StreamAuditContext.builder().spanId("12345").operationName("op_open").build())
             .build();
 
     HeadRequest headRequest = HeadRequest.builder().s3Uri(S3URI.of("bucket", "key")).build();

--- a/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
+++ b/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClientTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.OPERATION_NAME;
+import static software.amazon.s3.analyticsaccelerator.request.Constants.SPAN_ID;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
@@ -274,7 +276,7 @@ public class S3SdkObjectClientTest {
             .get()
             .executionAttributes()
             .getAttributes()
-            .get(RequestAttributes.SPAN_ID));
+            .get(SPAN_ID));
     assertEquals(
         "op_open",
         capturedRequest
@@ -282,7 +284,7 @@ public class S3SdkObjectClientTest {
             .get()
             .executionAttributes()
             .getAttributes()
-            .get(RequestAttributes.OPERATION_NAME));
+            .get(OPERATION_NAME));
   }
 
   @Test
@@ -321,7 +323,7 @@ public class S3SdkObjectClientTest {
             .get()
             .executionAttributes()
             .getAttributes()
-            .get(RequestAttributes.SPAN_ID));
+            .get(SPAN_ID));
     assertEquals(
         null,
         capturedRequest
@@ -329,7 +331,7 @@ public class S3SdkObjectClientTest {
             .get()
             .executionAttributes()
             .getAttributes()
-            .get(RequestAttributes.OPERATION_NAME));
+            .get(OPERATION_NAME));
   }
 
   @Test
@@ -360,7 +362,7 @@ public class S3SdkObjectClientTest {
             .get()
             .executionAttributes()
             .getAttributes()
-            .get(RequestAttributes.SPAN_ID));
+            .get(SPAN_ID));
     assertEquals(
         "op_open",
         capturedRequest
@@ -368,7 +370,7 @@ public class S3SdkObjectClientTest {
             .get()
             .executionAttributes()
             .getAttributes()
-            .get(RequestAttributes.OPERATION_NAME));
+            .get(OPERATION_NAME));
   }
 
   @Test
@@ -395,7 +397,7 @@ public class S3SdkObjectClientTest {
             .get()
             .executionAttributes()
             .getAttributes()
-            .get(RequestAttributes.SPAN_ID));
+            .get(SPAN_ID));
     assertEquals(
         null,
         capturedRequest
@@ -403,7 +405,7 @@ public class S3SdkObjectClientTest {
             .get()
             .executionAttributes()
             .getAttributes()
-            .get(RequestAttributes.OPERATION_NAME));
+            .get(OPERATION_NAME));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Description of change

S3A PR: https://github.com/apache/hadoop/pull/7723/

Use executionAttributes to attach the correct span to each get request made for a stream. 


S3A generates a `span_id` for each operation. For example, when a stream to an object is opened in S3A's `executeOpen()`, a span_id is generated for this operation. The `executeOpen()` operation is also given the name `op_open`. 

This `span_id` is then used to log any S3 requests that happened for the operation in S3A's LoggingAuditor. For example, for an `executeOpen()`, there can be a HEAD request, and a GET request, and these show up in the logs as:

```
84ca7693-a471-4564-a6b9-70b6424548c4-00000009 Executing op_open with {action_http_head_request 'raw/2023/017/ohfh/OHFH017d.23_.gz' size=0, mutating=false}; https://audit.example.org/hadoop/1/op_open/84ca7693-a471-4564-a6b9-70b6424548c4-00000009/?op=op_open&p1=raw/2023/017/ohfh/OHFH017d.23_.gz&pr=ahmarsu&ps=77e8a486-2538-4e00-8f75-dfc1b6ded83d&id=84ca7693-a471-4564-a6b9-70b6424548c4-00000009&t0=34&fs=84ca7693-a471-4564-a6b9-70b6424548c4&t1=34&ts=1748877163303


84ca7693-a471-4564-a6b9-70b6424548c4-00000009 Executing op_open with {action_http_get_request 'raw/2023/017/ohfh/OHFH017d.23_.gz' size=8388607, mutating=false}; https://audit.example.org/hadoop/1/initialize/84ca7693-a471-4564-a6b9-70b6424548c4-00000008/?op=initialize&p1=noaa-cors-pds&pr=ahmarsu&ps=77e8a486-2538-4e00-8f75-dfc1b6ded83d&rg=5-8388612&id=84ca7693-a471-4564-a6b9-70b6424548c4-00000008&t0=15&fs=84ca7693-a471-4564-a6b9-70b6424548c4&t1=15&ts=1748877163292
```

The `84ca7693-a471-4564-a6b9-70b6424548c4-00000009` is the span-id. From the above logs, we can decipher exactly what S3 requests were made per operation, which helps in debugging. 

Since the S3 GETs are now made in AAL, we must find a way to attach these back to the correct span and operation. This is done as follows:

* S3A passes in the `span_id` and `operation_name` of the stream. This `span_id` is generated at stream creation time. 
* When AAL makes a GET or a HEAD request, it attaches these values to the request via `ExecutionAttributes`.

S3A's LoggingAuditor will then be able to access these in it's ExecutionInterceptor, and use it for it's logging and building the referrer header. 


#### Relevant issues
<!-- Please add issue numbers. -->
<!-- Please also link them to this PR. -->

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
<!-- Please explain why this was necessary. -->

#### Does this contribution introduce any new public APIs or behaviors?
<!-- Please describe them and explain what scenarios they target.  -->

#### How was the contribution tested?
<!-- Please describe how this contribution was tested. -->

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).