### PR TITLE
Add request coalescing and relevant configuration

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/ObjectRange.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/ObjectRange.java
@@ -46,4 +46,9 @@ public class ObjectRange {
     this.offset = offset;
     this.length = length;
   }
+
+  @Override
+  public String toString() {
+    return String.format("offset: %d, length: %d", offset, length);
+  }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/Range.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/request/Range.java
@@ -25,7 +25,7 @@ import software.amazon.s3.analyticsaccelerator.common.Preconditions;
  * like "bytes=0-555" -- this is SDK detail we should not care about in layers above Object Client.
  */
 @Value
-public class Range {
+public class Range implements Comparable<Range> {
   @Getter long start;
   @Getter long end;
 
@@ -84,5 +84,16 @@ public class Range {
    */
   public String toHttpString() {
     return String.format(TO_HTTP_STRING_FORMAT, start, end);
+  }
+
+  /**
+   * Allows sorting ranges based on their start position.
+   *
+   * @param other
+   * @return
+   */
+  @Override
+  public int compareTo(Range other) {
+    return Long.compare(this.start, other.start);
   }
 }

--- a/common/src/test/java/software/amazon/s3/analyticsaccelerator/common/ConnectorConfigurationTest.java
+++ b/common/src/test/java/software/amazon/s3/analyticsaccelerator/common/ConnectorConfigurationTest.java
@@ -264,6 +264,45 @@ public class ConnectorConfigurationTest {
         IllegalArgumentException.class, () -> configuration.getRequiredString("stringConfig1"));
   }
 
+  @Test
+  void testGetPositiveLong() {
+    ConnectorConfiguration configuration = getDefaultConfiguration(TEST_PREFIX);
+    long positiveLong = configuration.getPositiveLong("longConfig", 5);
+    assertEquals(1, positiveLong);
+  }
+
+  @Test
+  void testGetPositiveLongWithDefault() {
+    ConnectorConfiguration configuration = getDefaultConfiguration(TEST_PREFIX);
+    long positiveLong = configuration.getPositiveLong("nonExistentKey", 10);
+    assertEquals(10, positiveLong);
+  }
+
+  @Test
+  void testGetPositiveLongThrowsOnZero() {
+    Map<String, String> configMap = new HashMap<>();
+    configMap.put(TEST_PREFIX + ".zeroConfig", "0");
+    ConnectorConfiguration configuration = new ConnectorConfiguration(configMap, TEST_PREFIX);
+    assertThrows(
+        IllegalArgumentException.class, () -> configuration.getPositiveLong("zeroConfig", 5));
+  }
+
+  @Test
+  void testGetPositiveLongThrowsOnNegative() {
+    Map<String, String> configMap = new HashMap<>();
+    configMap.put(TEST_PREFIX + ".negativeConfig", "-5");
+    ConnectorConfiguration configuration = new ConnectorConfiguration(configMap, TEST_PREFIX);
+    assertThrows(
+        IllegalArgumentException.class, () -> configuration.getPositiveLong("negativeConfig", 5));
+  }
+
+  @Test
+  void testGetPositiveLongThrowsOnNegativeDefault() {
+    ConnectorConfiguration configuration = getDefaultConfiguration(TEST_PREFIX);
+    assertThrows(
+        IllegalArgumentException.class, () -> configuration.getPositiveLong("nonExistentKey", -1));
+  }
+
   private static ConnectorConfiguration getDefaultConfiguration(String prefix) {
 
     return new ConnectorConfiguration(getDefaultConfigurationMap(prefix), prefix);

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamFactory.java
@@ -171,7 +171,13 @@ public class S3SeekableInputStreamFactory implements AutoCloseable {
   PhysicalIO createPhysicalIO(S3URI s3URI, OpenStreamInformation openStreamInformation)
       throws IOException {
     return new PhysicalIOImpl(
-        s3URI, objectMetadataStore, objectBlobStore, telemetry, openStreamInformation, threadPool);
+        s3URI,
+        objectMetadataStore,
+        objectBlobStore,
+        telemetry,
+        openStreamInformation,
+        threadPool,
+        configuration.getPhysicalIOConfiguration());
   }
 
   void storeObjectMetadata(S3URI s3URI, ObjectMetadata metadata) {

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTest.java
@@ -393,7 +393,8 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
                           blobStore,
                           TestTelemetry.DEFAULT,
                           OpenStreamInformation.DEFAULT,
-                          executorService);
+                          executorService,
+                          PhysicalIOConfiguration.DEFAULT);
                   LogicalIO logicalIO =
                       new ParquetLogicalIOImpl(
                           TEST_OBJECT,
@@ -592,7 +593,8 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
                 blobStore,
                 TestTelemetry.DEFAULT,
                 OpenStreamInformation.DEFAULT,
-                executorService),
+                executorService,
+                PhysicalIOConfiguration.DEFAULT),
             TestTelemetry.DEFAULT,
             LogicalIOConfiguration.DEFAULT,
             new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT)),
