### PR TITLE
fix: using snapshot version for iceberg build

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -97,7 +97,18 @@ jobs:
         with:
           java-version: '11'
           distribution: 'corretto'
+          
+      - uses: actions/download-artifact@v4
+        with:
+          name: "analyticsaccelerator-s3-SNAPSHOT.jar"
+          path: ./aal
 
+      - name: Install aal SNAPSHOT to local Maven
+        run: |
+          mvn install:install-file -Dfile=./aal/analyticsaccelerator-s3-SNAPSHOT.jar \
+            -DgroupId=com.software.amazon -DartifactId=analyticsaccelerator-s3 \
+            -Dversion=SNAPSHOT -Dpackaging=jar
+      
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
 


### PR DESCRIPTION
maven local isn't shared between github actions so u need to check it out first.

tested with successful run: https://github.com/awslabs/analytics-accelerator-s3/actions/runs/17070734565