### PR TITLE
[New Physical IO] Sequential Prefetching Implementation

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/DataBlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/DataBlockManager.java
@@ -193,8 +193,7 @@ public class DataBlockManager implements Closeable {
     return Math.min(pos, getLastObjectByte());
   }
 
-  private boolean isRangeAvailable(long pos, long len) {
-    long endPos = pos + len - 1;
+  private boolean isRangeAvailable(long pos, long endPos) {
     List<Integer> missingBlockIndexes = blockStore.getMissingBlockIndexesInRange(pos, endPos);
     return missingBlockIndexes.isEmpty();
   }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/RangeOptimiser.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/RangeOptimiser.java
@@ -15,6 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.Value;
@@ -64,5 +65,87 @@ public class RangeOptimiser {
     }
 
     return generatedRanges;
+  }
+
+  /**
+   * Groups sequential block indexes into separate lists, ensuring each group doesn't exceed the
+   * maximum block count. This method optimizes read operations by: 1. First grouping blocks by
+   * sequential indexes (blocks with consecutive numbers) 2. Then splitting any large sequential
+   * groups that exceed maxRangeBlocks into smaller chunks of partSizeBlocks
+   *
+   * <p>Example 1 - Basic sequential grouping: Input: [1,2,3,5,6,8,9,10] Output:
+   * [[1,2,3],[5,6],[8,9,10]] (Blocks are grouped by sequential indexes regardless of size limits)
+   *
+   * <p>Example 2 - Size-based splitting: Input: [1,2,3,4,5,6,7,8,9,10] With maxRangeBlocks=4 and
+   * partSizeBlocks=3: Output: [[1,2,3], [4,5,6], [7,8,9], [10]] (Since the sequential group exceeds
+   * maxRangeBlocks=4, it's split into chunks of partSizeBlocks=3)
+   *
+   * <p>Example 3 - Mixed sequential and size-based splitting: Input:
+   * [1,2,3,4,5,6,10,11,12,13,14,15,16,17] With maxRangeBlocks=3 and partSizeBlocks=2: Output:
+   * [[1,2], [3,4], [5,6], [10,11], [12,13], [14,15], [16,17]] (Each sequential group exceeds
+   * maxRangeBlocks=3, so each is split into chunks of partSizeBlocks=2)
+   *
+   * @param blockIndexes an ordered list of block indexes
+   * @param readBufferSize size of each block in bytes
+   * @return a list of lists where each inner list contains sequential block indexes within size
+   *     limits
+   */
+  public List<List<Integer>> optimizeReads(List<Integer> blockIndexes, long readBufferSize) {
+    List<List<Integer>> result = new ArrayList<>();
+    if (blockIndexes == null || blockIndexes.isEmpty()) {
+      return result;
+    }
+
+    // Calculate max blocks per read based on configuration values
+    int maxRangeBlocks = (int) (configuration.getMaxRangeSizeBytes() / readBufferSize);
+    int partSizeBlocks = (int) (configuration.getPartSizeBytes() / readBufferSize);
+
+    // Ensure at least one block per read
+    maxRangeBlocks = Math.max(1, maxRangeBlocks);
+    partSizeBlocks = Math.max(1, partSizeBlocks);
+
+    // First, group by sequential blocks
+    List<List<Integer>> sequentialGroups = new ArrayList<>();
+    List<Integer> currentSequence = new ArrayList<>();
+    currentSequence.add(blockIndexes.get(0));
+
+    for (int i = 1; i < blockIndexes.size(); i++) {
+      int current = blockIndexes.get(i);
+      int previous = blockIndexes.get(i - 1);
+
+      if (current == previous + 1) {
+        // Sequential index, add to current sequence
+        currentSequence.add(current);
+      } else {
+        // Non-sequential index, start a new sequence
+        sequentialGroups.add(currentSequence);
+        currentSequence = new ArrayList<>();
+        currentSequence.add(current);
+      }
+    }
+
+    // Add the last sequence if not empty
+    if (!currentSequence.isEmpty()) {
+      sequentialGroups.add(currentSequence);
+    }
+
+    // Now split each sequential group if it exceeds maxRangeBlocks
+    for (List<Integer> group : sequentialGroups) {
+      if (group.size() <= maxRangeBlocks) {
+        // Group is within size limit, add as is
+        result.add(group);
+      } else {
+        // Group exceeds size limit, split into partSizeBlocks chunks
+        for (int j = 0; j < group.size(); j += partSizeBlocks) {
+          List<Integer> chunk = new ArrayList<>();
+          for (int k = j; k < j + partSizeBlocks && k < group.size(); k++) {
+            chunk.add(group.get(k));
+          }
+          result.add(chunk);
+        }
+      }
+    }
+
+    return result;
   }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/RangeOptimiser.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/RangeOptimiser.java
