### PR TITLE
Migration to Central Portal for Maven

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,11 @@ jobs:
 
     - name: Publish to Maven Central
       run: ./gradlew publish
+
+    - name: Notify Central Publisher Portal
+      run: |
+        curl -X POST \
+          "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${{ vars.MAVEN_GROUP_ID }}" \
+          -H "Authorization: Bearer $(aws secretsmanager get-secret-value --region ${{ vars.AWS_REGION }} --secret-id ${{ secrets.MAVEN_TOKEN_ID }} --query SecretString --output text | jq -r .bearer)" \
+          -H "Content-Type: application/json" \
+          --fail

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -376,7 +376,7 @@ publishing {
     repositories {
         maven {
             name = "sonatype"
-            url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
            credentials {
                username = findProperty("mavenUsername") as String? ?: ""
                password = findProperty("mavenPassword") as String? ?: ""


### PR DESCRIPTION
## Description of change
This PR makes the relevant changes to migrate maven publish to the [central portal](https://central.sonatype.com/account). Since we are depending on the `maven-publish` plugin, we also need to update our release-workflow to make a POST request to use UI for the next steps in release as mentioned [here](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#post-to-manualuploaddefaultrepositorynamespace).

#### Relevant issues
NA

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Manual Release 

#### Does this contribution need a changelog entry?
No

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).