### PR TITLE
Added error field to block to throw exception early

### DIFF
--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/EtagChangeTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/EtagChangeTest.java
@@ -36,7 +36,10 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 public class EtagChangeTest extends IntegrationTestBase {
 
-  private static final int DEFAULT_READ_AHEAD_BYTES = 64 * ONE_KB;
+  // This value should be Default ReadAhead bytes or read buffer size whichever
+  // is higher. Currently, default read buffer size is 128KB, this value
+  // should be 128KB
+  private static final int DEFAULT_READ_BYTES = 128 * ONE_KB;
 
   @ParameterizedTest
   @MethodSource("clientKinds")
@@ -104,7 +107,7 @@ public class EtagChangeTest extends IntegrationTestBase {
       IOException ex =
           assertThrows(
               IOException.class,
-              () -> readAndAssert(stream, buffer, 200, DEFAULT_READ_AHEAD_BYTES));
+              () -> readAndAssert(stream, buffer, 200, DEFAULT_READ_BYTES));
       S3Exception s3Exception =
           assertInstanceOf(S3Exception.class, ex.getCause(), "Cause should be S3Exception");
       assertEquals(412, s3Exception.statusCode(), "Expected Precondition Failed (412) status code");

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
@@ -351,7 +351,12 @@ public class PhysicalIOImplTest {
   @SuppressWarnings("unchecked")
   @Test
   public void test_FailureEvictsObjectsAsExpected_WhenSDKClientGetsStuck() throws IOException {
-    IOException ioException = new IOException(new IOException("Error while getting block"));
+    AwsServiceException sdkException =
+        S3Exception.builder()
+            .message(
+                "software.amazon.awssdk.services.s3.model.S3Exception: At least one of the pre-conditions you specified did not hold (Service: S3, Status Code: 412, Request ID")
+            .build();
+    IOException ioException = new IOException(sdkException);
 
     S3AsyncClient mockS3AsyncClient = mock(S3AsyncClient.class);
     CompletableFuture<ResponseInputStream<GetObjectResponse>> failedFuture =


### PR DESCRIPTION
## Description of change
This PR supports Block.read method to throw Exception without retry when SDK throws Status Code: 412 exception, when etag of a file changes.

#### Relevant issues
https://github.com/awslabs/analytics-accelerator-s3/pull/325

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No

#### Does this contribution introduce any new public APIs or behaviors?
No

#### How was the contribution tested?
Unit tests, integration tests

#### Does this contribution need a changelog entry?
N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).