@@ -136,10 +136,10 @@ public class RangeOptimiser {
         result.add(group);
       } else {
         // Group exceeds size limit, split into partSizeBlocks chunks
-        for (int j = 0; j < group.size(); j += partSizeBlocks) {
+        for (int i = 0; i < group.size(); i += partSizeBlocks) {
           List<Integer> chunk = new ArrayList<>();
-          for (int k = j; k < j + partSizeBlocks && k < group.size(); k++) {
-            chunk.add(group.get(k));
+          for (int j = i; j < i + partSizeBlocks && j < group.size(); j++) {
+            chunk.add(group.get(j));
           }
           result.add(chunk);
         }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/RangeOptimiserTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/RangeOptimiserTest.java
@@ -16,47 +16,231 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.util.LinkedList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.io.physical.PhysicalIOConfiguration;
 import software.amazon.s3.analyticsaccelerator.request.Range;
 
 public class RangeOptimiserTest {
 
-  @Test
-  public void test__splitRanges__smallRangesCauseNoSplit() {
-    // Given: small ranges
-    RangeOptimiser rangeOptimiser = new RangeOptimiser(PhysicalIOConfiguration.DEFAULT);
-    List<Range> ranges = new LinkedList<>();
-    ranges.add(new Range(0, 100));
-    ranges.add(new Range(200, 300));
-    ranges.add(new Range(300, 400));
-    ranges.add(new Range(400, 500));
+  private PhysicalIOConfiguration mockConfig;
+  private RangeOptimiser rangeOptimiser;
+  private static final long READ_BUFFER_SIZE = 1024;
+  private static final long MAX_RANGE_SIZE = 4 * READ_BUFFER_SIZE;
+  private static final long PART_SIZE = 3 * READ_BUFFER_SIZE;
 
-    // When: splitRanges is called
-    List<Range> splitRanges = rangeOptimiser.splitRanges(ranges);
+  @BeforeEach
+  void setUp() {
+    mockConfig = mock(PhysicalIOConfiguration.class);
+    when(mockConfig.getMaxRangeSizeBytes()).thenReturn(MAX_RANGE_SIZE);
+    when(mockConfig.getPartSizeBytes()).thenReturn(PART_SIZE);
 
-    // Then: nothing happens
-    assertEquals(ranges, splitRanges);
+    rangeOptimiser = new RangeOptimiser(mockConfig);
   }
 
   @Test
-  public void test__splitRanges__bigRangesResultInSplits() {
-    // Given: a 16MB range
-    RangeOptimiser rangeOptimiser = new RangeOptimiser(PhysicalIOConfiguration.DEFAULT);
-    List<Range> ranges = new LinkedList<>();
-    ranges.add(new Range(0, 16 * ONE_MB - 1));
+  public void testSplitRanges_noSplitNeeded() {
+    Range range = new Range(0, MAX_RANGE_SIZE - 1);
+    List<Range> ranges = Collections.singletonList(range);
 
-    // When: splitRanges is called
-    List<Range> splitRanges = rangeOptimiser.splitRanges(ranges);
+    List<Range> result = rangeOptimiser.splitRanges(ranges);
 
-    // Then: 16MB range is split into 4x4MB ranges
-    List<Range> expected = new LinkedList<>();
-    expected.add(new Range(0, 8 * ONE_MB - 1));
-    expected.add(new Range(8 * ONE_MB, 16 * ONE_MB - 1));
-    assertEquals(expected, splitRanges);
+    assertEquals(1, result.size(), "Range under max size should not be split");
+    assertEquals(range, result.get(0), "Range should remain unchanged");
+  }
+
+  @Test
+  public void testSplitRanges_splitNeeded() {
+    Range range = new Range(0, MAX_RANGE_SIZE + PART_SIZE);
+    List<Range> ranges = Collections.singletonList(range);
+
+    List<Range> result = rangeOptimiser.splitRanges(ranges);
+
+    assertEquals(
+        3, result.size(), "Range exceeding max size should be split into correct number of parts");
+    assertEquals(new Range(0, PART_SIZE - 1), result.get(0), "First part should match part size");
+    assertEquals(
+        new Range(PART_SIZE, 2 * PART_SIZE - 1),
+        result.get(1),
+        "Second part should match part size");
+    assertEquals(
+        new Range(2 * PART_SIZE, MAX_RANGE_SIZE + PART_SIZE),
+        result.get(2),
+        "Last part should contain remainder");
+  }
+
+  @Test
+  public void testOptimizeReads_emptyList() {
+    List<List<Integer>> result =
+        rangeOptimiser.optimizeReads(Collections.emptyList(), READ_BUFFER_SIZE);
+    assertTrue(result.isEmpty(), "Result should be empty for empty input");
+  }
+
+  @Test
+  public void testOptimizeReads_basicSequentialGrouping() {
+    // Example 1: Basic sequential grouping
+    List<Integer> input = Arrays.asList(1, 2, 3, 5, 6, 8, 9, 10);
+    List<List<Integer>> expected =
+        Arrays.asList(Arrays.asList(1, 2, 3), Arrays.asList(5, 6), Arrays.asList(8, 9, 10));
+
+    List<List<Integer>> result = rangeOptimiser.optimizeReads(input, READ_BUFFER_SIZE);
+
+    assertEquals(expected.size(), result.size(), "Should have the same number of groups");
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(expected.get(i), result.get(i), "Group " + i + " should match");
+    }
+  }
+
+  @Test
+  public void testOptimizeReads_sizeSplitting() {
+    // Example 2: Size-based splitting
+    List<Integer> input = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+    // With maxRangeBlocks=4 and partSizeBlocks=3
+    // Expected: [[1,2,3], [4,5,6], [7,8,9], [10]]
+    List<List<Integer>> expected =
+        Arrays.asList(
+            Arrays.asList(1, 2, 3),
+            Arrays.asList(4, 5, 6),
+            Arrays.asList(7, 8, 9),
+            Arrays.asList(10));
+
+    List<List<Integer>> result = rangeOptimiser.optimizeReads(input, READ_BUFFER_SIZE);
+
+    assertEquals(expected.size(), result.size(), "Should have the same number of groups");
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(expected.get(i), result.get(i), "Group " + i + " should match");
+    }
+  }
+
+  @Test
+  public void testOptimizeReads_mixedSplitting() {
+    // Example 3: Mixed sequential and size-based splitting
+    List<Integer> input = Arrays.asList(1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14, 15, 16, 17);
+
+    // With maxRangeBlocks=3 and partSizeBlocks=2
+    when(mockConfig.getMaxRangeSizeBytes()).thenReturn(3 * READ_BUFFER_SIZE);
+    when(mockConfig.getPartSizeBytes()).thenReturn(2 * READ_BUFFER_SIZE);
+
+    // Expected: [[1,2], [3,4], [5,6], [10,11], [12,13], [14,15], [16,17]]
+    List<List<Integer>> expected =
+        Arrays.asList(
+            Arrays.asList(1, 2),
+            Arrays.asList(3, 4),
+            Arrays.asList(5, 6),
+            Arrays.asList(10, 11),
+            Arrays.asList(12, 13),
+            Arrays.asList(14, 15),
+            Arrays.asList(16, 17));
+
+    List<List<Integer>> result = rangeOptimiser.optimizeReads(input, READ_BUFFER_SIZE);
+
+    assertEquals(expected.size(), result.size(), "Should have the same number of groups");
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(expected.get(i), result.get(i), "Group " + i + " should match");
+    }
+  }
+
+  @Test
+  public void testOptimizeReads_singleBlock() {
+    List<Integer> input = Collections.singletonList(42);
+    List<List<Integer>> expected = Collections.singletonList(Collections.singletonList(42));
+
+    List<List<Integer>> result = rangeOptimiser.optimizeReads(input, READ_BUFFER_SIZE);
+
+    assertEquals(expected, result, "Single block should be in its own group");
+  }
+
+  @Test
+  public void testOptimizeReads_ensureMinimumBlockSize() {
+    // Test when configuration would result in zero blocks per read
+    when(mockConfig.getMaxRangeSizeBytes()).thenReturn(READ_BUFFER_SIZE / 2);
+    when(mockConfig.getPartSizeBytes()).thenReturn(READ_BUFFER_SIZE / 2);
+
+    List<Integer> input = Arrays.asList(1, 2, 3);
+    List<List<Integer>> expected =
+        Arrays.asList(
+            Collections.singletonList(1),
+            Collections.singletonList(2),
+            Collections.singletonList(3));
+
+    List<List<Integer>> result = rangeOptimiser.optimizeReads(input, READ_BUFFER_SIZE);
+
+    assertEquals(
+        expected.size(),
+        result.size(),
+        "Should have one group per block when max size is less than block size");
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(expected.get(i), result.get(i), "Group " + i + " should match");
+    }
+  }
+
+  @Test
+  public void testOptimizeReads_nullInput() {
+    List<List<Integer>> result = rangeOptimiser.optimizeReads(null, READ_BUFFER_SIZE);
+    assertTrue(result.isEmpty(), "Result should be empty for null input");
+  }
+
+  @Test
+  public void testOptimizeReads_nonSequentialLargeGroups() {
+    // Test with non-sequential groups that each exceed maxRangeBlocks
+    when(mockConfig.getMaxRangeSizeBytes()).thenReturn(2 * READ_BUFFER_SIZE);
+    when(mockConfig.getPartSizeBytes()).thenReturn(1 * READ_BUFFER_SIZE);
+
+    // Three non-sequential groups, each exceeding maxRangeBlocks=2
+    List<Integer> input = Arrays.asList(1, 2, 3, 5, 6, 7, 10, 11, 12);
+
+    // Expected: Each group split into chunks of partSizeBlocks=1
+    List<List<Integer>> expected =
+        Arrays.asList(
+            Collections.singletonList(1),
+            Collections.singletonList(2),
+            Collections.singletonList(3),
+            Collections.singletonList(5),
+            Collections.singletonList(6),
+            Collections.singletonList(7),
+            Collections.singletonList(10),
+            Collections.singletonList(11),
+            Collections.singletonList(12));
+
+    List<List<Integer>> result = rangeOptimiser.optimizeReads(input, READ_BUFFER_SIZE);
+
+    assertEquals(expected.size(), result.size(), "Should have correct number of groups");
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(expected.get(i), result.get(i), "Group " + i + " should match");
+    }
+  }
+
+  @Test
+  public void testOptimizeReads_mixedGroupSizes() {
+    // Test with mixed group sizes - some within maxRangeBlocks, some exceeding
+    when(mockConfig.getMaxRangeSizeBytes()).thenReturn(2 * READ_BUFFER_SIZE);
+    when(mockConfig.getPartSizeBytes()).thenReturn(1 * READ_BUFFER_SIZE);
+
+    // First group (1,2) within limit, second group (4,5,6) exceeds, third group (8) within limit
+    List<Integer> input = Arrays.asList(1, 2, 4, 5, 6, 8);
+
+    // Expected: First and third groups unchanged, second group split
+    List<List<Integer>> expected =
+        Arrays.asList(
+            Arrays.asList(1, 2),
+            Collections.singletonList(4),
+            Collections.singletonList(5),
+            Collections.singletonList(6),
+            Collections.singletonList(8));
+
+    List<List<Integer>> result = rangeOptimiser.optimizeReads(input, READ_BUFFER_SIZE);
+
+    assertEquals(expected.size(), result.size(), "Should have correct number of groups");
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(expected.get(i), result.get(i), "Group " + i + " should match");
+    }
   }
 }


### PR DESCRIPTION
## Description of change
This PR adds a new method optimizeReads to the RangeOptimiser class to improve read performance by intelligently grouping and splitting block indexes. The implementation reduces the complexity in DataBlockManager and makes the optimization logic more testable.

Changes are: 
- Adds readAheadBytes logic
- Adds sequential prefetching logic
- Groups sequential block indexes together
- Splits large sequential groups into smaller chunks based on configuration parameters
- Refactored DataBlockManager to use the new method instead of implementing the logic itself
- Added comprehensive unit tests for the new method

Out of Scope
- Range coalescing will be implemented in a separate PR


#### Relevant issues
PR History:

https://github.com/awslabs/analytics-accelerator-s3/pull/286
https://github.com/awslabs/analytics-accelerator-s3/pull/287
https://github.com/awslabs/analytics-accelerator-s3/pull/288

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).