@@ -622,7 +624,8 @@ public class S3SeekableInputStreamTest extends S3SeekableInputStreamTestBase {
                 blobStore,
                 TestTelemetry.DEFAULT,
                 OpenStreamInformation.DEFAULT,
-                executorService),
+                executorService,
+                PhysicalIOConfiguration.DEFAULT),
             TestTelemetry.DEFAULT,
             LogicalIOConfiguration.DEFAULT,
             new ParquetColumnPrefetchStore(LogicalIOConfiguration.DEFAULT));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStreamTestBase.java
@@ -72,7 +72,8 @@ public class S3SeekableInputStreamTestBase {
                   blobStore,
                   TestTelemetry.DEFAULT,
                   OpenStreamInformation.DEFAULT,
-                  executorService),
+                  executorService,
+                  PhysicalIOConfiguration.DEFAULT),
               TestTelemetry.DEFAULT,
               logicalIOConfiguration,
               new ParquetColumnPrefetchStore(logicalIOConfiguration));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/ParquetLogicalIOImplTest.java
@@ -158,7 +158,8 @@ public class ParquetLogicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            mock(ExecutorService.class));
+            mock(ExecutorService.class),
+            PhysicalIOConfiguration.DEFAULT);
     assertDoesNotThrow(
         () ->
             new ParquetLogicalIOImpl(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/PhysicalIOConfigurationTest.java
@@ -80,6 +80,8 @@ public class PhysicalIOConfigurationTest {
             + "\tthreadPoolSize: 96\n"
             + "\treadBufferSize: 131072\n"
             + "\ttargetRequestSize: 20\n"
-            + "\trequestToleranceRatio: 1.4\n");
+            + "\trequestToleranceRatio: 1.4\n"
+            + "\trequestCoalesce: true\n"
+            + "\trequestCoalesceTolerance: 1048576\n");
   }
 }

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImplTest.java
@@ -72,7 +72,8 @@ public class PhysicalIOImplTest {
               mock(BlobStore.class),
               TestTelemetry.DEFAULT,
               OpenStreamInformation.DEFAULT,
-              executorService);
+              executorService,
+              PhysicalIOConfiguration.DEFAULT);
         });
 
     assertThrows(
@@ -84,7 +85,8 @@ public class PhysicalIOImplTest {
               mock(BlobStore.class),
               TestTelemetry.DEFAULT,
               mock(OpenStreamInformation.class),
-              executorService);
+              executorService,
+              PhysicalIOConfiguration.DEFAULT);
         });
 
     assertThrows(
@@ -96,7 +98,8 @@ public class PhysicalIOImplTest {
               null,
               TestTelemetry.DEFAULT,
               mock(OpenStreamInformation.class),
-              executorService);
+              executorService,
+              PhysicalIOConfiguration.DEFAULT);
         });
 
     assertThrows(
@@ -108,7 +111,8 @@ public class PhysicalIOImplTest {
               mock(BlobStore.class),
               null,
               mock(OpenStreamInformation.class),
-              executorService);
+              executorService,
+              PhysicalIOConfiguration.DEFAULT);
         });
 
     assertThrows(
@@ -120,7 +124,8 @@ public class PhysicalIOImplTest {
               mock(BlobStore.class),
               TestTelemetry.DEFAULT,
               null,
-              null);
+              null,
+              PhysicalIOConfiguration.DEFAULT);
         });
 
     assertThrows(
@@ -132,7 +137,8 @@ public class PhysicalIOImplTest {
               mock(BlobStore.class),
               TestTelemetry.DEFAULT,
               OpenStreamInformation.DEFAULT,
-              executorService);
+              executorService,
+              PhysicalIOConfiguration.DEFAULT);
         });
 
     assertThrows(
@@ -144,7 +150,8 @@ public class PhysicalIOImplTest {
               null,
               TestTelemetry.DEFAULT,
               OpenStreamInformation.DEFAULT,
-              executorService);
+              executorService,
+              PhysicalIOConfiguration.DEFAULT);
         });
 
     assertThrows(
@@ -156,7 +163,8 @@ public class PhysicalIOImplTest {
               mock(BlobStore.class),
               null,
               OpenStreamInformation.DEFAULT,
-              executorService);
+              executorService,
+              PhysicalIOConfiguration.DEFAULT);
         });
 
     assertThrows(
@@ -168,7 +176,8 @@ public class PhysicalIOImplTest {
               mock(BlobStore.class),
               TestTelemetry.DEFAULT,
               OpenStreamInformation.DEFAULT,
-              null);
+              null,
+              PhysicalIOConfiguration.DEFAULT);
         });
   }
 
