### PR TITLE
fix: update to push snapshot to maven local for iceberg build

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -45,8 +45,6 @@ jobs:
           path: "input-stream/build/libs/analyticsaccelerator-s3-SNAPSHOT.jar"
           name: "analyticsaccelerator-s3-SNAPSHOT.jar"
 
-          
-
 #  BuildHadoopAndUploadArtifact:
 #    name: Build Hadoop artifacts
 #    runs-on: ubuntu-latest

--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -2,6 +2,7 @@ name: Build and upload artifact JARs to S3 treatment bucket
 
 # Controls when the action will run. Invokes the workflow on push events but only for the main branch
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -36,13 +37,15 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew -PsnapshotBuild=true build
+          ./gradlew -PsnapshotBuild=true build publishToMavenLocal
           ./gradlew jmhJar
 
       - uses: actions/upload-artifact@v4
         with:
           path: "input-stream/build/libs/analyticsaccelerator-s3-SNAPSHOT.jar"
           name: "analyticsaccelerator-s3-SNAPSHOT.jar"
+
+          
 
 #  BuildHadoopAndUploadArtifact:
 #    name: Build Hadoop artifacts


### PR DESCRIPTION
We currently don't use the snapshot build when building the iceberg artifacts this fixes that. Also adding a manual trigger so we can test downstream changes and trigger this independent of a PR.

#### Does this contribution need a changelog entry?
- [x] I have updated the CHANGELOG or README if appropriate

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).