### PR TITLE
Enhance benchmark for concurrent streams. {}

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ sdk-url-connection-client = { module = "software.amazon.awssdk:url-connection-cl
 sdk-bom = { group = "software.amazon.awssdk", name = "bom", version.ref = "s3" }
 crt = { module = "software.amazon.awssdk.crt:aws-crt", version.ref = "crt" }
 netty-nio-client = { module = "software.amazon.awssdk:netty-nio-client", version.ref = "s3" }
+apache-client = {module = "software.amazon.awssdk:apache-client", version.ref = "s3" }
 parquet-format = { module = "org.apache.parquet:parquet-format", version.ref = "parquetFormat" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j"}
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -77,6 +77,8 @@ dependencies {
 
     jmhImplementation(libs.s3)
     jmhImplementation(libs.s3.transfer.manager)
+    jmhImplementation(libs.netty.nio.client)
+    jmhImplementation(libs.apache.client)
     jmhImplementation(testFixtures(project(":input-stream")))
 
     testFixturesImplementation(libs.s3)

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/BenchmarkBase.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/BenchmarkBase.java
@@ -104,10 +104,10 @@ public abstract class BenchmarkBase extends ExecutionBase {
     return AALInputStreamConfigurationKind.DEFAULT;
   }
 
-  @Benchmark
-  public void execute() throws Exception {
-    this.executeBenchmark();
-  }
+//  @Benchmark
+//  public void execute() throws Exception {
+//    this.executeBenchmark();
+//  }
 
   /**
    * Benchmark specific execution

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
@@ -1,0 +1,181 @@
+package software.amazon.s3.analyticsaccelerator.benchmarks;
+
+
+import lombok.SneakyThrows;
+import org.openjdk.jmh.annotations.*;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.endpoints.internal.Value;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.s3.analyticsaccelerator.access.S3ClientKind;
+import software.amazon.s3.analyticsaccelerator.access.S3ExecutionConfiguration;
+import software.amazon.s3.analyticsaccelerator.access.S3ExecutionContext;
+import software.amazon.s3.analyticsaccelerator.request.Range;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
+
+public class ConcurrentStreamPerformanceBenchmark {
+
+    @State(Scope.Thread)
+    public static class BenchmarkState {
+        S3Client s3Client;
+        S3AsyncClient s3AsyncClient;
+        List<S3Object> s3Objects;
+        ExecutorService executor;
+        S3ExecutionContext s3ExecutionContext;
+        String bucketName;
+        int maxConcurrency;
+
+        @Param({"ASYNC_JAVA", "SYNC_JAVA"})
+        public String clientKind;
+
+
+        @Setup
+        public void setup() {
+            this.s3AsyncClient = S3AsyncClient.builder()
+                    .httpClient(NettyNioAsyncHttpClient.builder().maxConcurrency(400).build())
+                    .region(Region.US_EAST_1).build();
+
+            this.s3Client = S3Client.builder()
+                    .httpClient(ApacheHttpClient.builder().maxConnections(400).build())
+                    .region(Region.US_EAST_1).build();
+
+            // The number of reads to do in parallel
+            this.maxConcurrency = Runtime.getRuntime().availableProcessors();
+            this.executor = Executors.newFixedThreadPool(100);
+            this.s3ExecutionContext = new S3ExecutionContext(S3ExecutionConfiguration.fromEnvironment());
+            this.bucketName = s3ExecutionContext.getConfiguration().getParquetBucket();
+            this.s3Objects = getKeys(s3Client, bucketName, s3ExecutionContext.getConfiguration().getPrefix());
+        }
+
+        @TearDown
+        public void tearDown() {
+            executor.shutdown();
+        }
+
+        private List<S3Object> getKeys(S3Client s3Client, String bucket, String prefix) {
+            ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
+                    .bucket(bucket).prefix(prefix)
+                    .maxKeys(50);
+
+            ListObjectsV2Response response = s3Client.listObjectsV2(requestBuilder.build());
+
+            System.out.println("\nObjects fetched: " + response.contents().size());
+
+            return response.contents();
+        }
+    }
+
+    @Benchmark
+    @Measurement(iterations = 2)
+    @Fork(1)
+    @BenchmarkMode(Mode.SingleShotTime)
+    public void runBenchmark(BenchmarkState state) throws Exception {
+            execute(state);
+    }
+
+    private void execute(BenchmarkState state) throws Exception {
+        System.out.println("\nReading parquet files with: " + state.clientKind);
+
+        for (int i = 0; i < state.s3Objects.size() - 1; i = i + state.maxConcurrency) {
+            List<Future<Integer>> futures = new ArrayList<>();
+
+            for (int j = i; j < i + state.maxConcurrency && j < state.s3Objects.size() - 1; j++) {
+                final int k = j;
+                    Future<Integer> f = state.executor.submit(() -> {
+                        try {
+                            return fetchObjectChunksByRange(state.bucketName, state.s3Objects.get(k), state);
+                        } catch (ExecutionException e) {
+                            throw new RuntimeException(e);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    futures.add(f);
+            }
+
+            for(Future<Integer> f : futures) {
+                f.get();
+            }
+
+            System.out.printf("DONE READING FOR ITERATION <<<< " + i);
+        }
+    }
+
+    private int fetchObjectChunksByRange(String bucket, S3Object s3Object, BenchmarkState state) throws ExecutionException, InterruptedException {
+        long objSize = s3Object.size();
+
+        if (objSize < 80 * ONE_MB) {
+            return -1;
+        }
+
+        List<Range> ranges = new ArrayList<>();
+        ranges.add(new Range(objSize - ONE_MB, objSize));
+        ranges.add(new Range(4, 4 + 4 * ONE_MB));
+        ranges.add(new Range(30 * ONE_MB, 30 * ONE_MB + 8 * ONE_MB));
+        ranges.add(new Range(50 * ONE_MB, 50 * ONE_MB + 12 * ONE_MB));
+        ranges.add(new Range(60 * ONE_MB, 60 * ONE_MB + 10 * ONE_MB));
+
+        List<Future<Long>> fList = new ArrayList<>();
+
+        for (Range range : ranges) {
+
+            GetObjectRequest request = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Object.key())
+                    .range("bytes="+range.getStart() + "-" + range.getEnd()).build();
+
+            System.out.println("\nMaking a GET request for: " + s3Object.key() + " start: " + range.getStart() + " end: " + range.getEnd());
+
+            ResponseInputStream<GetObjectResponse> dataStream;
+
+            if (Objects.equals(state.clientKind, "ASYNC_JAVA")) {
+                dataStream = state.s3AsyncClient.getObject(request,
+                        AsyncResponseTransformer.toBlockingInputStream()).join();
+            } else if (Objects.equals(state.clientKind, "SYNC_JAVA")) {
+                dataStream = state.s3Client.getObject(request);
+            } else {
+                dataStream = null;
+            }
+
+            fList.add(state.executor.submit(() -> readStream(dataStream, s3Object.key(), range)));
+        }
+
+        for(Future<Long> f : fList) {
+            f.get();
+        }
+
+        return 0;
+    }
+
+
+    private long readStream(ResponseInputStream<GetObjectResponse> inputStream, String key, Range range) throws Exception {
+        byte[] buffer = new byte[range.getLength()];
+        long read = 0;
+        try {
+            read = inputStream.read(buffer);
+            System.out.printf("\nDone reading for: " + key + " start: " + range.getStart() + " end: " + range.getEnd());
+            inputStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return read;
+    }
+
+}

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
@@ -124,7 +124,7 @@ public class ConcurrentStreamPerformanceBenchmark {
                 f.get();
             }
 
-            System.out.printf("DONE READING FOR ITERATION <<<< " + i);
+          //  System.out.printf("DONE READING FOR ITERATION <<<< " + i);
         }
     }
 
@@ -184,7 +184,7 @@ public class ConcurrentStreamPerformanceBenchmark {
                     .key(s3Object.key())
                     .range("bytes="+range.getStart() + "-" + range.getEnd()).build();
 
-            System.out.println("\nMaking a GET request for: " + s3Object.key() + " start: " + range.getStart() + " end: " + range.getEnd());
+          //  System.out.println("\nMaking a GET request for: " + s3Object.key() + " start: " + range.getStart() + " end: " + range.getEnd());
 
             ResponseInputStream<GetObjectResponse> dataStream;
 
@@ -213,7 +213,7 @@ public class ConcurrentStreamPerformanceBenchmark {
         long read = 0;
         try {
             read = inputStream.read(buffer);
-            System.out.printf("\nDone reading for: " + key + " start: " + range.getStart() + " end: " + range.getEnd());
+           // System.out.printf("\nDone reading for: " + key + " start: " + range.getStart() + " end: " + range.getEnd());
             inputStream.close();
         } catch (IOException e) {
             e.printStackTrace();

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
@@ -110,7 +110,7 @@ public class ConcurrentStreamPerformanceBenchmark {
     }
 
     private void execute(BenchmarkState state, String bucket) throws Exception {
-        System.out.println("\nReading parquet files with: " + state.clientKind);
+        System.out.println("\nReading parquet files with: " + state.clientKind + " bucket: " + bucket);
 
         for (int i = 0; i < state.s3Objects.size() - 1; i = i + state.maxConcurrency) {
             List<Future<Integer>> futures = new ArrayList<>();

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
@@ -110,7 +110,7 @@ public class ConcurrentStreamPerformanceBenchmark {
     }
 
     private void execute(BenchmarkState state, String bucket) throws Exception {
-        System.out.println("\nReading parquet files with: " + state.clientKind + " bucket: " + bucket);
+        System.out.println("\nReading parquet files with: " + state.clientKind + "from bucket: " + bucket);
 
         for (int i = 0; i < state.s3Objects.size() - 1; i = i + state.maxConcurrency) {
             List<Future<Integer>> futures = new ArrayList<>();

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
@@ -71,7 +71,7 @@ public class ConcurrentStreamPerformanceBenchmark {
         private List<S3Object> getKeys(S3Client s3Client, String bucket, String prefix) {
             ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
                     .bucket(bucket).prefix(prefix)
-                    .maxKeys(50);
+                    .maxKeys(1000);
 
             ListObjectsV2Response response = s3Client.listObjectsV2(requestBuilder.build());
 
@@ -82,7 +82,7 @@ public class ConcurrentStreamPerformanceBenchmark {
     }
 
     @Benchmark
-    @Measurement(iterations = 2)
+    @Measurement(iterations = 5)
     @Fork(1)
     @BenchmarkMode(Mode.SingleShotTime)
     public void runBenchmark(BenchmarkState state) throws Exception {

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmarks.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmarks.java
@@ -1,0 +1,11 @@
+//package software.amazon.s3.analyticsaccelerator.benchmarks;
+//
+//import software.amazon.s3.analyticsaccelerator.access.StreamReadPatternKind;
+//
+//public class ConcurrentStreamPerformanceBenchmarks {
+//
+//    public static class ComparisonParquet extends ConcurrentStreamPerformanceBenchmark {
+//        /** Constructor */
+//        public ComparisonParquet() {super();}
+//        }
+//    }

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/StreamPatternComparisonBenchmarks.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/StreamPatternComparisonBenchmarks.java
@@ -23,43 +23,43 @@ import software.amazon.s3.analyticsaccelerator.access.StreamReadPatternKind;
  * pattern
  */
 public class StreamPatternComparisonBenchmarks {
-  /** SEQUENTIAL pattern */
-  public static class ComparisonSequential extends StreamPatternComparisonBenchmark {
-    /** Constructor */
-    public ComparisonSequential() {
-      super(StreamReadPatternKind.SEQUENTIAL);
-    }
-  }
-
-  /** SKIPPING_FORWARD pattern */
-  public static class ComparisonSkippingForward extends StreamPatternComparisonBenchmark {
-    /** Constructor */
-    public ComparisonSkippingForward() {
-      super(StreamReadPatternKind.SKIPPING_FORWARD);
-    }
-  }
-
-  /** SKIPPING_BACKWARD pattern */
-  public static class ComparisonSkippingBackward extends StreamPatternComparisonBenchmark {
-    /** Constructor */
-    public ComparisonSkippingBackward() {
-      super(StreamReadPatternKind.SKIPPING_BACKWARD);
-    }
-  }
-
-  /** QUASI_PARQUET_ROW_GROUP pattern */
-  public static class ComparisonQuasiParquetRowGroup extends StreamPatternComparisonBenchmark {
-    /** Constructor */
-    public ComparisonQuasiParquetRowGroup() {
-      super(StreamReadPatternKind.QUASI_PARQUET_ROW_GROUP);
-    }
-  }
-
-  /** QUASI_PARQUET_COLUMN_CHUNK */
-  public static class ComparisonQuasiParquetColumnChunk extends StreamPatternComparisonBenchmark {
-    /** Constructor */
-    public ComparisonQuasiParquetColumnChunk() {
-      super(StreamReadPatternKind.QUASI_PARQUET_COLUMN_CHUNK);
-    }
-  }
+//  /** SEQUENTIAL pattern */
+//  public static class ComparisonSequential extends StreamPatternComparisonBenchmark {
+//    /** Constructor */
+//    public ComparisonSequential() {
+//      super(StreamReadPatternKind.SEQUENTIAL);
+//    }
+//  }
+//
+//  /** SKIPPING_FORWARD pattern */
+//  public static class ComparisonSkippingForward extends StreamPatternComparisonBenchmark {
+//    /** Constructor */
+//    public ComparisonSkippingForward() {
+//      super(StreamReadPatternKind.SKIPPING_FORWARD);
+//    }
+//  }
+//
+//  /** SKIPPING_BACKWARD pattern */
+//  public static class ComparisonSkippingBackward extends StreamPatternComparisonBenchmark {
+//    /** Constructor */
+//    public ComparisonSkippingBackward() {
+//      super(StreamReadPatternKind.SKIPPING_BACKWARD);
+//    }
+//  }
+//
+//  /** QUASI_PARQUET_ROW_GROUP pattern */
+//  public static class ComparisonQuasiParquetRowGroup extends StreamPatternComparisonBenchmark {
+//    /** Constructor */
+//    public ComparisonQuasiParquetRowGroup() {
+//      super(StreamReadPatternKind.QUASI_PARQUET_ROW_GROUP);
+//    }
+//  }
+//
+//  /** QUASI_PARQUET_COLUMN_CHUNK */
+//  public static class ComparisonQuasiParquetColumnChunk extends StreamPatternComparisonBenchmark {
+//    /** Constructor */
+//    public ComparisonQuasiParquetColumnChunk() {
+//      super(StreamReadPatternKind.QUASI_PARQUET_COLUMN_CHUNK);
+//    }
+//  }
 }

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ExecutionConfiguration.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ExecutionConfiguration.java
@@ -31,11 +31,16 @@ public class S3ExecutionConfiguration {
   public static final String PREFIX_KEY = "S3_TEST_PREFIX";
   public static final String READ_BUFFER_SIZE_MB_KEY = "S3_TEST_READ_BUFFER_SIZE_MB";
   public static final int DEFAULT_READ_BUFFER_SIZE_MB_KEY = 8;
-  public static final String PARQUET_BENCHMARK_KEY = "S3_TEST_PARQUET_BENCHMARK_BUCKET";
+  public static final String BUCKET_KEY_ASYNC = "S3_TEST_BUCKET_ASYNC";
+  public static final String BUCKET_KEY_SYNC = "S3_TEST_BUCKET_SYNC";
+  public static final String BUCKET_KEY_VECTORED = "S3_TEST_BUCKET_VECTORED";
+  public static final int DEFAULT_PARQUET_BENCHMARK_BUCKET_KEY = 8;
 
   @NonNull String bucket;
   @NonNull String prefix;
-  @NonNull String parquetBucket;
+  @NonNull String asyncBucket;
+  @NonNull String syncBucket;
+  @NonNull String vectoredBucket;
   int bufferSizeMb;
   @NonNull S3AsyncClientFactoryConfiguration clientFactoryConfiguration;
 
@@ -48,7 +53,10 @@ public class S3ExecutionConfiguration {
   public static S3ExecutionConfiguration fromConfiguration(ConnectorConfiguration configuration) {
     return S3ExecutionConfiguration.builder()
         .bucket(configuration.getRequiredString(BUCKET_KEY))
-        .parquetBucket(configuration.getRequiredString(PARQUET_BENCHMARK_KEY))
+        .asyncBucket(configuration.getRequiredString(BUCKET_KEY_ASYNC))
+        .asyncBucket(configuration.getRequiredString(BUCKET_KEY_ASYNC))
+        .syncBucket(configuration.getRequiredString(BUCKET_KEY_SYNC))
+        .vectoredBucket(configuration.getRequiredString(BUCKET_KEY_VECTORED))
         .prefix(configuration.getRequiredString(PREFIX_KEY))
         .bufferSizeMb(
             configuration.getInt(READ_BUFFER_SIZE_MB_KEY, DEFAULT_READ_BUFFER_SIZE_MB_KEY))

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ExecutionConfiguration.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ExecutionConfiguration.java
@@ -31,9 +31,11 @@ public class S3ExecutionConfiguration {
   public static final String PREFIX_KEY = "S3_TEST_PREFIX";
   public static final String READ_BUFFER_SIZE_MB_KEY = "S3_TEST_READ_BUFFER_SIZE_MB";
   public static final int DEFAULT_READ_BUFFER_SIZE_MB_KEY = 8;
+  public static final String PARQUET_BENCHMARK_KEY = "S3_TEST_PARQUET_BENCHMARK_BUCKET";
 
   @NonNull String bucket;
   @NonNull String prefix;
+  @NonNull String parquetBucket;
   int bufferSizeMb;
   @NonNull S3AsyncClientFactoryConfiguration clientFactoryConfiguration;
 
@@ -46,6 +48,7 @@ public class S3ExecutionConfiguration {
   public static S3ExecutionConfiguration fromConfiguration(ConnectorConfiguration configuration) {
     return S3ExecutionConfiguration.builder()
         .bucket(configuration.getRequiredString(BUCKET_KEY))
+        .parquetBucket(configuration.getRequiredString(PARQUET_BENCHMARK_KEY))
         .prefix(configuration.getRequiredString(PREFIX_KEY))
         .bufferSizeMb(
             configuration.getInt(READ_BUFFER_SIZE_MB_KEY, DEFAULT_READ_BUFFER_SIZE_MB_KEY))


### PR DESCRIPTION
## Description of change

PR adds in microbenchmarks which replicates what would happen on a Spark node:

* Number of open concurrent streams = number of cores on the node
* Each stream doing some concurrent reads for different parts of an object, each of these represent a column read.


#### Relevant issues
<!-- Please add issue numbers. -->
<!-- Please also link them to this PR. -->

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?

No

#### Does this contribution introduce any new public APIs or behaviors?

No

#### How was the contribution tested?

Ran microbenchmarks

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).