### PR TITLE
Changed default read buffer size to 128KB

### DIFF
--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfiguration.java
@@ -45,7 +45,7 @@ public class PhysicalIOConfiguration {
   private static final boolean DEFAULT_SMALL_OBJECTS_PREFETCHING_ENABLED = true;
   private static final long DEFAULT_SMALL_OBJECT_SIZE_THRESHOLD = 8 * ONE_MB;
   private static final int DEFAULT_THREAD_POOL_SIZE = 96;
-  private static final long DEFAULT_READ_BUFFER_SIZE = 8 * ONE_KB;
+  private static final long DEFAULT_READ_BUFFER_SIZE = 128 * ONE_KB;
   private static final long DEFAULT_TARGET_REQUEST_SIZE = 8 * ONE_MB;
   private static final double DEFAULT_REQUEST_TOLERANCE_RATIO = 1.4;
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
@@ -76,7 +76,7 @@ public class PhysicalIOConfigurationTest {
             + "\tsmallObjectsPrefetchingEnabled: true\n"
             + "\tsmallObjectSizeThreshold: 8388608\n"
             + "\tthreadPoolSize: 96\n"
-            + "\treadBufferSize: 8192\n"
+            + "\treadBufferSize: 131072\n"
             + "\ttargetRequestSize: 20\n"
             + "\trequestToleranceRatio: 1.4\n");
   }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
@@ -229,6 +229,7 @@ public class BlockManagerTest {
         PhysicalIOConfiguration.builder()
             .smallObjectSizeThreshold(8 * ONE_MB)
             .smallObjectsPrefetchingEnabled(true)
+            .readBufferSize(8 * ONE_KB)
             .build();
 
     // Given
@@ -249,6 +250,7 @@ public class BlockManagerTest {
         PhysicalIOConfiguration.builder()
             .smallObjectSizeThreshold(8 * ONE_MB)
             .smallObjectsPrefetchingEnabled(true)
+            .readBufferSize(8 * ONE_KB)
             .build();
     BlockManager blockManager = getTestBlockManager(objectClient, 42, configuration);
 
@@ -269,6 +271,7 @@ public class BlockManagerTest {
             .smallObjectsPrefetchingEnabled(false)
             .smallObjectSizeThreshold(
                 8 * ONE_MB) // Make sure that threshold is always higher than small object size
+            .readBufferSize(8 * ONE_KB)
             .build();
 
     ObjectClient objectClient = mock(ObjectClient.class);
@@ -305,7 +308,10 @@ public class BlockManagerTest {
   void testGetBlockReturnsAvailableBlock() {
     // Given
     PhysicalIOConfiguration config =
-        PhysicalIOConfiguration.builder().smallObjectsPrefetchingEnabled(false).build();
+        PhysicalIOConfiguration.builder()
+            .smallObjectsPrefetchingEnabled(false)
+            .readBufferSize(8 * ONE_KB)
+            .build();
     BlockManager blockManager = getTestBlockManager(mock(ObjectClient.class), 65 * ONE_KB, config);
 
     // When: have a 64KB block available from 0
@@ -320,7 +326,10 @@ public class BlockManagerTest {
     // Given
 
     PhysicalIOConfiguration config =
-        PhysicalIOConfiguration.builder().smallObjectsPrefetchingEnabled(false).build();
+        PhysicalIOConfiguration.builder()
+            .smallObjectsPrefetchingEnabled(false)
+            .readBufferSize(8 * ONE_KB)
+            .build();
 
     final int objectSize = (int) config.getReadAheadBytes() + ONE_KB;
     ObjectClient objectClient = mock(ObjectClient.class);
@@ -368,7 +377,10 @@ public class BlockManagerTest {
         getTestBlockManager(
             objectClient,
             136 * ONE_KB,
-            PhysicalIOConfiguration.builder().smallObjectsPrefetchingEnabled(false).build());
+            PhysicalIOConfiguration.builder()
+                .smallObjectsPrefetchingEnabled(false)
+                .readBufferSize(8 * ONE_KB)
+                .build());
     blockManager.makePositionAvailable(
         0, ReadMode.SYNC); // This code will create blocks [0,1,2,3,4,5,6,7]
     blockManager.makePositionAvailable(
@@ -448,7 +460,10 @@ public class BlockManagerTest {
         getTestBlockManager(
             objectClient,
             128 * ONE_MB,
-            PhysicalIOConfiguration.builder().sequentialPrefetchBase(2.0).build());
+            PhysicalIOConfiguration.builder()
+                .readBufferSize(8 * ONE_KB)
+                .sequentialPrefetchBase(2.0)
+                .build());
     blockManager.makeRangeAvailable(20_837_974, 8_323_072, ReadMode.SYNC);
     blockManager.makeRangeAvailable(20_772_438, 65_536, ReadMode.SYNC);
     blockManager.makeRangeAvailable(29_161_046, 4_194_305, ReadMode.SYNC);
@@ -517,7 +532,11 @@ public class BlockManagerTest {
                 ObjectContent.builder().stream(new ByteArrayInputStream(new byte[1024])).build()));
 
     PhysicalIOConfiguration config =
-        PhysicalIOConfiguration.builder().readAheadBytes(512).sequentialPrefetchBase(2.0).build();
+        PhysicalIOConfiguration.builder()
+            .readAheadBytes(512)
+            .sequentialPrefetchBase(2.0)
+            .readBufferSize(8 * ONE_KB)
+            .build();
 
     BlockManager blockManager = getTestBlockManager(objectClient, 1024, config);
 
@@ -711,7 +730,9 @@ public class BlockManagerTest {
   }
 
   private BlockManager getTestBlockManager(ObjectClient objectClient, int size) {
-    return getTestBlockManager(objectClient, size, PhysicalIOConfiguration.DEFAULT);
+    PhysicalIOConfiguration configuration =
+        PhysicalIOConfiguration.builder().readBufferSize(8 * ONE_KB).build();
+    return getTestBlockManager(objectClient, size, configuration);
   }
 
   private BlockManager getTestBlockManager(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
@@ -17,6 +17,7 @@ package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_KB;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
@@ -52,7 +53,7 @@ public class BlockStoreTest {
   public void setUp() {
     mockIndexCache = mock(BlobStoreIndexCache.class);
     mockMetrics = mock(Metrics.class);
-    configuration = PhysicalIOConfiguration.DEFAULT;
+    configuration = PhysicalIOConfiguration.builder().readBufferSize(8 * ONE_KB).build();
     blockStore = new BlockStore(mockIndexCache, mockMetrics, configuration);
   }
 


### PR DESCRIPTION
## Description of change
This PR changes default read buffer size to 128KB to have a better performance

#### Relevant issues
https://github.com/awslabs/analytics-accelerator-s3/pull/286
https://github.com/awslabs/analytics-accelerator-s3/pull/287
https://github.com/awslabs/analytics-accelerator-s3/pull/288
https://github.com/awslabs/analytics-accelerator-s3/pull/289
https://github.com/awslabs/analytics-accelerator-s3/pull/294
https://github.com/awslabs/analytics-accelerator-s3/pull/316
https://github.com/awslabs/analytics-accelerator-s3/pull/320
https://github.com/awslabs/analytics-accelerator-s3/pull/323

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Unit tests

#### Does this contribution need a changelog entry?
N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).