### PR TITLE
Added iostats get request callback to streamReader

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/reader/StreamReader.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/reader/StreamReader.java
@@ -120,6 +120,8 @@ public class StreamReader implements Closeable {
               .referrer(new Referrer(requestRange.toHttpString(), readMode))
               .build();
 
+      openStreamInformation.getRequestCallback().onGetRequest();
+
       // Fetch the object content from S3
       ObjectContent objectContent = fetchObjectContent(getRequest);
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/reader/StreamReaderTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/reader/StreamReaderTest.java
@@ -39,6 +39,7 @@ import software.amazon.s3.analyticsaccelerator.util.BlockKey;
 import software.amazon.s3.analyticsaccelerator.util.MetricKey;
 import software.amazon.s3.analyticsaccelerator.util.ObjectKey;
 import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
+import software.amazon.s3.analyticsaccelerator.util.RequestCallback;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 @SuppressFBWarnings(
@@ -64,6 +65,9 @@ public class StreamReaderTest {
     mockRemoveBlocksFunc = mock(Consumer.class);
     mockMetrics = mock(Metrics.class);
     mockOpenStreamInfo = mock(OpenStreamInformation.class);
+
+    RequestCallback mockRequestCallback = mock(RequestCallback.class);
+    when(mockOpenStreamInfo.getRequestCallback()).thenReturn(mockRequestCallback);
 
     streamReader =
         new StreamReader(
@@ -193,6 +197,7 @@ public class StreamReaderTest {
     verify(mockMetrics).add(MetricKey.GET_REQUEST_COUNT, 1);
     verifyNoMoreInteractions(mockMetrics);
     verify(block).setData(testData);
+    verify(mockOpenStreamInfo.getRequestCallback(), times(1)).onGetRequest();
   }
 
   @Test


### PR DESCRIPTION
## Description of change
This PR moves IOStat callback method request from Block to StreamReader. Needs to be done as part of code rebase

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).