### PR TITLE
Fix for ITests failures due to new env variables.

### DIFF
--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
@@ -48,8 +48,6 @@ import software.amazon.s3.analyticsaccelerator.S3SdkObjectClient;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
-import software.amazon.s3.analyticsaccelerator.access.S3ExecutionConfiguration;
-import software.amazon.s3.analyticsaccelerator.access.S3ExecutionContext;
 import software.amazon.s3.analyticsaccelerator.access.StreamRead;
 import software.amazon.s3.analyticsaccelerator.access.StreamReadPattern;
 import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/ConcurrentStreamPerformanceBenchmark.java
@@ -52,6 +52,7 @@ import software.amazon.s3.analyticsaccelerator.access.S3ExecutionConfiguration;
 import software.amazon.s3.analyticsaccelerator.access.S3ExecutionContext;
 import software.amazon.s3.analyticsaccelerator.access.StreamRead;
 import software.amazon.s3.analyticsaccelerator.access.StreamReadPattern;
+import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
 import software.amazon.s3.analyticsaccelerator.common.ObjectRange;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
 import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
@@ -64,6 +65,11 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
  */
 public class ConcurrentStreamPerformanceBenchmark {
 
+  public static final String BUCKET_KEY_ASYNC = "S3_TEST_BUCKET_ASYNC";
+  public static final String BUCKET_KEY_SYNC = "S3_TEST_BUCKET_SYNC";
+  public static final String BUCKET_KEY_VECTORED = "S3_TEST_BUCKET_VECTORED";
+  public static final String PREFIX_KEY = "S3_TEST_PREFIX";
+
   /** This class holds the common variables to be used across micro benchmarks in this class. */
   @State(Scope.Thread)
   public static class BenchmarkState {
@@ -71,7 +77,7 @@ public class ConcurrentStreamPerformanceBenchmark {
     S3AsyncClient s3AsyncClient;
     List<S3Object> s3Objects;
     ExecutorService executor;
-    S3ExecutionContext s3ExecutionContext;
+    ConnectorConfiguration configuration;
     S3SeekableInputStreamFactory s3SeekableInputStreamFactory;
     String bucketName;
     int maxConcurrency;
@@ -99,11 +105,11 @@ public class ConcurrentStreamPerformanceBenchmark {
       // The number of reads to do in parallel
       this.maxConcurrency = Runtime.getRuntime().availableProcessors();
       this.executor = Executors.newFixedThreadPool(100);
-      this.s3ExecutionContext = new S3ExecutionContext(S3ExecutionConfiguration.fromEnvironment());
-      this.bucketName = s3ExecutionContext.getConfiguration().getAsyncBucket();
+      this.configuration = new ConnectorConfiguration(System.getenv());
+      this.bucketName = this.configuration.getRequiredString(BUCKET_KEY_ASYNC);
       this.s3Objects =
           BenchmarkUtils.getKeys(
-              s3Client, bucketName, s3ExecutionContext.getConfiguration().getPrefix(), 500);
+              s3Client, bucketName, configuration.getRequiredString(PREFIX_KEY), 500);
       this.s3SeekableInputStreamFactory =
           new S3SeekableInputStreamFactory(
               new S3SdkObjectClient(this.s3AsyncClient),
@@ -124,13 +130,13 @@ public class ConcurrentStreamPerformanceBenchmark {
   public void runBenchmark(BenchmarkState state) throws Exception {
     switch (state.clientKind) {
       case SDK_ASYNC_JAVA:
-        execute(state, state.s3ExecutionContext.getConfiguration().getAsyncBucket());
+        execute(state, state.configuration.getRequiredString(BUCKET_KEY_ASYNC));
         break;
       case SDK_SYNC_JAVA:
-        execute(state, state.s3ExecutionContext.getConfiguration().getSyncBucket());
+        execute(state, state.configuration.getRequiredString(BUCKET_KEY_SYNC));
         break;
       case AAL_ASYNC_READ_VECTORED:
-        execute(state, state.s3ExecutionContext.getConfiguration().getVectoredBucket());
+        execute(state, state.configuration.getRequiredString(BUCKET_KEY_VECTORED));
         break;
     }
   }

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ExecutionConfiguration.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/S3ExecutionConfiguration.java
@@ -31,15 +31,12 @@ public class S3ExecutionConfiguration {
   public static final String PREFIX_KEY = "S3_TEST_PREFIX";
   public static final String READ_BUFFER_SIZE_MB_KEY = "S3_TEST_READ_BUFFER_SIZE_MB";
   public static final int DEFAULT_READ_BUFFER_SIZE_MB_KEY = 8;
-  public static final String BUCKET_KEY_ASYNC = "S3_TEST_BUCKET_ASYNC";
-  public static final String BUCKET_KEY_SYNC = "S3_TEST_BUCKET_SYNC";
-  public static final String BUCKET_KEY_VECTORED = "S3_TEST_BUCKET_VECTORED";
 
   @NonNull String bucket;
   @NonNull String prefix;
-  @NonNull String asyncBucket;
-  @NonNull String syncBucket;
-  @NonNull String vectoredBucket;
+  String asyncBucket;
+  String syncBucket;
+  String vectoredBucket;
   int bufferSizeMb;
   @NonNull S3AsyncClientFactoryConfiguration clientFactoryConfiguration;
 
@@ -52,9 +49,6 @@ public class S3ExecutionConfiguration {
   public static S3ExecutionConfiguration fromConfiguration(ConnectorConfiguration configuration) {
     return S3ExecutionConfiguration.builder()
         .bucket(configuration.getRequiredString(BUCKET_KEY))
-        .asyncBucket(configuration.getRequiredString(BUCKET_KEY_ASYNC))
-        .syncBucket(configuration.getRequiredString(BUCKET_KEY_SYNC))
-        .vectoredBucket(configuration.getRequiredString(BUCKET_KEY_VECTORED))
         .prefix(configuration.getRequiredString(PREFIX_KEY))
         .bufferSizeMb(
             configuration.getInt(READ_BUFFER_SIZE_MB_KEY, DEFAULT_READ_BUFFER_SIZE_MB_KEY))


### PR DESCRIPTION
## Description of change

Microbenchmark PR added new env variables, but if these are not set ITests should run. This PR isolates those variables to the micro benchmark class. 

#### Relevant issues
<!-- Please add issue numbers. -->
<!-- Please also link them to this PR. -->

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
<!-- Please explain why this was necessary. -->

#### Does this contribution introduce any new public APIs or behaviors?
<!-- Please describe them and explain what scenarios they target.  -->

#### How was the contribution tested?
<!-- Please describe how this contribution was tested. -->

#### Does this contribution need a changelog entry?
- [ ] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).