### PR TITLE
Move Block constructor to Block Builder

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/Telemetry.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/Telemetry.java
@@ -344,4 +344,6 @@ public interface Telemetry extends Closeable {
           new NoOpTelemetryReporter(),
           Optional.empty(),
           TelemetryLevel.CRITICAL);
+
+  public static Telemetry DEFAULT = new ConfigurableTelemetry(TelemetryConfiguration.DEFAULT);
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -213,17 +213,17 @@ public class BlockManager implements Closeable {
           for (Range r : splits) {
             BlockKey blockKey = new BlockKey(objectKey, r);
             Block block =
-                new Block(
-                    blockKey,
-                    objectClient,
-                    telemetry,
-                    generation,
-                    readMode,
-                    this.configuration.getBlockReadTimeout(),
-                    this.configuration.getBlockReadRetryCount(),
-                    aggregatingMetrics,
-                    indexCache,
-                    openStreamInformation);
+                Block.builder()
+                    .blockKey(blockKey)
+                    .objectClient(objectClient)
+                    .telemetry(telemetry)
+                    .generation(generation)
+                    .readMode(readMode)
+                    .configuration(configuration)
+                    .aggregatingMetrics(aggregatingMetrics)
+                    .indexCache(indexCache)
+                    .openStreamInformation(openStreamInformation)
+                    .build();
             blockStore.add(blockKey, block);
           }
         });

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import software.amazon.s3.analyticsaccelerator.TestTelemetry;
 import software.amazon.s3.analyticsaccelerator.common.Metrics;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.request.Range;
@@ -95,19 +94,16 @@ public class IOPlannerTest {
     FakeObjectClient fakeObjectClient =
         new FakeObjectClient(new String(content, StandardCharsets.UTF_8));
     BlockKey blockKey = new BlockKey(objectKey, new Range(100, 200));
-    blockStore.add(
-        blockKey,
-        new Block(
-            blockKey,
-            fakeObjectClient,
-            TestTelemetry.DEFAULT,
-            0,
-            ReadMode.SYNC,
-            120_000,
-            20,
-            mock(Metrics.class),
-            mock(BlobStoreIndexCache.class),
-            OpenStreamInformation.DEFAULT));
+    Block block =
+        Block.builder()
+            .blockKey(blockKey)
+            .objectClient(fakeObjectClient)
+            .readMode(ReadMode.SYNC)
+            .aggregatingMetrics(mock(Metrics.class))
+            .indexCache(mock(BlobStoreIndexCache.class))
+            .openStreamInformation(OpenStreamInformation.DEFAULT)
+            .build();
+    blockStore.add(blockKey, block);
     IOPlanner ioPlanner = new IOPlanner(blockStore);
 
     // When: a read plan is requested for a range (0, 400)


### PR DESCRIPTION
## Description of change
Hey, with this change, i am proposing to move away from constructor for Block class and introduced a custom builder. This is because constructor was getting out of help with 8+ parameters, making it hard to navigate with Default values + ordering. 

This will help me to introduce more parameters when adding retry strategies. 
#### Relevant issues
None. 
#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No. It only touches private surface. 

#### Does this contribution introduce any new public APIs or behaviors?
No.

#### How was the contribution tested?
Updating existing tests to use the new Builder and confirmed all of them are passing. 

#### Does this contribution need a changelog entry?
- [NA ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).