### PR TITLE
fix: shading dependency on google error prone

### DIFF
--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -138,6 +138,10 @@ val shadowJar = tasks.withType<ShadowJar> {
         exclude(dependency("org.apache.httpcomponents:"))
         exclude(dependency("commons-codec:"))
         exclude(dependency("commons-logging:"))
+        exclude(dependency("com.google.errorprone:"))
+        exclude(dependency("org.checkerframework:"))
+        exclude(dependency("com.google.guava:"))
+
         exclude {
             it.moduleGroup.startsWith("software.amazon.awssdk", 0) ||
                     it.moduleGroup.startsWith("software.amazon.eventstream", 0)
@@ -147,6 +151,9 @@ val shadowJar = tasks.withType<ShadowJar> {
     relocate("org.apache.parquet.format", "software.amazon.s3.shaded.apache.parquet.format")
     relocate("shaded.parquet.org.apache.thrift", "software.amazon.s3.shaded.parquet.org.apache.thrift")
     relocate("com.github.benmanes.caffeine", "software.amazon.s3.shaded.com.github.benmanes.caffeine")
+    relocate("org.checkerframework", "software.amazon.s3.shaded.org.checkerframework")
+    relocate("com.google.errorprone", "software.amazon.s3.shaded.com.google.errorprone")
+    relocate("com.google.guava", "software.amazon.s3.shaded.com.google.guava")
 }
 
 val refTest = task<Test>("referenceTest") {


### PR DESCRIPTION
## Description of change
Removing transitive dependencies in our project.
When we introduced caffeine it came with some transitive dependencies.

## testing
jar tvf before this change had 
- com/google/ and a many more paths.

After this change
- nothing, is all shaded

Also iceberg builds would give us a warning (not fail)
They no longer give us this warning.


#### Does this contribution need a changelog entry?
- [x] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).