@@ -197,7 +206,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -233,7 +243,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
 
     // When: we read
     // Then: returned data is correct
@@ -264,7 +275,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
 
     byte[] buffer = new byte[5];
     assertEquals(5, physicalIOImplV2.read(buffer, 0, 5, 5));
@@ -294,7 +306,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
     byte[] buffer = new byte[5];
     assertEquals(5, physicalIOImplV2.readTail(buffer, 0, 5));
     assertEquals(1, blobStore.blobCount());
@@ -341,7 +354,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
 
     assertThrows(IOException.class, () -> physicalIOImplV2.read(0));
     assertEquals(0, blobStore.blobCount());
@@ -383,7 +397,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
 
     assertThrows(IOException.class, () -> physicalIOImplV2.read(0));
     assertEquals(0, blobStore.blobCount());
@@ -416,7 +431,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
 
     // When: Read data to ensure blob is created
     byte[] buffer = new byte[4];
@@ -459,7 +475,8 @@ public class PhysicalIOImplTest {
             mockBlobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
     ObjectKey objectKey = ObjectKey.builder().s3URI(s3URI).etag(fakeObjectClient.getEtag()).build();
     // When
     physicalIO.close(true);
@@ -493,7 +510,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
 
     // When: Read partial data
     byte[] buffer = new byte[4];
@@ -538,7 +556,8 @@ public class PhysicalIOImplTest {
             blobStore,
             TestTelemetry.DEFAULT,
             OpenStreamInformation.DEFAULT,
-            executorService);
+            executorService,
+            PhysicalIOConfiguration.DEFAULT);
 
     List<ObjectRange> objectRanges = new ArrayList<>();
     objectRanges.add(new ObjectRange(new CompletableFuture<>(), 2, 3));

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/plan/IOPlanTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/plan/IOPlanTest.java
@@ -68,4 +68,89 @@ public class IOPlanTest {
   void testEmptyPlanToString() {
     assertEquals("[]", IOPlan.EMPTY_PLAN.toString());
   }
+
+  @Test
+  void testCoalesceOverlappingRanges() {
+    ArrayList<Range> ranges = new ArrayList<>();
+    ranges.add(new Range(1, 5));
+    ranges.add(new Range(3, 8));
+    IOPlan ioPlan = new IOPlan(ranges);
+    ioPlan.coalesce(0);
+    assertEquals(1, ioPlan.getPrefetchRanges().size());
+    assertEquals(new Range(1, 8), ioPlan.getPrefetchRanges().get(0));
+  }
+
+  @Test
+  void testCoalesceAdjacentRanges() {
+    ArrayList<Range> ranges = new ArrayList<>();
+    ranges.add(new Range(1, 5));
+    ranges.add(new Range(5, 10));
+    IOPlan ioPlan = new IOPlan(ranges);
+    ioPlan.coalesce(0);
+    assertEquals(1, ioPlan.getPrefetchRanges().size());
+    assertEquals(new Range(1, 10), ioPlan.getPrefetchRanges().get(0));
+  }
+
+  @Test
+  void testCoalesceWithTolerance() {
+    ArrayList<Range> ranges = new ArrayList<>();
+    ranges.add(new Range(1, 5));
+    ranges.add(new Range(7, 12));
+    IOPlan ioPlan = new IOPlan(ranges);
+    ioPlan.coalesce(2);
+    assertEquals(1, ioPlan.getPrefetchRanges().size());
+    assertEquals(new Range(1, 12), ioPlan.getPrefetchRanges().get(0));
+  }
+
+  @Test
+  void testCoalesceNoMerge() {
+    ArrayList<Range> ranges = new ArrayList<>();
+    ranges.add(new Range(1, 5));
+    ranges.add(new Range(10, 15));
+    IOPlan ioPlan = new IOPlan(ranges);
+    ioPlan.coalesce(0);
+    assertEquals(2, ioPlan.getPrefetchRanges().size());
+  }
+
+  @Test
+  void testCoalesceSingleRange() {
+    IOPlan ioPlan = new IOPlan(new Range(1, 5));
+    ioPlan.coalesce(0);
+    assertEquals(1, ioPlan.getPrefetchRanges().size());
+    assertEquals(new Range(1, 5), ioPlan.getPrefetchRanges().get(0));
+  }
+
+  @Test
+  void testCoalesceEmptyPlan() {
+    IOPlan ioPlan = new IOPlan(new ArrayList<>());
+    ioPlan.coalesce(0);
+    assertEquals(0, ioPlan.getPrefetchRanges().size());
+  }
+
+  @Test
+  void testCoalesceMultipleRanges() {
+    ArrayList<Range> ranges = new ArrayList<>();
+    ranges.add(new Range(1, 3));
+    ranges.add(new Range(4, 7));
+    ranges.add(new Range(9, 11));
+    ranges.add(new Range(12, 15));
+    IOPlan ioPlan = new IOPlan(ranges);
+    ioPlan.coalesce(1);
+    assertEquals(2, ioPlan.getPrefetchRanges().size());
+    assertEquals(new Range(1, 7), ioPlan.getPrefetchRanges().get(0));
+    assertEquals(new Range(9, 15), ioPlan.getPrefetchRanges().get(1));
+  }
+
+  @Test
+  void testCoalesceUnorderedRanges() {
+    ArrayList<Range> ranges = new ArrayList<>();
+    ranges.add(new Range(10, 15));
+    ranges.add(new Range(1, 5));
+    ranges.add(new Range(6, 8));
+    IOPlan ioPlan = new IOPlan(ranges);
+    ioPlan.coalesce(1);
+    assertEquals(2, ioPlan.getPrefetchRanges().size());
+    assertEquals(new Range(1, 8), ioPlan.getPrefetchRanges().get(0));
+    assertEquals(new Range(10, 15), ioPlan.getPrefetchRanges().get(1));
+  }
 }

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/AALInputStreamConfigurationKind.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/AALInputStreamConfigurationKind.java
@@ -30,7 +30,8 @@ public enum AALInputStreamConfigurationKind {
   GRAY_FAILURE("GRAY_FAILURE", grayFailureConfiguration()),
   READ_CORRECTNESS("READ_CORRECTNESS", readCorrectnessConfiguration()),
   CONCURRENCY_CORRECTNESS("CONCURRENCY_CORRECTNESS", concurrencyCorrectnessConfiguration()),
-  NO_RETRY("NO_RETRY", noRetryConfiguration());
+  NO_RETRY("NO_RETRY", noRetryConfiguration()),
+  NO_REQUEST_COALESCING("NO_COALESCING", noRequestCoalescing());
 
   private final String name;
   private final S3SeekableInputStreamConfiguration value;
@@ -74,6 +75,15 @@ public enum AALInputStreamConfigurationKind {
     Map<String, String> customConfiguration = new HashMap<>();
     customConfiguration.put(
         configurationPrefix + ".physicalio.max.memory.limit", getMemoryCapacity());
+    ConnectorConfiguration config =
+        new ConnectorConfiguration(customConfiguration, configurationPrefix);
+    return S3SeekableInputStreamConfiguration.fromConfiguration(config);
+  }
+
+  private static S3SeekableInputStreamConfiguration noRequestCoalescing() {
+    String configurationPrefix = "noCoalescing";
+    Map<String, String> customConfiguration = new HashMap<>();
+    customConfiguration.put(configurationPrefix + ".physicalio.request.coalesce", "false");
     ConnectorConfiguration config =
         new ConnectorConfiguration(customConfiguration, configurationPrefix);
     return S3SeekableInputStreamConfiguration.fromConfiguration(config);


### PR DESCRIPTION
## Description of change
With this change, AAL can coalesce requests in a close proximity to each other. This enables to take spatial locality
into account and reduce request count. In my testing I observed that this is particularly important for vectored reads
reading vectors near each other. 

#### Relevant issues
N/A

#### Does this contribution introduce any breaking changes to the existing APIs or behaviors?
No. It changes the behaviour of vectored reads and merges smaller requests to bigger requests.
These bigger requests might be split to smaller requests later to make sure all requests are around `target.request.size`

#### Does this contribution introduce any new public APIs or behaviors?
<!-- Please describe them and explain what scenarios they target.  -->

#### How was the contribution tested?
Added new unit tests. Extended existing IntegrationTests to run for both coalescing enabled and disabled. 

#### Does this contribution need a changelog entry?
- Yes, i shall be updating the README after we finalise the behaviour part of this PR. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).