### PR TITLE
Build Iceberg with Spark 3.5

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Build Iceberg jar
         run: |
-          ./gradlew build -x test -x integrationTest
+          ./gradlew build -x test -x integrationTest -DsparkVersions=3.5
           ./gradlew :iceberg-aws:test
         working-directory: iceberg
 


### PR DESCRIPTION
## Description of change
Since we have updated the Iceberg repository to latest, it by default expects Java 17 and also has the different spark version being used for build. But to keep it uniform with S3A, we want to continue building with spark 3.5. 

#### Relevant issues
In the future, [this followup PR](https://github.com/awslabs/analytics-accelerator-s3/pull/302) can be merged as well.

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Local builds work with this flag

#### Does this contribution need a changelog entry?
- [x] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).