### PR TITLE
Use CRT wrapper library to make it similar to Iceberg

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ spotbugs = "6.0.20"
 s3 = "2.25.31"
 s3mock = "3.11.0"
 testcontainers = "1.19.7"
-crt = "0.29.10"
 lombok = "1.18.32"
 parquetFormat = "2.10.0"
 jqwik = "1.9.1"
@@ -23,7 +22,7 @@ s3 = { module = "software.amazon.awssdk:s3", version.ref = "s3" }
 s3-transfer-manager = { module = "software.amazon.awssdk:s3-transfer-manager", version.ref = "s3" }
 sdk-url-connection-client = { module = "software.amazon.awssdk:url-connection-client", version.ref = "s3" }
 sdk-bom = { group = "software.amazon.awssdk", name = "bom", version.ref = "s3" }
-crt = { module = "software.amazon.awssdk.crt:aws-crt", version.ref = "crt" }
+crt = { module = "software.amazon.awssdk:http-auth-aws-crt", version.ref = "s3" }
 netty-nio-client = { module = "software.amazon.awssdk:netty-nio-client", version.ref = "s3" }
 parquet-format = { module = "org.apache.parquet:parquet-format", version.ref = "parquetFormat" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j"}


### PR DESCRIPTION
## Description of change
We have seen Iceberg project where we integrated using this [http-auth-aws-crt](https://github.com/apache/iceberg/blob/main/aws-bundle/build.gradle#L32) instead of `aws-crt`. So to make it uniform, we wanted to use that in our AAL for testing purposes also. Right now, this CRT is used only for tests. There is also an advantage that it uses the same version as SDK itself.

#### Relevant issues
NA

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Existing integration tests pass

#### Does this contribution need a changelog entry?
- [X] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).